### PR TITLE
parse: allow C23 attributes on _kargs forward declarations (#9)

### DIFF
--- a/c_ncc.bnf
+++ b/c_ncc.bnf
@@ -336,7 +336,7 @@
     | <declaration_specifiers> <init_declarator_list>? %";"
 <declaration> ::= <static_assert_declaration>
     | <attribute_declaration>
-    | <declaration_specifiers> <declarator> <keyword_clause> %";"
+    | <attribute_specifier_sequence>? <declaration_specifiers> <declarator> <keyword_clause> %";"
     | <declaration_specifiers> <attribute_specifier_sequence> %";"
     | %"__extension__" <declaration>
 

--- a/test/test_kargs.c
+++ b/test/test_kargs.c
@@ -9,10 +9,19 @@ int add(int x, int y) _kargs { int bias = 0; bool verbose = false; } {
     return x + y + bias;
 }
 
+// Regression: a C23 attribute prefix on a _kargs forward declaration
+// must not break parsing (crashappsec/ncc#9).
+[[deprecated("regression-only")]] int sub(int x, int y) _kargs { int bias = 0; };
+
+int sub(int x, int y) _kargs { int bias = 0; } {
+    return x - y - bias;
+}
+
 int main(void) {
     int r1 = add(1, 2);                             // defaults: bias=0, verbose=false
     int r2 = add(1, 2, .bias = 10);                 // override bias
     int r3 = add(1, 2, .verbose = true, .bias = 5); // both overridden
     printf("%d %d %d\n", r1, r2, r3);               // 3 13 8
-    return (r1 != 3 || r2 != 13 || r3 != 8);
+    int r4 = sub(10, 3, .bias = 2);                 // 5
+    return (r1 != 3 || r2 != 13 || r3 != 8 || r4 != 5);
 }


### PR DESCRIPTION
## Summary

Fixes crashappsec/ncc#9 — the parser rejected a `_kargs` forward declaration when prefixed by a C23 attribute such as `[[noreturn]]`, even though the same prefix is already accepted on a `_kargs` function *definition*.

The `<function_definition>` rule already permits a leading `<attribute_specifier_sequence>?`; this extends the same optionality to the `<declaration>` form that carries a `<keyword_clause>`. One-character grammar change.

Before:
```
| <declaration_specifiers> <declarator> <keyword_clause> ";"
```
After:
```
| <attribute_specifier_sequence>? <declaration_specifiers> <declarator> <keyword_clause> ";"
```

With the fix, the bug's repro now lowers correctly:
```c
[[noreturn]] extern void n00b_abort() _kargs { n00b_string_t *message = nullptr; };
```
→
```c
struct _n00b_abort__kargs { n00b_string_t * message ; unsigned _has_message : 1 ; };
[[noreturn]] extern void n00b_abort (struct _n00b_abort__kargs * kargs);
```

The attribute survives the rewrite intact, so the optimizer/diagnostic value of `[[noreturn]]` is preserved.

## Test plan

- [x] `meson test --suite ncc` — 44/44 pass.
- [x] Added regression coverage in `test/test_kargs.c`: a `[[deprecated]]`-prefixed `_kargs` forward declaration that previously would have failed to parse. (Chose `[[deprecated]]` rather than `[[noreturn]]` so the call site still returns and the runtime check in `main()` is meaningful.)
- [x] Verified the original bug repro from the ticket now produces correct lowered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)