### PR TITLE
test(xform): fallback to subprojects/ncc/c_ncc.bnf when embedded as subproject

### DIFF
--- a/test/test_xform_template.c
+++ b/test/test_xform_template.c
@@ -54,6 +54,11 @@ load_c_grammar(void)
         char path[1024];
         snprintf(path, sizeof(path), "%s/c_ncc.bnf", srcroot);
         f = fopen(path, "r");
+        if (!f) {
+            snprintf(path, sizeof(path),
+                     "%s/subprojects/ncc/c_ncc.bnf", srcroot);
+            f = fopen(path, "r");
+        }
     }
 
     if (!f) {


### PR DESCRIPTION
## Summary
- When ncc is consumed as a meson subproject, `MESON_SOURCE_ROOT` points at the parent project root, so `$srcroot/c_ncc.bnf` doesn't resolve.
- Adds a second fallback that looks for `$srcroot/subprojects/ncc/c_ncc.bnf` so `test_xform_template` can still locate the grammar in that layout.

## Test plan
- [x] `meson compile -C build`
- [x] `meson test -C build` — 40/40 passing locally