### PR TITLE
xform: add @rpc annotation for n00b method-style RPC generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ build/
 .#*
 **/.cache/*
 docker/sdk/*.tar.*
+
+# AI-assisted-work state — not part of the source tree.
+AGENTS.md
+.agents/

--- a/README.md
+++ b/README.md
@@ -469,6 +469,70 @@ don't currently check because, again, laziness).
 Outside of definitions and declarations, `once` is treated like an
 identifier. Everything above isn't; they're all keywords.
 
+### RPC Annotations (`@rpc(...)`)
+
+`@rpc("package.Service/Method")` on a function declaration or
+definition tells ncc to emit a small bundle of glue code so the
+function participates in a CBOR-over-the-wire RPC system. ncc itself
+ships no transport — the synthesized code calls into a runtime
+your project provides (`n00b_rpc_register`, `n00b_rpc_call_unary`,
+the per-type CBOR `encode`/`decode` symbols, etc.). The libn00b
+ecosystem has a complete implementation; downstream projects can
+swap in their own runtime as long as the names match.
+
+The handler signature picks the RPC shape:
+
+| Return type                                                | First parameter                    | Shape          |
+|------------------------------------------------------------|------------------------------------|----------------|
+| `n00b_result_t(T *)`                                       | `U *`                              | unary          |
+| `n00b_result_t(n00b_rpc_stream_t(T) *)`                    | `U *`                              | server-stream  |
+| `n00b_result_t(T *)`                                       | `n00b_rpc_stream_t(U) *`           | client-stream  |
+| `n00b_result_t(n00b_rpc_stream_t(T) *)`                    | `n00b_rpc_stream_t(U) *`           | bidi           |
+
+Every handler must take a trailing `n00b_rpc_ctx_t *ctx` parameter.
+
+Example:
+
+```c
+#include <n00b.h>
+#include <net/quic/rpc.h>
+
+n00b_result_t(GreetReply *)
+greet_hello(GreetRequest *req, n00b_rpc_ctx_t *ctx)
+    @rpc("greet.v1.Greeter/Hello")
+{
+    /* handler body */
+}
+```
+
+For each annotated handler ncc emits three external declarations
+following the spelling rules:
+
+| Symbol                                                | Visibility       |
+|-------------------------------------------------------|------------------|
+| `_n00b_rpc_dispatch__<svc_underscored>__<method>`     | static           |
+| `_n00b_rpc_register__<svc_underscored>__<method>`     | static + ctor    |
+| `n00b_rpc_call_<svc_underscored>__<method>`           | extern (public)  |
+
+where `<svc_underscored>` replaces dots with underscores in the
+service path (`greet.v1.Greeter` → `greet_v1_Greeter`). The
+constructor fires at process start and registers the dispatcher
+with the runtime; the public client stub is the typed call site
+service authors invoke.
+
+The method string is validated against
+`^[a-zA-Z_][a-zA-Z0-9_.]*\.[A-Z][a-zA-Z0-9]*\/[A-Z][a-zA-Z0-9]*$` —
+dotted package + service starting with an uppercase letter, then
+`/`, then an uppercase method name. The xform also rejects:
+combining `@rpc` with `_kargs` on the same function; a missing
+trailing `n00b_rpc_ctx_t *` parameter; and two `@rpc(...)`
+handlers in the same translation unit binding the same method
+string.
+
+The `rpc` token is contextual: outside an `@rpc(...)` clause it
+still tokenizes as a plain identifier, so existing code using `rpc`
+as a variable, field, function, or parameter name is unaffected.
+
 ### Rich String Literals (`r""`)
 
 Pre-compiled string literals with inline styling markup. We provide a

--- a/c_ncc.bnf
+++ b/c_ncc.bnf
@@ -337,6 +337,9 @@
 <declaration> ::= <static_assert_declaration>
     | <attribute_declaration>
     | <attribute_specifier_sequence>? <declaration_specifiers> <declarator> <keyword_clause> %";"
+    | <declaration_specifiers> <declarator> <rpc_clause> %";"
+    | <declaration_specifiers> <declarator> <keyword_clause> <rpc_clause> %";"
+    | <declaration_specifiers> <declarator> <rpc_clause> <keyword_clause> %";"
     | <declaration_specifiers> <attribute_specifier_sequence> %";"
     | %"__extension__" <declaration>
 
@@ -408,6 +411,9 @@
 <function_declarator> ::= <direct_declarator> %"(" <parameter_type_list>? %")"
 
 <function_definition> ::= <attribute_specifier_sequence>? <declaration_specifiers> <declarator> <keyword_clause> <function_body>
+    | <attribute_specifier_sequence>? <declaration_specifiers> <declarator> <rpc_clause> <function_body>
+    | <attribute_specifier_sequence>? <declaration_specifiers> <declarator> <keyword_clause> <rpc_clause> <function_body>
+    | <attribute_specifier_sequence>? <declaration_specifiers> <declarator> <rpc_clause> <keyword_clause> <function_body>
     | <attribute_specifier_sequence>? <declaration_specifiers> <declarator> <function_body>
     | %"__extension__" <function_definition>
 
@@ -471,6 +477,11 @@
 
 <keyword_clause> ::= %"_kargs" %"{" <keyword_param_list> %"}"
     | %"_kargs" %":" %"opaque"
+
+# The `rpc` keyword is contextual — the tokenizer only emits it as a
+# grammar terminal when preceded by `@`, so existing user code that
+# uses `rpc` as an identifier (variable, field, function) is unaffected.
+<rpc_clause> ::= %"@" %"rpc" %"(" <string_literal> %")"
 
 <keyword_param> ::= <declaration_specifiers> <declarator> %"=" <initializer> %";"
     | <declaration_specifiers> <declarator> %";"

--- a/include/xform/xform_rpc.h
+++ b/include/xform/xform_rpc.h
@@ -1,0 +1,20 @@
+#pragma once
+
+/**
+ * @file xform_rpc.h
+ * @brief Transform: `@rpc("svc/method")` function annotation.
+ *
+ * Recognizes `@rpc(...)` on a function declaration or definition and
+ * (in later phases) synthesizes a CBOR dispatcher, a constructor
+ * that registers the dispatcher with the runtime, and a typed
+ * client stub.
+ *
+ * Must run FIRST in the xform registration sequence — before
+ * generic_struct, typeid, option, kargs_vargs — because the
+ * synthesized bodies reference type-mangled identifiers those
+ * passes produce.
+ */
+
+#include "xform/transform.h"
+
+extern void ncc_register_rpc_xform(ncc_xform_registry_t *reg);

--- a/meson.build
+++ b/meson.build
@@ -426,6 +426,11 @@ ncc_error_tests = {
   'err_once_non_function':       test_dir / 'err_once_non_function.c',
   'err_rstr_bad_tag':            test_dir / 'err_rstr_bad_tag.c',
   'err_typeid_no_args':          test_dir / 'err_typeid_no_args.c',
+  'err_rpc_void_return':         test_dir / 'err_rpc_void_return.c',
+  'err_rpc_no_ctx':              test_dir / 'err_rpc_no_ctx.c',
+  'err_rpc_bad_method':          test_dir / 'err_rpc_bad_method.c',
+  'err_rpc_with_kargs':          test_dir / 'err_rpc_with_kargs.c',
+  'err_rpc_dup_method':          test_dir / 'err_rpc_dup_method.c',
 }
 
 foreach name, src : ncc_error_tests

--- a/meson.build
+++ b/meson.build
@@ -286,6 +286,8 @@ ncc_compile_tests = {
   'option':       ['compile_run',  test_dir / 'test_option.c'],
   'generic_struct': ['compile_run', test_dir / 'test_generic_struct.c'],
   'gs_result':      ['compile_run', test_dir / 'test_gs_result.c'],
+  'rpc_keyword_collision': ['compile_run',
+                            test_dir / 'test_rpc_keyword_collision.c'],
 }
 
 foreach name, params : ncc_compile_tests

--- a/meson.build
+++ b/meson.build
@@ -293,6 +293,12 @@ ncc_compile_tests = {
                             test_dir / 'test_rpc_strip_smoke.c'],
   'rpc_unary':             ['compile_run',
                             test_dir / 'test_rpc_unary.c'],
+  'rpc_server_stream':     ['compile_run',
+                            test_dir / 'test_rpc_server_stream.c'],
+  'rpc_client_stream':     ['compile_run',
+                            test_dir / 'test_rpc_client_stream.c'],
+  'rpc_bidi':              ['compile_run',
+                            test_dir / 'test_rpc_bidi.c'],
 }
 
 foreach name, params : ncc_compile_tests

--- a/meson.build
+++ b/meson.build
@@ -291,6 +291,8 @@ ncc_compile_tests = {
                             test_dir / 'test_rpc_keyword_collision.c'],
   'rpc_strip_smoke':       ['compile_run',
                             test_dir / 'test_rpc_strip_smoke.c'],
+  'rpc_unary':             ['compile_run',
+                            test_dir / 'test_rpc_unary.c'],
 }
 
 foreach name, params : ncc_compile_tests

--- a/meson.build
+++ b/meson.build
@@ -139,6 +139,7 @@ src_xform = files(
   'src/xform/xform_kargs_vargs.c',
   'src/xform/xform_once.c',
   'src/xform/xform_option.c',
+  'src/xform/xform_rpc.c',
   'src/xform/xform_rstr.c',
   'src/xform/xform_typeid.c',
   'src/xform/xform_typestr.c',
@@ -288,6 +289,8 @@ ncc_compile_tests = {
   'gs_result':      ['compile_run', test_dir / 'test_gs_result.c'],
   'rpc_keyword_collision': ['compile_run',
                             test_dir / 'test_rpc_keyword_collision.c'],
+  'rpc_strip_smoke':       ['compile_run',
+                            test_dir / 'test_rpc_strip_smoke.c'],
 }
 
 foreach name, params : ncc_compile_tests

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -52,6 +52,7 @@ static const char embedded_grammar[] = {
 static const size_t embedded_grammar_len = sizeof(embedded_grammar) - 1;
 
 // Transform registration prototypes.
+extern void ncc_register_rpc_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_generic_struct_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_typeid_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_typestr_xform(ncc_xform_registry_t *reg);
@@ -1729,6 +1730,11 @@ compile_file(ncc_opts_t *opts)
     ncc_verbose("registering transforms");
     ncc_xform_registry_t xreg;
     ncc_xform_registry_init(&xreg, g);
+    // rpc must run first — its synthesized bodies reference the
+    // type-mangled identifiers that typeid / option / generic_struct /
+    // kargs_vargs produce; running after any of those would see the
+    // already-mangled signatures.
+    ncc_register_rpc_xform(&xreg);
     ncc_register_generic_struct_xform(&xreg);
     ncc_register_typeid_xform(&xreg);
     ncc_register_option_xform(&xreg);

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -1789,6 +1789,37 @@ compile_file(ncc_opts_t *opts)
     };
     ncc_template_register(&tmpl_reg, "bang", "primary_expression", bang_tmpl);
 
+    // @rpc(...) templates — one per stream shape. Parsed as
+    // translation_unit because each expands to multiple external
+    // declarations (dispatcher, constructor, client stub).
+    static const char rpc_unary_tmpl[] = {
+#embed "templates/rpc_unary.c.tmpl"
+        , '\0'
+    };
+    ncc_template_register(&tmpl_reg, "rpc_unary", "translation_unit",
+                          rpc_unary_tmpl);
+
+    static const char rpc_server_stream_tmpl[] = {
+#embed "templates/rpc_server_stream.c.tmpl"
+        , '\0'
+    };
+    ncc_template_register(&tmpl_reg, "rpc_server_stream",
+                          "translation_unit", rpc_server_stream_tmpl);
+
+    static const char rpc_client_stream_tmpl[] = {
+#embed "templates/rpc_client_stream.c.tmpl"
+        , '\0'
+    };
+    ncc_template_register(&tmpl_reg, "rpc_client_stream",
+                          "translation_unit", rpc_client_stream_tmpl);
+
+    static const char rpc_bidi_tmpl[] = {
+#embed "templates/rpc_bidi.c.tmpl"
+        , '\0'
+    };
+    ncc_template_register(&tmpl_reg, "rpc_bidi", "translation_unit",
+                          rpc_bidi_tmpl);
+
     // Resolve vargs_type, once_prefix, rstr_string_type: CLI > meson define > default.
     const char *vargs_type      = "ncc_vargs_t";
     const char *once_prefix     = "__ncc_";

--- a/src/parse/c_tokenizer.c
+++ b/src/parse/c_tokenizer.c
@@ -10,6 +10,7 @@
 // - All C23 operators
 
 #include "parse/c_tokenizer.h"
+#include "parse/token.h"
 #include "scanner/scan_builtins.h"
 #include "scanner/token_stream.h"
 #include "lib/alloc.h"
@@ -585,6 +586,38 @@ scan_raw_string(ncc_scanner_t *s, int32_t tid)
 }
 
 // ============================================================================
+// Internal: contextual demotion for the `rpc` keyword
+//
+// `rpc` participates in the grammar only as part of an `@rpc("...")`
+// clause, but the name is common in user code (variables, fields,
+// function names). The grammar registers `rpc` as a terminal so the
+// `<rpc_clause>` production can match it; without this demotion every
+// existing use of `rpc` as an identifier would tokenize as the
+// terminal and break the parse. We force the terminal id only when
+// the previous emitted token is `@`.
+// ============================================================================
+
+static int32_t
+demote_contextual_keyword(ncc_scanner_t *s, ncc_string_t id, int32_t kw_id)
+{
+    if (id.u8_bytes != 3 || memcmp(id.data, "rpc", 3) != 0) {
+        return kw_id;
+    }
+
+    ncc_token_stream_t *ts = s->stream;
+
+    if (ts && ts->token_count > 0) {
+        ncc_token_info_t *prev = ts->tokens[ts->token_count - 1];
+
+        if (prev && prev->tid == '@') {
+            return kw_id;
+        }
+    }
+
+    return (int32_t)NCC_TOK_IDENTIFIER;
+}
+
+// ============================================================================
 // Main tokenizer callback
 // ============================================================================
 
@@ -673,12 +706,11 @@ restart:
 
         int64_t kw_id = ncc_scan_terminal_id(s, id_str.data);
 
-        if (kw_id != NCC_TOK_OTHER) {
-            ncc_scan_emit(s, (int32_t)kw_id, id_val);
-        }
-        else {
-            ncc_scan_emit(s, (int32_t)NCC_TOK_IDENTIFIER, id_val);
-        }
+        int32_t tid = (kw_id != NCC_TOK_OTHER)
+                          ? demote_contextual_keyword(s, id_str,
+                                                      (int32_t)kw_id)
+                          : (int32_t)NCC_TOK_IDENTIFIER;
+        ncc_scan_emit(s, tid, id_val);
 
         mark_system_header(s);
         return true;
@@ -703,12 +735,11 @@ restart:
             ncc_string_t id_str = ncc_option_get(id_val);
             int64_t kw_id = ncc_scan_terminal_id(s, id_str.data);
 
-            if (kw_id != NCC_TOK_OTHER) {
-                ncc_scan_emit(s, (int32_t)kw_id, id_val);
-            }
-            else {
-                ncc_scan_emit(s, (int32_t)NCC_TOK_IDENTIFIER, id_val);
-            }
+            int32_t tid = (kw_id != NCC_TOK_OTHER)
+                              ? demote_contextual_keyword(s, id_str,
+                                                          (int32_t)kw_id)
+                              : (int32_t)NCC_TOK_IDENTIFIER;
+            ncc_scan_emit(s, tid, id_val);
 
             mark_system_header(s);
             return true;

--- a/src/xform/xform_rpc.c
+++ b/src/xform/xform_rpc.c
@@ -1,0 +1,354 @@
+// xform_rpc.c — Transform: `@rpc("svc/method")` function annotation.
+//
+// Recognizes `@rpc(...)` on a function declaration or definition.
+//
+// Phase B scope: find @rpc clauses on external_declarations, validate
+// the method-string format, reject combination with `_kargs`, and
+// strip the clause from the parent so plain clang accepts the result.
+// The synthesized dispatcher / ctor / client stub land in subsequent
+// phases.
+//
+// Registered pre-order on "translation_unit". The framework continues
+// recursing into children after we return, so later xforms still see
+// the (now-clause-free) declarations.
+
+#include "lib/alloc.h"
+#include "xform/xform_data.h"
+#include "xform/xform_helpers.h"
+#include "xform/xform_rpc.h"
+
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// ============================================================================
+// Method-string validator
+//
+// Regex equivalent (per spec §5.3):
+//   ^[a-zA-Z_][a-zA-Z0-9_.]*\.[A-Z][a-zA-Z0-9]*\/[A-Z][a-zA-Z0-9]*$
+//
+// Hand-rolled to avoid pulling in a regex dependency for one
+// validation site.
+// ============================================================================
+
+static bool
+is_lower_alpha_digit_under(char c)
+{
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+        || (c >= '0' && c <= '9') || c == '_';
+}
+
+static bool
+is_alpha_digit(char c)
+{
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+        || (c >= '0' && c <= '9');
+}
+
+static bool
+validate_method_string(const char *s)
+{
+    if (!s || !*s) {
+        return false;
+    }
+
+    const char *slash = strchr(s, '/');
+
+    if (!slash || strchr(slash + 1, '/')) {
+        return false;
+    }
+
+    // Method (after slash): [A-Z][a-zA-Z0-9]*
+    const char *m = slash + 1;
+
+    if (*m < 'A' || *m > 'Z') {
+        return false;
+    }
+
+    for (m++; *m; m++) {
+        if (!is_alpha_digit(*m)) {
+            return false;
+        }
+    }
+
+    // Service path (before slash): identifier chars / dots, at least
+    // one dot, and the segment after the last dot must start with an
+    // uppercase letter.
+    size_t pre_len = (size_t)(slash - s);
+
+    if (pre_len == 0) {
+        return false;
+    }
+
+    if (!(s[0] == '_' || (s[0] >= 'a' && s[0] <= 'z')
+          || (s[0] >= 'A' && s[0] <= 'Z'))) {
+        return false;
+    }
+
+    const char *last_dot = nullptr;
+
+    for (size_t i = 0; i < pre_len; i++) {
+        char c = s[i];
+
+        if (c == '.') {
+            last_dot = s + i;
+        }
+        else if (!is_lower_alpha_digit_under(c)) {
+            return false;
+        }
+    }
+
+    if (!last_dot) {
+        return false;
+    }
+
+    const char *svc = last_dot + 1;
+
+    if (svc >= slash) {
+        return false;
+    }
+
+    if (*svc < 'A' || *svc > 'Z') {
+        return false;
+    }
+
+    for (svc++; svc < slash; svc++) {
+        if (!is_alpha_digit(*svc)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// ============================================================================
+// Extract the method string from an <rpc_clause> subtree.
+//
+// Grammar: <rpc_clause> ::= %"@" %"rpc" %"(" <string_literal> %")"
+// <string_literal> ::= %STRING+   — each STRING leaf carries its own
+// surrounding quotes; for adjacent string literals we concatenate
+// their contents.
+// ============================================================================
+
+static char *
+extract_method_string(ncc_parse_tree_t *rpc_clause)
+{
+    ncc_parse_tree_t *str_lit
+        = ncc_xform_find_child_nt(rpc_clause, "string_literal");
+
+    if (!str_lit) {
+        return nullptr;
+    }
+
+    ncc_string_t text = ncc_xform_node_to_text(str_lit);
+
+    if (!text.data) {
+        return nullptr;
+    }
+
+    // Strip outer quotes (and any whitespace) for each STRING piece.
+    // Walks the verbatim text and copies bytes that lie strictly
+    // between matched quote pairs.
+    char *out  = ncc_alloc_size(1, text.u8_bytes + 1);
+    size_t  oi = 0;
+    bool    in = false;
+
+    for (size_t i = 0; i < text.u8_bytes; i++) {
+        char c = text.data[i];
+
+        if (c == '"') {
+            in = !in;
+            continue;
+        }
+
+        if (!in) {
+            continue;
+        }
+
+        if (c == '\\' && i + 1 < text.u8_bytes) {
+            // Preserve backslash escapes verbatim — the method
+            // grammar doesn't allow them, but we'd rather hand the
+            // text to the validator and produce a precise error than
+            // strip them into something unrecognizable.
+            out[oi++] = text.data[i++];
+            out[oi++] = text.data[i];
+            continue;
+        }
+
+        out[oi++] = c;
+    }
+
+    out[oi] = '\0';
+    ncc_free(text.data);
+    return out;
+}
+
+// ============================================================================
+// Find an <rpc_clause> or <keyword_clause> child of a
+// function_definition / declaration.
+// ============================================================================
+
+static ncc_parse_tree_t *
+find_child_nt_index(ncc_parse_tree_t *parent, const char *name, size_t *idx)
+{
+    size_t nc = ncc_tree_num_children(parent);
+
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *c = ncc_tree_child(parent, i);
+
+        if (c && !ncc_tree_is_leaf(c) && ncc_xform_nt_name_is(c, name)) {
+            if (idx) {
+                *idx = i;
+            }
+            return c;
+        }
+    }
+
+    return nullptr;
+}
+
+// ============================================================================
+// Diagnostics
+// ============================================================================
+
+[[noreturn]] static void
+rpc_diagnostic(ncc_parse_tree_t *anchor, const char *fmt, ...)
+{
+    uint32_t line = 0, col = 0;
+
+    if (anchor) {
+        ncc_xform_first_leaf_pos(anchor, &line, &col);
+    }
+
+    fprintf(stderr, "ncc: error: ");
+
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+
+    fprintf(stderr, " (line %u, col %u)\n", line, col);
+    exit(1);
+}
+
+// ============================================================================
+// Process one external_declaration's inner (function_definition or
+// declaration).
+//
+// Returns true if the inner had an @rpc clause we recognized (and
+// stripped); false otherwise.
+// ============================================================================
+
+static bool
+process_inner(ncc_parse_tree_t *inner)
+{
+    size_t            rpc_idx;
+    ncc_parse_tree_t *rpc_clause = find_child_nt_index(inner, "rpc_clause",
+                                                       &rpc_idx);
+
+    if (!rpc_clause) {
+        return false;
+    }
+
+    // Spec §4: `@rpc` and `_kargs` on the same function are rejected
+    // at parse time. The grammar accepts the combination so we can
+    // produce a precise diagnostic instead of a generic parse fail.
+    if (find_child_nt_index(inner, "keyword_clause", nullptr)) {
+        rpc_diagnostic(rpc_clause,
+                       "@rpc cannot be combined with _kargs on the same "
+                       "function");
+    }
+
+    char *method = extract_method_string(rpc_clause);
+
+    if (!method) {
+        rpc_diagnostic(rpc_clause,
+                       "@rpc requires a string literal of the form "
+                       "\"package.Service/Method\"");
+    }
+
+    if (!validate_method_string(method)) {
+        rpc_diagnostic(rpc_clause,
+                       "@rpc method string \"%s\" does not match "
+                       "\"<package>.<Service>/<Method>\" (package: "
+                       "dotted identifiers; Service and Method must "
+                       "start with an uppercase letter)",
+                       method);
+    }
+
+    ncc_free(method);
+
+    // Strip the rpc_clause so plain clang accepts the result. The
+    // emit phase reads what's left in the tree; once the clause is
+    // gone, the function definition / prototype looks like vanilla C.
+    ncc_xform_remove_child(inner, rpc_idx);
+
+    return true;
+}
+
+// ============================================================================
+// Recursive walker: process every function_definition / declaration
+// anywhere in the tree.
+//
+// The parser groups <external_declaration>+ under a `$$group_*`
+// wrapper, so a flat TU-children loop would miss them. Recursion
+// also handles the (legal-but-unusual) case of a declaration with
+// @rpc nested inside a function body. We recurse into children
+// first, then process this node — that way `process_inner`'s child
+// removal can't perturb an in-flight loop.
+// ============================================================================
+
+static bool
+walk_and_strip(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+
+    bool changed = false;
+
+    size_t nc = ncc_tree_num_children(node);
+
+    for (size_t i = 0; i < nc; i++) {
+        if (walk_and_strip(ncc_tree_child(node, i))) {
+            changed = true;
+        }
+    }
+
+    if (ncc_xform_nt_name_is(node, "function_definition")
+        || ncc_xform_nt_name_is(node, "declaration")) {
+        if (process_inner(node)) {
+            changed = true;
+        }
+    }
+
+    return changed;
+}
+
+// ============================================================================
+// Pre-order transform on translation_unit
+// ============================================================================
+
+static ncc_parse_tree_t *
+xform_rpc_tu(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu,
+             [[maybe_unused]] ncc_xform_control_t *control)
+{
+    if (!walk_and_strip(tu)) {
+        return nullptr;
+    }
+
+    ctx->nodes_replaced++;
+    return tu;
+}
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+void
+ncc_register_rpc_xform(ncc_xform_registry_t *reg)
+{
+    ncc_xform_register_pre(reg, "translation_unit", xform_rpc_tu, "rpc");
+}

--- a/src/xform/xform_rpc.c
+++ b/src/xform/xform_rpc.c
@@ -1,18 +1,23 @@
 // xform_rpc.c — Transform: `@rpc("svc/method")` function annotation.
 //
 // Recognizes `@rpc(...)` on a function declaration or definition.
+// Validates the method string, strips the clause so plain clang
+// accepts the source, and (for unary shape) instantiates the
+// `rpc_unary` template to emit the dispatcher + constructor +
+// client-stub trio.
 //
-// Phase B scope: find @rpc clauses on external_declarations, validate
-// the method-string format, reject combination with `_kargs`, and
-// strip the clause from the parent so plain clang accepts the result.
-// The synthesized dispatcher / ctor / client stub land in subsequent
-// phases.
+// Operates pre-order on "translation_unit". We flatten the TU's
+// `$$group_*` wrapper, walk the external_declarations, strip + maybe
+// synthesize for each annotated one, then rebuild the TU with the
+// original (now-clause-free) decls followed by the synthesized
+// dispatcher / ctor / stub.
 //
-// Registered pre-order on "translation_unit". The framework continues
-// recursing into children after we return, so later xforms still see
-// the (now-clause-free) declarations.
+// Must run FIRST in the xform sequence so the synthesized bodies
+// flow through generic_struct / typeid / option / kargs_vargs after
+// the synthesis.
 
 #include "lib/alloc.h"
+#include "lib/buffer.h"
 #include "xform/xform_data.h"
 #include "xform/xform_helpers.h"
 #include "xform/xform_rpc.h"
@@ -234,110 +239,877 @@ rpc_diagnostic(ncc_parse_tree_t *anchor, const char *fmt, ...)
 }
 
 // ============================================================================
-// Process one external_declaration's inner (function_definition or
-// declaration).
-//
-// Returns true if the inner had an @rpc clause we recognized (and
-// stripped); false otherwise.
+// Function-name extraction (copy of xform_once's idiom; the helper
+// itself is static there so we re-implement rather than link)
 // ============================================================================
 
 static bool
-process_inner(ncc_parse_tree_t *inner)
+is_ident_start_char(char c)
 {
-    size_t            rpc_idx;
-    ncc_parse_tree_t *rpc_clause = find_child_nt_index(inner, "rpc_clause",
-                                                       &rpc_idx);
+    return isalpha((unsigned char)c) || c == '_';
+}
 
-    if (!rpc_clause) {
-        return false;
+static bool
+is_ident_char(char c)
+{
+    return isalnum((unsigned char)c) || c == '_';
+}
+
+static size_t
+find_last_top_level_paren_open(const char *text)
+{
+    int    depth = 0;
+    size_t last  = (size_t)-1;
+
+    for (size_t i = 0; text[i]; i++) {
+        if (text[i] == '(') {
+            if (depth == 0) {
+                last = i;
+            }
+            depth++;
+        }
+        else if (text[i] == ')' && depth > 0) {
+            depth--;
+        }
     }
 
-    // Spec §4: `@rpc` and `_kargs` on the same function are rejected
-    // at parse time. The grammar accepts the combination so we can
-    // produce a precise diagnostic instead of a generic parse fail.
-    if (find_child_nt_index(inner, "keyword_clause", nullptr)) {
-        rpc_diagnostic(rpc_clause,
-                       "@rpc cannot be combined with _kargs on the same "
-                       "function");
+    return last;
+}
+
+static char *
+copy_last_identifier_before(const char *text, size_t end)
+{
+    size_t i = end;
+
+    while (i > 0) {
+        while (i > 0 && !is_ident_char(text[i - 1])) {
+            i--;
+        }
+
+        size_t ident_end = i;
+
+        while (i > 0 && is_ident_char(text[i - 1])) {
+            i--;
+        }
+
+        if (ident_end > i && is_ident_start_char(text[i])) {
+            size_t len  = ident_end - i;
+            char  *name = ncc_alloc_size(1, len + 1);
+            memcpy(name, text + i, len);
+            name[len] = '\0';
+            return name;
+        }
     }
 
-    char *method = extract_method_string(rpc_clause);
+    return nullptr;
+}
 
-    if (!method) {
-        rpc_diagnostic(rpc_clause,
-                       "@rpc requires a string literal of the form "
-                       "\"package.Service/Method\"");
+static char *
+extract_func_name(ncc_parse_tree_t *declarator)
+{
+    ncc_string_t text = ncc_xform_node_to_text(declarator);
+
+    if (!text.data) {
+        return nullptr;
     }
 
-    if (!validate_method_string(method)) {
-        rpc_diagnostic(rpc_clause,
-                       "@rpc method string \"%s\" does not match "
-                       "\"<package>.<Service>/<Method>\" (package: "
-                       "dotted identifiers; Service and Method must "
-                       "start with an uppercase letter)",
-                       method);
-    }
+    size_t paren = find_last_top_level_paren_open(text.data);
+    size_t end   = (paren == (size_t)-1) ? text.u8_bytes : paren;
+    char  *name  = copy_last_identifier_before(text.data, end);
 
-    ncc_free(method);
-
-    // Strip the rpc_clause so plain clang accepts the result. The
-    // emit phase reads what's left in the tree; once the clause is
-    // gone, the function definition / prototype looks like vanilla C.
-    ncc_xform_remove_child(inner, rpc_idx);
-
-    return true;
+    ncc_free(text.data);
+    return name;
 }
 
 // ============================================================================
-// Recursive walker: process every function_definition / declaration
-// anywhere in the tree.
+// Method-string splitting + sanitization
 //
-// The parser groups <external_declaration>+ under a `$$group_*`
-// wrapper, so a flat TU-children loop would miss them. Recursion
-// also handles the (legal-but-unusual) case of a declaration with
-// @rpc nested inside a function body. We recurse into children
-// first, then process this node — that way `process_inner`'s child
-// removal can't perturb an in-flight loop.
+// Input  : "package.path.Service/Method"
+// Output : svc_underscored = "package_path_Service"
+//          method          = "Method"
 // ============================================================================
 
+static void
+split_method(const char *method_str, char **svc_out, char **method_out)
+{
+    const char *slash = strchr(method_str, '/');
+
+    // Validator already ran; both pieces exist.
+    size_t pre_len = (size_t)(slash - method_str);
+
+    char *svc = ncc_alloc_size(1, pre_len + 1);
+    memcpy(svc, method_str, pre_len);
+    svc[pre_len] = '\0';
+
+    for (size_t i = 0; i < pre_len; i++) {
+        if (svc[i] == '.') {
+            svc[i] = '_';
+        }
+    }
+
+    *svc_out    = svc;
+    *method_out = ncc_string_from_cstr(slash + 1).data;
+}
+
+// ============================================================================
+// Type-parameter extraction from `typeid("result", T *)` leaf text
+//
+// Returns the inner T (with the trailing `*` removed and whitespace
+// trimmed). Returns nullptr if the pattern isn't present.
+// ============================================================================
+
+static char *
+extract_typeid_inner(const char *text, const char *tag)
+{
+    if (!text) {
+        return nullptr;
+    }
+
+    // Locate `typeid(<ws>?"<tag>"<ws>?,` allowing arbitrary
+    // whitespace between tokens (the leaf-text emitter inserts
+    // single spaces).
+    size_t      tag_len = strlen(tag);
+    const char *p       = text;
+    const char *after   = nullptr;
+
+    while ((p = strstr(p, "typeid")) != nullptr) {
+        const char *q = p + 6;
+
+        while (*q == ' ' || *q == '\t' || *q == '\n') {
+            q++;
+        }
+
+        if (*q != '(') {
+            p++;
+            continue;
+        }
+
+        q++;
+
+        while (*q == ' ' || *q == '\t' || *q == '\n') {
+            q++;
+        }
+
+        if (*q != '"') {
+            p++;
+            continue;
+        }
+
+        q++;
+
+        if (strncmp(q, tag, tag_len) == 0 && q[tag_len] == '"') {
+            q += tag_len + 1;
+
+            while (*q == ' ' || *q == '\t' || *q == '\n') {
+                q++;
+            }
+
+            if (*q == ',') {
+                after = q + 1;
+                break;
+            }
+        }
+
+        p++;
+    }
+
+    if (!after) {
+        return nullptr;
+    }
+
+    p = after;
+
+    while (*p == ' ' || *p == '\t' || *p == '\n') {
+        p++;
+    }
+
+    // Scan to matching close-paren, ignoring nested parens.
+    int         depth = 1;
+    const char *start = p;
+
+    while (*p && depth > 0) {
+        if (*p == '(') {
+            depth++;
+        }
+        else if (*p == ')') {
+            depth--;
+            if (depth == 0) {
+                break;
+            }
+        }
+
+        p++;
+    }
+
+    if (depth != 0) {
+        return nullptr;
+    }
+
+    // Trim trailing whitespace.
+    const char *end = p;
+
+    while (end > start && (end[-1] == ' ' || end[-1] == '\t'
+                            || end[-1] == '\n')) {
+        end--;
+    }
+
+    // Strip a trailing `*`.
+    if (end > start && end[-1] == '*') {
+        end--;
+
+        while (end > start && (end[-1] == ' ' || end[-1] == '\t')) {
+            end--;
+        }
+    }
+
+    size_t len = (size_t)(end - start);
+
+    if (len == 0) {
+        return nullptr;
+    }
+
+    char *out = ncc_alloc_size(1, len + 1);
+    memcpy(out, start, len);
+    out[len] = '\0';
+
+    // Collapse internal whitespace runs to single spaces for use in
+    // a generated identifier or type position. (Real users won't
+    // embed weird whitespace here; this guards the synthesized
+    // identifiers we paste together later.)
+    char  *w     = out;
+    bool   in_ws = false;
+
+    for (char *r = out; *r; r++) {
+        if (*r == ' ' || *r == '\t' || *r == '\n') {
+            if (!in_ws) {
+                *w++  = ' ';
+                in_ws = true;
+            }
+        }
+        else {
+            *w++  = *r;
+            in_ws = false;
+        }
+    }
+
+    *w = '\0';
+
+    return out;
+}
+
+// ============================================================================
+// Extract the type of the first parameter (the request, in unary
+// shape). The expected leaf text shape is `T *<name>` — peel off
+// the trailing identifier and the `*`.
+// ============================================================================
+
+static ncc_parse_tree_t *
+find_descendant_nt(ncc_parse_tree_t *node, const char *name)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return nullptr;
+    }
+
+    if (ncc_xform_nt_name_is(node, name)) {
+        return node;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *r = find_descendant_nt(ncc_tree_child(node, i),
+                                                  name);
+        if (r) {
+            return r;
+        }
+    }
+
+    return nullptr;
+}
+
+static char *
+extract_first_param_type(ncc_parse_tree_t *declarator)
+{
+    ncc_parse_tree_t *ptl = find_descendant_nt(declarator,
+                                                "parameter_type_list");
+
+    if (!ptl) {
+        return nullptr;
+    }
+
+    ncc_parse_tree_t *pl = ncc_xform_find_child_nt(ptl, "parameter_list");
+
+    if (!pl) {
+        pl = ptl;
+    }
+
+    // First parameter_declaration child.
+    ncc_parse_tree_t *first_pd = ncc_xform_find_child_nt(pl,
+                                                         "parameter_declaration");
+
+    if (!first_pd) {
+        return nullptr;
+    }
+
+    ncc_string_t text = ncc_xform_node_to_text(first_pd);
+
+    if (!text.data) {
+        return nullptr;
+    }
+
+    // Walk from the right past the name + whitespace + `*`.
+    char *s   = text.data;
+    int   n   = (int)text.u8_bytes;
+    int   end = n;
+
+    while (end > 0
+           && (s[end - 1] == ' ' || s[end - 1] == '\t'
+               || s[end - 1] == '\n')) {
+        end--;
+    }
+
+    // Strip trailing identifier (param name).
+    while (end > 0 && is_ident_char(s[end - 1])) {
+        end--;
+    }
+
+    while (end > 0
+           && (s[end - 1] == ' ' || s[end - 1] == '\t')) {
+        end--;
+    }
+
+    // Strip the `*`.
+    if (end == 0 || s[end - 1] != '*') {
+        // Not the expected `T *name` shape.
+        ncc_free(text.data);
+        return nullptr;
+    }
+
+    end--;
+
+    while (end > 0
+           && (s[end - 1] == ' ' || s[end - 1] == '\t')) {
+        end--;
+    }
+
+    char *out = ncc_alloc_size(1, (size_t)end + 1);
+    memcpy(out, s, (size_t)end);
+    out[end] = '\0';
+
+    ncc_free(text.data);
+    return out;
+}
+
+// ============================================================================
+// Stream-shape detection (Phase D: unary only)
+//
+// Returns true iff the signature looks unary — return type contains
+// `typeid("result"` and not `typeid("rpc_stream"`, AND the first
+// parameter's type isn't a stream.
+// ============================================================================
+
+// Match a `typeid(<whitespace>?"<tag>"<whitespace>?,` substring in
+// `text`. The leaf-text representation may include arbitrary
+// whitespace between `typeid`, `(`, and the tag string.
 static bool
-walk_and_strip(ncc_parse_tree_t *node)
+text_has_typeid_tag(const char *text, const char *tag)
+{
+    if (!text) {
+        return false;
+    }
+
+    size_t      tag_len = strlen(tag);
+    const char *p       = text;
+
+    while ((p = strstr(p, "typeid")) != nullptr) {
+        const char *q = p + 6;
+
+        while (*q == ' ' || *q == '\t' || *q == '\n') {
+            q++;
+        }
+
+        if (*q != '(') {
+            p++;
+            continue;
+        }
+
+        q++;
+
+        while (*q == ' ' || *q == '\t' || *q == '\n') {
+            q++;
+        }
+
+        if (*q != '"') {
+            p++;
+            continue;
+        }
+
+        q++;
+
+        if (strncmp(q, tag, tag_len) == 0 && q[tag_len] == '"') {
+            return true;
+        }
+
+        p++;
+    }
+
+    return false;
+}
+
+static bool
+is_unary_shape(ncc_parse_tree_t *inner)
+{
+    ncc_parse_tree_t *decl_specs
+        = ncc_xform_find_child_nt(inner, "declaration_specifiers");
+    ncc_parse_tree_t *declarator
+        = ncc_xform_find_child_nt(inner, "declarator");
+
+    if (!decl_specs || !declarator) {
+        return false;
+    }
+
+    ncc_string_t ret_text = ncc_xform_node_to_text(decl_specs);
+
+    bool ok = false;
+
+    if (text_has_typeid_tag(ret_text.data, "result")
+        && !text_has_typeid_tag(ret_text.data, "rpc_stream")) {
+        // First parameter — must not be a stream.
+        char *first_type = extract_first_param_type(declarator);
+
+        if (first_type
+            && strstr(first_type, "rpc_stream") == nullptr) {
+            ok = true;
+        }
+
+        ncc_free(first_type);
+    }
+
+    ncc_free(ret_text.data);
+    return ok;
+}
+
+// ============================================================================
+// Splice infrastructure (mirrors xform_once)
+// ============================================================================
+
+typedef struct {
+    ncc_parse_tree_t **items;
+    size_t             len;
+    size_t             cap;
+} ptrvec_t;
+
+static void
+ptrvec_init(ptrvec_t *v, size_t init_cap)
+{
+    v->cap   = init_cap > 0 ? init_cap : 16;
+    v->len   = 0;
+    v->items = ncc_alloc_array(ncc_parse_tree_t *, v->cap);
+}
+
+static void
+ptrvec_push(ptrvec_t *v, ncc_parse_tree_t *p)
+{
+    if (v->len >= v->cap) {
+        v->cap *= 2;
+        v->items = ncc_realloc(v->items,
+                                v->cap * sizeof(ncc_parse_tree_t *));
+    }
+
+    v->items[v->len++] = p;
+}
+
+static bool
+is_group_node(ncc_parse_tree_t *node)
 {
     if (!node || ncc_tree_is_leaf(node)) {
         return false;
     }
 
-    bool changed = false;
+    ncc_nt_node_t pn = ncc_tree_node_value(node);
+    return pn.group_top;
+}
 
-    size_t nc = ncc_tree_num_children(node);
+static void
+flatten_group(ncc_parse_tree_t *node, ptrvec_t *out)
+{
+    if (!node) {
+        return;
+    }
+
+    if (ncc_tree_is_leaf(node)) {
+        ptrvec_push(out, node);
+        return;
+    }
+
+    if (is_group_node(node)) {
+        size_t nc = ncc_tree_num_children(node);
+
+        for (size_t i = 0; i < nc; i++) {
+            flatten_group(ncc_tree_child(node, i), out);
+        }
+    }
+    else {
+        ptrvec_push(out, node);
+    }
+}
+
+// ============================================================================
+// Synthesize unary dispatcher / ctor / stub via template
+// ============================================================================
+
+static void
+synthesize_unary(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *inner,
+                 ncc_parse_tree_t *rpc_clause,
+                 const char *method_string, ptrvec_t *appended)
+{
+    ncc_parse_tree_t *declarator
+        = ncc_xform_find_child_nt(inner, "declarator");
+    ncc_parse_tree_t *decl_specs
+        = ncc_xform_find_child_nt(inner, "declaration_specifiers");
+
+    if (!declarator || !decl_specs) {
+        rpc_diagnostic(rpc_clause,
+                       "@rpc handler is missing a declarator or "
+                       "return type");
+    }
+
+    char *func_name = extract_func_name(declarator);
+
+    if (!func_name) {
+        rpc_diagnostic(rpc_clause,
+                       "@rpc could not determine the handler's "
+                       "function name");
+    }
+
+    char *svc;
+    char *method;
+    split_method(method_string, &svc, &method);
+
+    // $3: full method string with quotes.
+    size_t  ms_len    = strlen(method_string);
+    char   *quoted_ms = ncc_alloc_size(1, ms_len + 3);
+    quoted_ms[0]      = '"';
+    memcpy(quoted_ms + 1, method_string, ms_len);
+    quoted_ms[ms_len + 1] = '"';
+    quoted_ms[ms_len + 2] = '\0';
+
+    // $5: response type T from typeid("result", T *).
+    ncc_string_t ret_text = ncc_xform_node_to_text(decl_specs);
+    char        *resp_type
+        = ret_text.data ? extract_typeid_inner(ret_text.data, "result")
+                        : nullptr;
+    ncc_free(ret_text.data);
+
+    if (!resp_type) {
+        rpc_diagnostic(rpc_clause,
+                       "@rpc unary handler must return "
+                       "n00b_result_t(T *) "
+                       "(expanded form: _generic_struct typeid(\"result\", T *))");
+    }
+
+    // $4: request type from the first parameter.
+    char *req_type = extract_first_param_type(declarator);
+
+    if (!req_type) {
+        rpc_diagnostic(rpc_clause,
+                       "@rpc unary handler must take T *req as its "
+                       "first parameter");
+    }
+
+    // Identifier names must be pre-computed (the template engine
+    // doesn't token-paste — `_n00b_rpc_dispatch__$1__$2` would
+    // become three separate IDENT tokens, not one identifier).
+    size_t svc_len    = strlen(svc);
+    size_t method_len = strlen(method);
+
+    // Compose `<prefix><svc>__<method>` into a fresh malloc'd string.
+    #define BUILD_NAME(prefix, suffix_out) do {                  \
+        size_t p_len = strlen(prefix);                          \
+        size_t total = p_len + svc_len + 2 + method_len + 1;    \
+        (suffix_out) = ncc_alloc_size(1, total);                \
+        memcpy((suffix_out), (prefix), p_len);                   \
+        memcpy((suffix_out) + p_len, svc, svc_len);              \
+        (suffix_out)[p_len + svc_len]     = '_';                 \
+        (suffix_out)[p_len + svc_len + 1] = '_';                 \
+        memcpy((suffix_out) + p_len + svc_len + 2,               \
+               method, method_len);                              \
+        (suffix_out)[total - 1] = '\0';                          \
+    } while (0)
+
+    char *dispatcher_name;
+    char *registrar_name;
+    char *call_name;
+    BUILD_NAME("_n00b_rpc_dispatch__", dispatcher_name);
+    BUILD_NAME("_n00b_rpc_register__", registrar_name);
+    BUILD_NAME("n00b_rpc_call_",       call_name);
+    #undef BUILD_NAME
+
+    // Decoder identifiers.
+    size_t pfx_len = strlen("_n00b_cbor_decode_");
+
+    size_t r4_len = strlen(req_type);
+    char  *dec_req = ncc_alloc_size(1, pfx_len + r4_len + 1);
+    memcpy(dec_req, "_n00b_cbor_decode_", pfx_len);
+    memcpy(dec_req + pfx_len, req_type, r4_len);
+    dec_req[pfx_len + r4_len] = '\0';
+
+    size_t r5_len = strlen(resp_type);
+    char  *dec_resp = ncc_alloc_size(1, pfx_len + r5_len + 1);
+    memcpy(dec_resp, "_n00b_cbor_decode_", pfx_len);
+    memcpy(dec_resp + pfx_len, resp_type, r5_len);
+    dec_resp[pfx_len + r5_len] = '\0';
+
+    // The template engine's parser path doesn't currently accept
+    // translation_unit start symbols — observed err 13 (parse fail)
+    // even on minimal multi-declaration templates that ncc parses
+    // fine when fed as a .c file. We sidestep by mirroring
+    // xform_once's pattern: build the source as a string, then
+    // hand it to ncc_xform_parse_source which IS known to handle
+    // translation_unit content. The .c.tmpl file in templates/ is
+    // kept as documentation of what the xform emits, but isn't
+    // instantiated through the template registry. (See Phase E for
+    // the streaming variants and a follow-up on the template engine
+    // limitation.)
+    ncc_buffer_t *src = ncc_buffer_empty();
+    ncc_buffer_printf(src,
+        "static _generic_struct typeid(\"result\", n00b_buffer_t *)\n"
+        "%s(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)\n"
+        "{\n"
+        "  _generic_struct typeid(\"result\", %s *) decoded = %s(req_cbor);\n"
+        "  if (!decoded.is_ok) {\n"
+        "    return (_generic_struct typeid(\"result\", n00b_buffer_t *)){\n"
+        "      .is_ok = false, .err = decoded.err,\n"
+        "    };\n"
+        "  }\n"
+        "  _generic_struct typeid(\"result\", %s *) resp = %s(decoded.ok, ctx);\n"
+        "  if (!resp.is_ok) {\n"
+        "    return (_generic_struct typeid(\"result\", n00b_buffer_t *)){\n"
+        "      .is_ok = false, .err = resp.err,\n"
+        "    };\n"
+        "  }\n"
+        "  return (_generic_struct typeid(\"result\", n00b_buffer_t *)){\n"
+        "    .is_ok = true, .ok = n00b_cbor_encode(resp.ok),\n"
+        "  };\n"
+        "}\n"
+        "__attribute__((constructor))\n"
+        "static void\n"
+        "%s(void)\n"
+        "{\n"
+        "  n00b_rpc_register(%s, &%s);\n"
+        "}\n"
+        "extern _generic_struct typeid(\"result\", %s *)\n"
+        "%s(n00b_rpc_ctx_t *ctx, n00b_rpc_channel_t *chan, %s *req)\n"
+        "{\n"
+        "  n00b_buffer_t *req_buf = n00b_cbor_encode(req);\n"
+        "  _generic_struct typeid(\"result\", n00b_buffer_t *) wire =\n"
+        "    n00b_rpc_call_unary(ctx, chan, %s, req_buf);\n"
+        "  if (!wire.is_ok) {\n"
+        "    return (_generic_struct typeid(\"result\", %s *)){\n"
+        "      .is_ok = false, .err = wire.err,\n"
+        "    };\n"
+        "  }\n"
+        "  return %s(wire.ok);\n"
+        "}\n",
+        dispatcher_name,
+        req_type, dec_req,
+        resp_type, func_name,
+        registrar_name,
+        quoted_ms, dispatcher_name,
+        resp_type, call_name, req_type,
+        quoted_ms,
+        resp_type,
+        dec_resp);
+
+    char *source = ncc_buffer_take(src);
+
+    ncc_parse_tree_t *new_tu
+        = ncc_xform_parse_source(ctx->grammar, "translation_unit",
+                                 source, "xform_rpc_unary");
+    ncc_free(source);
+
+    if (!new_tu) {
+        rpc_diagnostic(rpc_clause,
+                       "internal error: failed to parse synthesized "
+                       "unary dispatcher source");
+    }
+
+    // Flatten the synthesized TU and queue its external_decls for
+    // appending after the user's original.
+    ptrvec_t flat;
+    ptrvec_init(&flat, 8);
+
+    size_t nc = ncc_tree_num_children(new_tu);
 
     for (size_t i = 0; i < nc; i++) {
-        if (walk_and_strip(ncc_tree_child(node, i))) {
-            changed = true;
+        flatten_group(ncc_tree_child(new_tu, i), &flat);
+    }
+
+    for (size_t i = 0; i < flat.len; i++) {
+        if (flat.items[i]) {
+            ptrvec_push(appended, flat.items[i]);
         }
     }
 
-    if (ncc_xform_nt_name_is(node, "function_definition")
-        || ncc_xform_nt_name_is(node, "declaration")) {
-        if (process_inner(node)) {
-            changed = true;
-        }
-    }
-
-    return changed;
+    ncc_free(flat.items);
+    ncc_free(func_name);
+    ncc_free(svc);
+    ncc_free(method);
+    ncc_free(quoted_ms);
+    ncc_free(resp_type);
+    ncc_free(req_type);
+    ncc_free(dispatcher_name);
+    ncc_free(registrar_name);
+    ncc_free(call_name);
+    ncc_free(dec_req);
+    ncc_free(dec_resp);
 }
 
 // ============================================================================
 // Pre-order transform on translation_unit
+//
+// Strategy:
+//   1. Flatten the TU's `$$group_*` wrapper into a flat list of
+//      external_declarations.
+//   2. For each: strip @rpc (validates, diagnoses, removes the
+//      clause from the parent). If unary shape, instantiate the
+//      `rpc_unary` template and queue its declarations for append.
+//   3. Rebuild the TU as `[originals... ; appended...]`, wrapped in
+//      a single fresh `$$group_rpc` node — the standard ncc idiom
+//      for replacing TU children in bulk.
 // ============================================================================
 
 static ncc_parse_tree_t *
 xform_rpc_tu(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu,
              [[maybe_unused]] ncc_xform_control_t *control)
 {
-    if (!walk_and_strip(tu)) {
+    ptrvec_t flat;
+    ptrvec_init(&flat, 256);
+
+    size_t tu_nc = ncc_tree_num_children(tu);
+
+    for (size_t i = 0; i < tu_nc; i++) {
+        flatten_group(ncc_tree_child(tu, i), &flat);
+    }
+
+    ptrvec_t appended;
+    ptrvec_init(&appended, 16);
+
+    bool changed = false;
+
+    for (size_t i = 0; i < flat.len; i++) {
+        ncc_parse_tree_t *ext_decl = flat.items[i];
+
+        if (!ext_decl || ncc_tree_is_leaf(ext_decl)) {
+            continue;
+        }
+
+        // Find the inner function_definition / declaration.
+        ncc_parse_tree_t *inner    = nullptr;
+        size_t            inner_nc = ncc_tree_num_children(ext_decl);
+
+        for (size_t j = 0; j < inner_nc; j++) {
+            ncc_parse_tree_t *c = ncc_tree_child(ext_decl, j);
+
+            if (c && !ncc_tree_is_leaf(c)) {
+                inner = c;
+                break;
+            }
+        }
+
+        if (!inner
+            || (!ncc_xform_nt_name_is(inner, "function_definition")
+                && !ncc_xform_nt_name_is(inner, "declaration"))) {
+            continue;
+        }
+
+        // Locate the @rpc clause without removing it yet — we need
+        // the clause node alive for shape-detection diagnostics.
+        size_t            rpc_idx;
+        ncc_parse_tree_t *rpc_clause
+            = find_child_nt_index(inner, "rpc_clause", &rpc_idx);
+
+        if (!rpc_clause) {
+            continue;
+        }
+
+        // _kargs combination diagnostic (spec §4).
+        if (find_child_nt_index(inner, "keyword_clause", nullptr)) {
+            rpc_diagnostic(rpc_clause,
+                           "@rpc cannot be combined with _kargs on the "
+                           "same function");
+        }
+
+        char *method_string = extract_method_string(rpc_clause);
+
+        if (!method_string) {
+            rpc_diagnostic(rpc_clause,
+                           "@rpc requires a string literal of the form "
+                           "\"package.Service/Method\"");
+        }
+
+        if (!validate_method_string(method_string)) {
+            rpc_diagnostic(rpc_clause,
+                           "@rpc method string \"%s\" does not match "
+                           "\"<package>.<Service>/<Method>\"",
+                           method_string);
+        }
+
+        // Only synthesize for function_definition (the prototype
+        // declaration also gets stripped, but we don't double-emit
+        // the dispatcher / ctor / stub).
+        if (ncc_xform_nt_name_is(inner, "function_definition")) {
+            if (!is_unary_shape(inner)) {
+                rpc_diagnostic(rpc_clause,
+                               "@rpc: only unary shape is implemented "
+                               "in this phase (server-stream, "
+                               "client-stream, and bidi land in the "
+                               "next phase)");
+            }
+
+            synthesize_unary(ctx, inner, rpc_clause, method_string,
+                             &appended);
+        }
+
+        ncc_free(method_string);
+        ncc_xform_remove_child(inner, rpc_idx);
+        changed = true;
+    }
+
+    if (!changed) {
+        ncc_free(flat.items);
+        ncc_free(appended.items);
         return nullptr;
     }
+
+    // Rebuild the TU: originals first, synthesized second, all
+    // under one fresh `$$group_rpc` wrapper.
+    ncc_nt_node_t gpn = {0};
+    gpn.name          = ncc_string_from_cstr("$$group_rpc");
+    gpn.id            = (1 << 28);
+    gpn.group_top     = true;
+
+    ncc_parse_tree_t *new_group
+        = ncc_tree_node(ncc_nt_node_t, ncc_token_info_ptr_t, gpn);
+
+    for (size_t i = 0; i < flat.len; i++) {
+        if (flat.items[i]) {
+            ncc_tree_add_child(new_group, flat.items[i]);
+        }
+    }
+
+    for (size_t i = 0; i < appended.len; i++) {
+        if (appended.items[i]) {
+            ncc_tree_add_child(new_group, appended.items[i]);
+        }
+    }
+
+    ncc_free(flat.items);
+    ncc_free(appended.items);
+
+    ncc_tree_replace_children(tu, ncc_alloc_array(ncc_parse_tree_t *, 1),
+                              1);
+    ncc_tree_set_child(tu, 0, new_group);
 
     ctx->nodes_replaced++;
     return tu;

--- a/src/xform/xform_rpc.c
+++ b/src/xform/xform_rpc.c
@@ -757,6 +757,56 @@ peel_stream_type(const char *text)
     return out;
 }
 
+// True iff the last parameter of `declarator`'s parameter list is
+// of type `n00b_rpc_ctx_t *` (spec §5.2 requires every @rpc handler
+// to take an `n00b_rpc_ctx_t *ctx` trailing parameter).
+static bool
+last_param_is_ctx(ncc_parse_tree_t *declarator)
+{
+    ncc_parse_tree_t *ptl = find_descendant_nt(declarator,
+                                                "parameter_type_list");
+
+    if (!ptl) {
+        return false;
+    }
+
+    ncc_string_t text = ncc_xform_node_to_text(ptl);
+
+    if (!text.data) {
+        return false;
+    }
+
+    // Scan to the last top-level comma; the substring after it is
+    // the last parameter's declaration.
+    const char *s         = text.data;
+    int         depth     = 0;
+    size_t      last_comma = 0;
+    bool        have_comma = false;
+
+    for (size_t i = 0; i < text.u8_bytes; i++) {
+        char c = s[i];
+
+        if (c == '(' || c == '[' || c == '{') {
+            depth++;
+        }
+        else if (c == ')' || c == ']' || c == '}') {
+            if (depth > 0) {
+                depth--;
+            }
+        }
+        else if (c == ',' && depth == 0) {
+            last_comma = i;
+            have_comma = true;
+        }
+    }
+
+    const char *last = have_comma ? s + last_comma + 1 : s;
+    bool        ok   = strstr(last, "n00b_rpc_ctx_t") != nullptr;
+
+    ncc_free(text.data);
+    return ok;
+}
+
 // Decide which of the four shapes the handler matches. Also returns
 // (via the out-pointers) the inner element types — caller frees both.
 //
@@ -1319,6 +1369,12 @@ xform_rpc_tu(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu,
     ptrvec_t appended;
     ptrvec_init(&appended, 16);
 
+    // Per-TU registry of @rpc method strings already seen; used to
+    // diagnose duplicate `@rpc("same/method")` annotations. Each
+    // entry is a heap-copy of the method string we own.
+    ptrvec_t seen_methods;
+    ptrvec_init(&seen_methods, 8);
+
     bool changed = false;
 
     for (size_t i = 0; i < flat.len; i++) {
@@ -1383,6 +1439,37 @@ xform_rpc_tu(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu,
         // declaration also gets stripped, but we don't double-emit
         // the dispatcher / ctor / stub).
         if (ncc_xform_nt_name_is(inner, "function_definition")) {
+            // Check for a duplicate `@rpc(method)` earlier in the TU.
+            for (size_t k = 0; k < seen_methods.len; k++) {
+                if (strcmp((const char *)seen_methods.items[k],
+                            method_string)
+                    == 0) {
+                    rpc_diagnostic(rpc_clause,
+                                   "@rpc method \"%s\" is already bound "
+                                   "by another handler in this "
+                                   "translation unit",
+                                   method_string);
+                }
+            }
+
+            // Take ownership of method_string in seen_methods (we
+            // free the dup list at the end of the TU walk). Use a
+            // copy so the original can still be freed after the
+            // call to synthesize_for_shape.
+            size_t ms_len = strlen(method_string);
+            char  *kept   = ncc_alloc_size(1, ms_len + 1);
+            memcpy(kept, method_string, ms_len + 1);
+            ptrvec_push(&seen_methods, (ncc_parse_tree_t *)kept);
+
+            ncc_parse_tree_t *declarator
+                = ncc_xform_find_child_nt(inner, "declarator");
+
+            if (!declarator || !last_param_is_ctx(declarator)) {
+                rpc_diagnostic(rpc_clause,
+                               "@rpc handler must take a trailing "
+                               "n00b_rpc_ctx_t * parameter (saw none)");
+            }
+
             char       *req_inner  = nullptr;
             char       *resp_inner = nullptr;
             rpc_shape_t shape      = detect_shape(inner, &resp_inner,
@@ -1410,6 +1497,11 @@ xform_rpc_tu(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu,
         ncc_xform_remove_child(inner, rpc_idx);
         changed = true;
     }
+
+    for (size_t i = 0; i < seen_methods.len; i++) {
+        ncc_free(seen_methods.items[i]);
+    }
+    ncc_free(seen_methods.items);
 
     if (!changed) {
         ncc_free(flat.items);

--- a/src/xform/xform_rpc.c
+++ b/src/xform/xform_rpc.c
@@ -601,12 +601,28 @@ extract_first_param_type(ncc_parse_tree_t *declarator)
 }
 
 // ============================================================================
-// Stream-shape detection (Phase D: unary only)
+// Stream-shape detection
 //
-// Returns true iff the signature looks unary — return type contains
-// `typeid("result"` and not `typeid("rpc_stream"`, AND the first
-// parameter's type isn't a stream.
+// Distinguishes the four stream shapes by leaf-text inspection of
+// the return type and first parameter:
+//
+//   ret has `typeid("result", T *)`            +  param T *      → UNARY
+//   ret has `typeid("result", n00b_rpc_stream_t(T) *)` + param T *
+//                                              → SERVER_STREAM
+//   ret has `typeid("result", T *)`            +  param n00b_rpc_stream_t(T) *
+//                                              → CLIENT_STREAM
+//   ret has `typeid("result", n00b_rpc_stream_t(T) *)`
+//                                              +  param n00b_rpc_stream_t(T) *
+//                                              → BIDI
 // ============================================================================
+
+typedef enum {
+    RPC_SHAPE_UNKNOWN,
+    RPC_SHAPE_UNARY,
+    RPC_SHAPE_SERVER_STREAM,
+    RPC_SHAPE_CLIENT_STREAM,
+    RPC_SHAPE_BIDI,
+} rpc_shape_t;
 
 // Match a `typeid(<whitespace>?"<tag>"<whitespace>?,` substring in
 // `text`. The leaf-text representation may include arbitrary
@@ -656,37 +672,171 @@ text_has_typeid_tag(const char *text, const char *tag)
     return false;
 }
 
-static bool
-is_unary_shape(ncc_parse_tree_t *inner)
+// Peel a stream-of-T type → T. Recognizes both the libn00b macro
+// form `n00b_rpc_stream_t(T)` (which downstream cpp will have
+// expanded before ncc sees it, but show-up shape-wise in some
+// edge cases) and the raw `_generic_struct typeid("rpc_stream", T)`
+// form that the macro expands to. Returns nullptr if not a stream.
+// Caller frees on success.
+static char *
+peel_stream_type(const char *text)
 {
+    if (!text) {
+        return nullptr;
+    }
+
+    // Try the raw form via the typeid extractor.
+    if (text_has_typeid_tag(text, "rpc_stream")) {
+        return extract_typeid_inner(text, "rpc_stream");
+    }
+
+    // Fallback: literal `n00b_rpc_stream_t(T)` (would appear pre-cpp).
+    static const char prefix[] = "n00b_rpc_stream_t";
+    size_t            pre_len  = sizeof(prefix) - 1;
+    const char       *p        = text;
+
+    while (*p == ' ' || *p == '\t') {
+        p++;
+    }
+
+    if (strncmp(p, prefix, pre_len) != 0) {
+        return nullptr;
+    }
+
+    p += pre_len;
+
+    while (*p == ' ' || *p == '\t') {
+        p++;
+    }
+
+    if (*p != '(') {
+        return nullptr;
+    }
+
+    p++;
+
+    while (*p == ' ' || *p == '\t') {
+        p++;
+    }
+
+    int         depth = 1;
+    const char *start = p;
+
+    while (*p && depth > 0) {
+        if (*p == '(') {
+            depth++;
+        }
+        else if (*p == ')') {
+            depth--;
+            if (depth == 0) {
+                break;
+            }
+        }
+
+        p++;
+    }
+
+    if (depth != 0) {
+        return nullptr;
+    }
+
+    const char *end = p;
+
+    while (end > start && (end[-1] == ' ' || end[-1] == '\t')) {
+        end--;
+    }
+
+    if (end == start) {
+        return nullptr;
+    }
+
+    size_t len = (size_t)(end - start);
+    char  *out = ncc_alloc_size(1, len + 1);
+    memcpy(out, start, len);
+    out[len] = '\0';
+    return out;
+}
+
+// Decide which of the four shapes the handler matches. Also returns
+// (via the out-pointers) the inner element types — caller frees both.
+//
+//   * `resp_inner_out`: T from `typeid("result", T *)` (unary,
+//      client-stream) or T from `typeid("result", n00b_rpc_stream_t(T) *)`
+//      (server-stream, bidi).
+//   * `req_inner_out`: T from `T *req` (unary, server-stream) or T
+//      from `n00b_rpc_stream_t(T) *in` (client-stream, bidi).
+static rpc_shape_t
+detect_shape(ncc_parse_tree_t *inner, char **resp_inner_out,
+             char **req_inner_out)
+{
+    *resp_inner_out = nullptr;
+    *req_inner_out  = nullptr;
+
     ncc_parse_tree_t *decl_specs
         = ncc_xform_find_child_nt(inner, "declaration_specifiers");
     ncc_parse_tree_t *declarator
         = ncc_xform_find_child_nt(inner, "declarator");
 
     if (!decl_specs || !declarator) {
-        return false;
+        return RPC_SHAPE_UNKNOWN;
     }
 
     ncc_string_t ret_text = ncc_xform_node_to_text(decl_specs);
 
-    bool ok = false;
-
-    if (text_has_typeid_tag(ret_text.data, "result")
-        && !text_has_typeid_tag(ret_text.data, "rpc_stream")) {
-        // First parameter — must not be a stream.
-        char *first_type = extract_first_param_type(declarator);
-
-        if (first_type
-            && strstr(first_type, "rpc_stream") == nullptr) {
-            ok = true;
-        }
-
-        ncc_free(first_type);
+    if (!text_has_typeid_tag(ret_text.data, "result")) {
+        ncc_free(ret_text.data);
+        return RPC_SHAPE_UNKNOWN;
     }
 
+    char *raw_resp = extract_typeid_inner(ret_text.data, "result");
     ncc_free(ret_text.data);
-    return ok;
+
+    if (!raw_resp) {
+        return RPC_SHAPE_UNKNOWN;
+    }
+
+    bool resp_is_stream     = false;
+    char *resp_inner        = peel_stream_type(raw_resp);
+
+    if (resp_inner) {
+        resp_is_stream = true;
+        ncc_free(raw_resp);
+    }
+    else {
+        resp_inner = raw_resp;
+    }
+
+    char *first_type = extract_first_param_type(declarator);
+
+    if (!first_type) {
+        ncc_free(resp_inner);
+        return RPC_SHAPE_UNKNOWN;
+    }
+
+    bool req_is_stream = false;
+    char *req_inner    = peel_stream_type(first_type);
+
+    if (req_inner) {
+        req_is_stream = true;
+        ncc_free(first_type);
+    }
+    else {
+        req_inner = first_type;
+    }
+
+    *resp_inner_out = resp_inner;
+    *req_inner_out  = req_inner;
+
+    if (!resp_is_stream && !req_is_stream) {
+        return RPC_SHAPE_UNARY;
+    }
+    if (resp_is_stream && !req_is_stream) {
+        return RPC_SHAPE_SERVER_STREAM;
+    }
+    if (!resp_is_stream && req_is_stream) {
+        return RPC_SHAPE_CLIENT_STREAM;
+    }
+    return RPC_SHAPE_BIDI;
 }
 
 // ============================================================================
@@ -758,120 +908,26 @@ flatten_group(ncc_parse_tree_t *node, ptrvec_t *out)
 // Synthesize unary dispatcher / ctor / stub via template
 // ============================================================================
 
+// ============================================================================
+// Per-shape source builders
+//
+// Each builder emits three external_declarations (dispatcher, ctor,
+// client stub) wired through the appropriate runtime entry-points.
+// The streaming variants exploit the runtime's structural alias
+// between typed and buffer streams: dispatchers cast the inbound
+// `n00b_rpc_stream_t(n00b_buffer_t *) *` to `n00b_rpc_stream_t(T) *`
+// for the handler call, and cast the handler's returned typed
+// stream back to buffer-stream form. The handler does per-item
+// CBOR on send/recv.
+// ============================================================================
+
 static void
-synthesize_unary(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *inner,
-                 ncc_parse_tree_t *rpc_clause,
-                 const char *method_string, ptrvec_t *appended)
+build_unary_source(ncc_buffer_t *src, const char *handler,
+                   const char *dispatcher, const char *registrar,
+                   const char *call_, const char *quoted_method,
+                   const char *req_t, const char *resp_t,
+                   const char *dec_req, const char *dec_resp)
 {
-    ncc_parse_tree_t *declarator
-        = ncc_xform_find_child_nt(inner, "declarator");
-    ncc_parse_tree_t *decl_specs
-        = ncc_xform_find_child_nt(inner, "declaration_specifiers");
-
-    if (!declarator || !decl_specs) {
-        rpc_diagnostic(rpc_clause,
-                       "@rpc handler is missing a declarator or "
-                       "return type");
-    }
-
-    char *func_name = extract_func_name(declarator);
-
-    if (!func_name) {
-        rpc_diagnostic(rpc_clause,
-                       "@rpc could not determine the handler's "
-                       "function name");
-    }
-
-    char *svc;
-    char *method;
-    split_method(method_string, &svc, &method);
-
-    // $3: full method string with quotes.
-    size_t  ms_len    = strlen(method_string);
-    char   *quoted_ms = ncc_alloc_size(1, ms_len + 3);
-    quoted_ms[0]      = '"';
-    memcpy(quoted_ms + 1, method_string, ms_len);
-    quoted_ms[ms_len + 1] = '"';
-    quoted_ms[ms_len + 2] = '\0';
-
-    // $5: response type T from typeid("result", T *).
-    ncc_string_t ret_text = ncc_xform_node_to_text(decl_specs);
-    char        *resp_type
-        = ret_text.data ? extract_typeid_inner(ret_text.data, "result")
-                        : nullptr;
-    ncc_free(ret_text.data);
-
-    if (!resp_type) {
-        rpc_diagnostic(rpc_clause,
-                       "@rpc unary handler must return "
-                       "n00b_result_t(T *) "
-                       "(expanded form: _generic_struct typeid(\"result\", T *))");
-    }
-
-    // $4: request type from the first parameter.
-    char *req_type = extract_first_param_type(declarator);
-
-    if (!req_type) {
-        rpc_diagnostic(rpc_clause,
-                       "@rpc unary handler must take T *req as its "
-                       "first parameter");
-    }
-
-    // Identifier names must be pre-computed (the template engine
-    // doesn't token-paste — `_n00b_rpc_dispatch__$1__$2` would
-    // become three separate IDENT tokens, not one identifier).
-    size_t svc_len    = strlen(svc);
-    size_t method_len = strlen(method);
-
-    // Compose `<prefix><svc>__<method>` into a fresh malloc'd string.
-    #define BUILD_NAME(prefix, suffix_out) do {                  \
-        size_t p_len = strlen(prefix);                          \
-        size_t total = p_len + svc_len + 2 + method_len + 1;    \
-        (suffix_out) = ncc_alloc_size(1, total);                \
-        memcpy((suffix_out), (prefix), p_len);                   \
-        memcpy((suffix_out) + p_len, svc, svc_len);              \
-        (suffix_out)[p_len + svc_len]     = '_';                 \
-        (suffix_out)[p_len + svc_len + 1] = '_';                 \
-        memcpy((suffix_out) + p_len + svc_len + 2,               \
-               method, method_len);                              \
-        (suffix_out)[total - 1] = '\0';                          \
-    } while (0)
-
-    char *dispatcher_name;
-    char *registrar_name;
-    char *call_name;
-    BUILD_NAME("_n00b_rpc_dispatch__", dispatcher_name);
-    BUILD_NAME("_n00b_rpc_register__", registrar_name);
-    BUILD_NAME("n00b_rpc_call_",       call_name);
-    #undef BUILD_NAME
-
-    // Decoder identifiers.
-    size_t pfx_len = strlen("_n00b_cbor_decode_");
-
-    size_t r4_len = strlen(req_type);
-    char  *dec_req = ncc_alloc_size(1, pfx_len + r4_len + 1);
-    memcpy(dec_req, "_n00b_cbor_decode_", pfx_len);
-    memcpy(dec_req + pfx_len, req_type, r4_len);
-    dec_req[pfx_len + r4_len] = '\0';
-
-    size_t r5_len = strlen(resp_type);
-    char  *dec_resp = ncc_alloc_size(1, pfx_len + r5_len + 1);
-    memcpy(dec_resp, "_n00b_cbor_decode_", pfx_len);
-    memcpy(dec_resp + pfx_len, resp_type, r5_len);
-    dec_resp[pfx_len + r5_len] = '\0';
-
-    // The template engine's parser path doesn't currently accept
-    // translation_unit start symbols — observed err 13 (parse fail)
-    // even on minimal multi-declaration templates that ncc parses
-    // fine when fed as a .c file. We sidestep by mirroring
-    // xform_once's pattern: build the source as a string, then
-    // hand it to ncc_xform_parse_source which IS known to handle
-    // translation_unit content. The .c.tmpl file in templates/ is
-    // kept as documentation of what the xform emits, but isn't
-    // instantiated through the template registry. (See Phase E for
-    // the streaming variants and a follow-up on the template engine
-    // limitation.)
-    ncc_buffer_t *src = ncc_buffer_empty();
     ncc_buffer_printf(src,
         "static _generic_struct typeid(\"result\", n00b_buffer_t *)\n"
         "%s(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)\n"
@@ -893,11 +949,7 @@ synthesize_unary(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *inner,
         "  };\n"
         "}\n"
         "__attribute__((constructor))\n"
-        "static void\n"
-        "%s(void)\n"
-        "{\n"
-        "  n00b_rpc_register(%s, &%s);\n"
-        "}\n"
+        "static void %s(void) { n00b_rpc_register(%s, &%s); }\n"
         "extern _generic_struct typeid(\"result\", %s *)\n"
         "%s(n00b_rpc_ctx_t *ctx, n00b_rpc_channel_t *chan, %s *req)\n"
         "{\n"
@@ -911,31 +963,305 @@ synthesize_unary(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *inner,
         "  }\n"
         "  return %s(wire.ok);\n"
         "}\n",
-        dispatcher_name,
-        req_type, dec_req,
-        resp_type, func_name,
-        registrar_name,
-        quoted_ms, dispatcher_name,
-        resp_type, call_name, req_type,
-        quoted_ms,
-        resp_type,
+        dispatcher,
+        req_t, dec_req,
+        resp_t, handler,
+        registrar, quoted_method, dispatcher,
+        resp_t, call_, req_t,
+        quoted_method,
+        resp_t,
         dec_resp);
+}
+
+// Shorthand used in the streaming builders below. `n00b_rpc_stream_t(T)`
+// is a libn00b macro that expands to `_generic_struct typeid("rpc_stream", T)`;
+// since template-synthesized text is parsed without cpp, we spell the
+// raw form everywhere.
+#define STREAM_OF_BUF \
+    "_generic_struct typeid(\"rpc_stream\", n00b_buffer_t *)"
+#define STREAM_OF "_generic_struct typeid(\"rpc_stream\", %s)"
+
+static void
+build_server_stream_source(ncc_buffer_t *src, const char *handler,
+                            const char *dispatcher, const char *registrar,
+                            const char *call_, const char *quoted_method,
+                            const char *req_t, const char *resp_t,
+                            const char *dec_req)
+{
+    ncc_buffer_printf(src,
+        "static _generic_struct typeid(\"result\", " STREAM_OF_BUF " *)\n"
+        "%s(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)\n"
+        "{\n"
+        "  _generic_struct typeid(\"result\", %s *) decoded = %s(req_cbor);\n"
+        "  if (!decoded.is_ok) {\n"
+        "    return (_generic_struct typeid(\"result\", " STREAM_OF_BUF " *)){\n"
+        "      .is_ok = false, .err = decoded.err,\n"
+        "    };\n"
+        "  }\n"
+        "  _generic_struct typeid(\"result\", " STREAM_OF " *) resp =\n"
+        "    %s(decoded.ok, ctx);\n"
+        "  if (!resp.is_ok) {\n"
+        "    return (_generic_struct typeid(\"result\", " STREAM_OF_BUF " *)){\n"
+        "      .is_ok = false, .err = resp.err,\n"
+        "    };\n"
+        "  }\n"
+        "  return (_generic_struct typeid(\"result\", " STREAM_OF_BUF " *)){\n"
+        "    .is_ok = true,\n"
+        "    .ok    = (" STREAM_OF_BUF " *)resp.ok,\n"
+        "  };\n"
+        "}\n"
+        "__attribute__((constructor))\n"
+        "static void %s(void) { n00b_rpc_register_server_stream(%s, &%s); }\n"
+        "extern _generic_struct typeid(\"result\", " STREAM_OF " *)\n"
+        "%s(n00b_rpc_ctx_t *ctx, n00b_rpc_channel_t *chan, %s *req)\n"
+        "{\n"
+        "  n00b_buffer_t *req_buf = n00b_cbor_encode(req);\n"
+        "  _generic_struct typeid(\"result\", " STREAM_OF_BUF " *) wire =\n"
+        "    n00b_rpc_call_server_stream(ctx, chan, %s, req_buf);\n"
+        "  if (!wire.is_ok) {\n"
+        "    return (_generic_struct typeid(\"result\", " STREAM_OF " *)){\n"
+        "      .is_ok = false, .err = wire.err,\n"
+        "    };\n"
+        "  }\n"
+        "  return (_generic_struct typeid(\"result\", " STREAM_OF " *)){\n"
+        "    .is_ok = true,\n"
+        "    .ok    = (" STREAM_OF " *)wire.ok,\n"
+        "  };\n"
+        "}\n",
+        dispatcher,
+        req_t, dec_req,
+        resp_t, handler,
+        registrar, quoted_method, dispatcher,
+        resp_t, call_, req_t,
+        quoted_method,
+        resp_t,
+        resp_t, resp_t);
+}
+
+static void
+build_client_stream_source(ncc_buffer_t *src, const char *handler,
+                            const char *dispatcher, const char *registrar,
+                            const char *call_, const char *quoted_method,
+                            const char *req_t, const char *resp_t,
+                            const char *dec_resp)
+{
+    ncc_buffer_printf(src,
+        "static _generic_struct typeid(\"result\", n00b_buffer_t *)\n"
+        "%s(" STREAM_OF_BUF " *in, n00b_rpc_ctx_t *ctx)\n"
+        "{\n"
+        "  _generic_struct typeid(\"result\", %s *) resp =\n"
+        "    %s((" STREAM_OF " *)in, ctx);\n"
+        "  if (!resp.is_ok) {\n"
+        "    return (_generic_struct typeid(\"result\", n00b_buffer_t *)){\n"
+        "      .is_ok = false, .err = resp.err,\n"
+        "    };\n"
+        "  }\n"
+        "  return (_generic_struct typeid(\"result\", n00b_buffer_t *)){\n"
+        "    .is_ok = true, .ok = n00b_cbor_encode(resp.ok),\n"
+        "  };\n"
+        "}\n"
+        "__attribute__((constructor))\n"
+        "static void %s(void) { n00b_rpc_register_client_stream(%s, &%s); }\n"
+        "extern _generic_struct typeid(\"result\", %s *)\n"
+        "%s(n00b_rpc_ctx_t *ctx, n00b_rpc_channel_t *chan, " STREAM_OF " *in)\n"
+        "{\n"
+        "  _generic_struct typeid(\"result\", n00b_buffer_t *) wire =\n"
+        "    n00b_rpc_call_client_stream(ctx, chan, %s, (" STREAM_OF_BUF " *)in);\n"
+        "  if (!wire.is_ok) {\n"
+        "    return (_generic_struct typeid(\"result\", %s *)){\n"
+        "      .is_ok = false, .err = wire.err,\n"
+        "    };\n"
+        "  }\n"
+        "  return %s(wire.ok);\n"
+        "}\n",
+        dispatcher,
+        resp_t, handler, req_t,
+        registrar, quoted_method, dispatcher,
+        resp_t, call_, req_t,
+        quoted_method,
+        resp_t,
+        dec_resp);
+}
+
+static void
+build_bidi_source(ncc_buffer_t *src, const char *handler,
+                  const char *dispatcher, const char *registrar,
+                  const char *call_, const char *quoted_method,
+                  const char *req_t, const char *resp_t)
+{
+    ncc_buffer_printf(src,
+        "static _generic_struct typeid(\"result\", " STREAM_OF_BUF " *)\n"
+        "%s(" STREAM_OF_BUF " *in, n00b_rpc_ctx_t *ctx)\n"
+        "{\n"
+        "  _generic_struct typeid(\"result\", " STREAM_OF " *) resp =\n"
+        "    %s((" STREAM_OF " *)in, ctx);\n"
+        "  if (!resp.is_ok) {\n"
+        "    return (_generic_struct typeid(\"result\", " STREAM_OF_BUF " *)){\n"
+        "      .is_ok = false, .err = resp.err,\n"
+        "    };\n"
+        "  }\n"
+        "  return (_generic_struct typeid(\"result\", " STREAM_OF_BUF " *)){\n"
+        "    .is_ok = true,\n"
+        "    .ok    = (" STREAM_OF_BUF " *)resp.ok,\n"
+        "  };\n"
+        "}\n"
+        "__attribute__((constructor))\n"
+        "static void %s(void) { n00b_rpc_register_bidi(%s, &%s); }\n"
+        "extern _generic_struct typeid(\"result\", " STREAM_OF " *)\n"
+        "%s(n00b_rpc_ctx_t *ctx, n00b_rpc_channel_t *chan, " STREAM_OF " *in)\n"
+        "{\n"
+        "  _generic_struct typeid(\"result\", " STREAM_OF_BUF " *) wire =\n"
+        "    n00b_rpc_call_bidi(ctx, chan, %s, (" STREAM_OF_BUF " *)in);\n"
+        "  if (!wire.is_ok) {\n"
+        "    return (_generic_struct typeid(\"result\", " STREAM_OF " *)){\n"
+        "      .is_ok = false, .err = wire.err,\n"
+        "    };\n"
+        "  }\n"
+        "  return (_generic_struct typeid(\"result\", " STREAM_OF " *)){\n"
+        "    .is_ok = true,\n"
+        "    .ok    = (" STREAM_OF " *)wire.ok,\n"
+        "  };\n"
+        "}\n",
+        dispatcher,
+        resp_t, handler, req_t,
+        registrar, quoted_method, dispatcher,
+        resp_t, call_, req_t,
+        quoted_method,
+        resp_t,
+        resp_t, resp_t);
+}
+
+#undef STREAM_OF_BUF
+#undef STREAM_OF
+
+// ============================================================================
+// Unified synthesizer — picks the right per-shape builder, runs the
+// shared metadata extraction + parse + splice.
+// ============================================================================
+
+static void
+synthesize_for_shape(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *inner,
+                     ncc_parse_tree_t *rpc_clause,
+                     const char *method_string,
+                     rpc_shape_t shape,
+                     char *req_inner, char *resp_inner,
+                     ptrvec_t *appended)
+{
+    ncc_parse_tree_t *declarator
+        = ncc_xform_find_child_nt(inner, "declarator");
+
+    char *func_name = extract_func_name(declarator);
+
+    if (!func_name) {
+        rpc_diagnostic(rpc_clause,
+                       "@rpc could not determine the handler's "
+                       "function name");
+    }
+
+    char *svc;
+    char *method;
+    split_method(method_string, &svc, &method);
+
+    size_t  ms_len    = strlen(method_string);
+    char   *quoted_ms = ncc_alloc_size(1, ms_len + 3);
+    quoted_ms[0]      = '"';
+    memcpy(quoted_ms + 1, method_string, ms_len);
+    quoted_ms[ms_len + 1] = '"';
+    quoted_ms[ms_len + 2] = '\0';
+
+    size_t svc_len    = strlen(svc);
+    size_t method_len = strlen(method);
+
+    #define BUILD_NAME(prefix, suffix_out) do {                  \
+        size_t p_len = strlen(prefix);                          \
+        size_t total = p_len + svc_len + 2 + method_len + 1;    \
+        (suffix_out) = ncc_alloc_size(1, total);                \
+        memcpy((suffix_out), (prefix), p_len);                   \
+        memcpy((suffix_out) + p_len, svc, svc_len);              \
+        (suffix_out)[p_len + svc_len]     = '_';                 \
+        (suffix_out)[p_len + svc_len + 1] = '_';                 \
+        memcpy((suffix_out) + p_len + svc_len + 2,               \
+               method, method_len);                              \
+        (suffix_out)[total - 1] = '\0';                          \
+    } while (0)
+
+    char *dispatcher_name;
+    char *registrar_name;
+    char *call_name;
+    BUILD_NAME("_n00b_rpc_dispatch__", dispatcher_name);
+    BUILD_NAME("_n00b_rpc_register__", registrar_name);
+    BUILD_NAME("n00b_rpc_call_",       call_name);
+    #undef BUILD_NAME
+
+    // Decoder identifiers — `_n00b_cbor_decode_<TypeName>`. Only
+    // request decoder for unary / server-stream; only response
+    // decoder for unary / client-stream; bidi needs neither
+    // (handler + runtime handle per-item CBOR themselves).
+    size_t pfx_len = strlen("_n00b_cbor_decode_");
+
+    char *dec_req  = nullptr;
+    char *dec_resp = nullptr;
+
+    if (shape == RPC_SHAPE_UNARY || shape == RPC_SHAPE_SERVER_STREAM) {
+        size_t r_len = strlen(req_inner);
+        dec_req      = ncc_alloc_size(1, pfx_len + r_len + 1);
+        memcpy(dec_req, "_n00b_cbor_decode_", pfx_len);
+        memcpy(dec_req + pfx_len, req_inner, r_len);
+        dec_req[pfx_len + r_len] = '\0';
+    }
+
+    if (shape == RPC_SHAPE_UNARY || shape == RPC_SHAPE_CLIENT_STREAM) {
+        size_t r_len = strlen(resp_inner);
+        dec_resp     = ncc_alloc_size(1, pfx_len + r_len + 1);
+        memcpy(dec_resp, "_n00b_cbor_decode_", pfx_len);
+        memcpy(dec_resp + pfx_len, resp_inner, r_len);
+        dec_resp[pfx_len + r_len] = '\0';
+    }
+
+    ncc_buffer_t *src = ncc_buffer_empty();
+
+    switch (shape) {
+    case RPC_SHAPE_UNARY:
+        build_unary_source(src, func_name, dispatcher_name,
+                            registrar_name, call_name, quoted_ms,
+                            req_inner, resp_inner, dec_req, dec_resp);
+        break;
+    case RPC_SHAPE_SERVER_STREAM:
+        build_server_stream_source(src, func_name, dispatcher_name,
+                                    registrar_name, call_name,
+                                    quoted_ms, req_inner, resp_inner,
+                                    dec_req);
+        break;
+    case RPC_SHAPE_CLIENT_STREAM:
+        build_client_stream_source(src, func_name, dispatcher_name,
+                                    registrar_name, call_name,
+                                    quoted_ms, req_inner, resp_inner,
+                                    dec_resp);
+        break;
+    case RPC_SHAPE_BIDI:
+        build_bidi_source(src, func_name, dispatcher_name,
+                           registrar_name, call_name, quoted_ms,
+                           req_inner, resp_inner);
+        break;
+    default:
+        rpc_diagnostic(rpc_clause,
+                       "@rpc: handler has an unrecognized signature "
+                       "shape");
+    }
 
     char *source = ncc_buffer_take(src);
 
     ncc_parse_tree_t *new_tu
         = ncc_xform_parse_source(ctx->grammar, "translation_unit",
-                                 source, "xform_rpc_unary");
+                                 source, "xform_rpc");
     ncc_free(source);
 
     if (!new_tu) {
         rpc_diagnostic(rpc_clause,
                        "internal error: failed to parse synthesized "
-                       "unary dispatcher source");
+                       "@rpc source");
     }
 
-    // Flatten the synthesized TU and queue its external_decls for
-    // appending after the user's original.
     ptrvec_t flat;
     ptrvec_init(&flat, 8);
 
@@ -956,8 +1282,6 @@ synthesize_unary(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *inner,
     ncc_free(svc);
     ncc_free(method);
     ncc_free(quoted_ms);
-    ncc_free(resp_type);
-    ncc_free(req_type);
     ncc_free(dispatcher_name);
     ncc_free(registrar_name);
     ncc_free(call_name);
@@ -1059,16 +1383,27 @@ xform_rpc_tu(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu,
         // declaration also gets stripped, but we don't double-emit
         // the dispatcher / ctor / stub).
         if (ncc_xform_nt_name_is(inner, "function_definition")) {
-            if (!is_unary_shape(inner)) {
+            char       *req_inner  = nullptr;
+            char       *resp_inner = nullptr;
+            rpc_shape_t shape      = detect_shape(inner, &resp_inner,
+                                                  &req_inner);
+
+            if (shape == RPC_SHAPE_UNKNOWN) {
                 rpc_diagnostic(rpc_clause,
-                               "@rpc: only unary shape is implemented "
-                               "in this phase (server-stream, "
-                               "client-stream, and bidi land in the "
-                               "next phase)");
+                               "@rpc: handler signature does not match "
+                               "any supported shape (expected return "
+                               "n00b_result_t(T *) or "
+                               "n00b_result_t(n00b_rpc_stream_t(T) *), "
+                               "with first parameter T * or "
+                               "n00b_rpc_stream_t(T) *)");
             }
 
-            synthesize_unary(ctx, inner, rpc_clause, method_string,
-                             &appended);
+            synthesize_for_shape(ctx, inner, rpc_clause, method_string,
+                                 shape, req_inner, resp_inner,
+                                 &appended);
+
+            ncc_free(req_inner);
+            ncc_free(resp_inner);
         }
 
         ncc_free(method_string);

--- a/templates/rpc_bidi.c.tmpl
+++ b/templates/rpc_bidi.c.tmpl
@@ -1,0 +1,48 @@
+// Generated from @rpc($3) on $0 (bidi).
+//
+// Slot layout:
+//   $4 — element type of the inbound stream
+//   $5 — element type of the outbound stream
+
+static n00b_result_t(n00b_rpc_stream_t(n00b_buffer_t *) *)
+_n00b_rpc_dispatch__$1__$2(n00b_rpc_stream_t(n00b_buffer_t *) *in,
+                           n00b_rpc_ctx_t                     *ctx)
+{
+    n00b_result_t(n00b_rpc_stream_t($5) *) resp =
+        $0((n00b_rpc_stream_t($4) *)in, ctx);
+
+    if (n00b_result_is_err(resp)) {
+        return n00b_result_err(n00b_rpc_stream_t(n00b_buffer_t *) *,
+                               n00b_result_get_err(resp));
+    }
+
+    return n00b_result_ok(
+        n00b_rpc_stream_t(n00b_buffer_t *) *,
+        (n00b_rpc_stream_t(n00b_buffer_t *) *)n00b_result_get(resp));
+}
+
+__attribute__((constructor))
+static void
+_n00b_rpc_register__$1__$2(void)
+{
+    n00b_rpc_register_bidi($3, &_n00b_rpc_dispatch__$1__$2);
+}
+
+extern n00b_result_t(n00b_rpc_stream_t($5) *)
+n00b_rpc_call_$1__$2(n00b_rpc_ctx_t        *ctx,
+                     n00b_rpc_channel_t    *chan,
+                     n00b_rpc_stream_t($4) *in)
+{
+    n00b_result_t(n00b_rpc_stream_t(n00b_buffer_t *) *) wire =
+        n00b_rpc_call_bidi(ctx, chan, $3,
+                           (n00b_rpc_stream_t(n00b_buffer_t *) *)in);
+
+    if (n00b_result_is_err(wire)) {
+        return n00b_result_err(n00b_rpc_stream_t($5) *,
+                               n00b_result_get_err(wire));
+    }
+
+    return n00b_result_ok(
+        n00b_rpc_stream_t($5) *,
+        (n00b_rpc_stream_t($5) *)n00b_result_get(wire));
+}

--- a/templates/rpc_client_stream.c.tmpl
+++ b/templates/rpc_client_stream.c.tmpl
@@ -1,0 +1,46 @@
+// Generated from @rpc($3) on $0 (client-stream).
+//
+// Slot layout:
+//   $4 — element type of the inbound stream (T from
+//        `n00b_rpc_stream_t(T) *in` parameter)
+//   $5 — response type (T from `n00b_result_t(T *)` return)
+//
+// As with server-stream, typed and buffer streams alias structurally
+// at the runtime layer — cast at the dispatcher / call boundary.
+
+static n00b_result_t(n00b_buffer_t *)
+_n00b_rpc_dispatch__$1__$2(n00b_rpc_stream_t(n00b_buffer_t *) *in,
+                           n00b_rpc_ctx_t                     *ctx)
+{
+    n00b_result_t($5 *) resp = $0((n00b_rpc_stream_t($4) *)in, ctx);
+
+    if (n00b_result_is_err(resp)) {
+        return n00b_result_err(n00b_buffer_t *,
+                               n00b_result_get_err(resp));
+    }
+
+    return n00b_result_ok(n00b_buffer_t *,
+                          n00b_cbor_encode(n00b_result_get(resp)));
+}
+
+__attribute__((constructor))
+static void
+_n00b_rpc_register__$1__$2(void)
+{
+    n00b_rpc_register_client_stream($3, &_n00b_rpc_dispatch__$1__$2);
+}
+
+extern n00b_result_t($5 *)
+n00b_rpc_call_$1__$2(n00b_rpc_ctx_t        *ctx,
+                     n00b_rpc_channel_t    *chan,
+                     n00b_rpc_stream_t($4) *in)
+{
+    n00b_result_t(n00b_buffer_t *) wire = n00b_rpc_call_client_stream(
+        ctx, chan, $3, (n00b_rpc_stream_t(n00b_buffer_t *) *)in);
+
+    if (n00b_result_is_err(wire)) {
+        return n00b_result_err($5 *, n00b_result_get_err(wire));
+    }
+
+    return _n00b_cbor_decode($5, n00b_result_get(wire));
+}

--- a/templates/rpc_server_stream.c.tmpl
+++ b/templates/rpc_server_stream.c.tmpl
@@ -1,0 +1,57 @@
+// Generated from @rpc($3) on $0 (server-stream).
+//
+// Slot layout matches rpc_unary.c.tmpl. $5 is the *element type* of
+// the returned stream (T from `n00b_result_t(n00b_rpc_stream_t(T) *)`).
+//
+// The runtime's stream-of-buffers is structurally identical to a
+// `n00b_rpc_stream_t(T)` (handler responsibility: encode each item
+// before send, decode on recv). Cast at the dispatcher boundary.
+
+static n00b_result_t(n00b_rpc_stream_t(n00b_buffer_t *) *)
+_n00b_rpc_dispatch__$1__$2(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)
+{
+    n00b_result_t($4 *) decoded = _n00b_cbor_decode($4, req_cbor);
+    if (n00b_result_is_err(decoded)) {
+        return n00b_result_err(n00b_rpc_stream_t(n00b_buffer_t *) *,
+                               n00b_result_get_err(decoded));
+    }
+
+    n00b_result_t(n00b_rpc_stream_t($5) *) resp =
+        $0(n00b_result_get(decoded), ctx);
+
+    if (n00b_result_is_err(resp)) {
+        return n00b_result_err(n00b_rpc_stream_t(n00b_buffer_t *) *,
+                               n00b_result_get_err(resp));
+    }
+
+    return n00b_result_ok(
+        n00b_rpc_stream_t(n00b_buffer_t *) *,
+        (n00b_rpc_stream_t(n00b_buffer_t *) *)n00b_result_get(resp));
+}
+
+__attribute__((constructor))
+static void
+_n00b_rpc_register__$1__$2(void)
+{
+    n00b_rpc_register_server_stream($3, &_n00b_rpc_dispatch__$1__$2);
+}
+
+extern n00b_result_t(n00b_rpc_stream_t($5) *)
+n00b_rpc_call_$1__$2(n00b_rpc_ctx_t     *ctx,
+                     n00b_rpc_channel_t *chan,
+                     $4                 *req)
+{
+    n00b_buffer_t *req_buf = n00b_cbor_encode(req);
+
+    n00b_result_t(n00b_rpc_stream_t(n00b_buffer_t *) *) wire =
+        n00b_rpc_call_server_stream(ctx, chan, $3, req_buf);
+
+    if (n00b_result_is_err(wire)) {
+        return n00b_result_err(n00b_rpc_stream_t($5) *,
+                               n00b_result_get_err(wire));
+    }
+
+    return n00b_result_ok(
+        n00b_rpc_stream_t($5) *,
+        (n00b_rpc_stream_t($5) *)n00b_result_get(wire));
+}

--- a/templates/rpc_unary.c.tmpl
+++ b/templates/rpc_unary.c.tmpl
@@ -1,0 +1,52 @@
+// Generated from @rpc($3) on $0.
+//
+// Slots:
+//   $0 — user handler name
+//   $1 — sanitized service name (e.g., `greet_v1_Greeter`)
+//   $2 — sanitized method name  (e.g., `Hello`)
+//   $3 — full method string literal, including quotes
+//   $4 — request type (T from `T *req` parameter)
+//   $5 — response type (T from `n00b_result_t(T *)` return)
+
+static n00b_result_t(n00b_buffer_t *)
+_n00b_rpc_dispatch__$1__$2(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)
+{
+    n00b_result_t($4 *) decoded = _n00b_cbor_decode($4, req_cbor);
+    if (n00b_result_is_err(decoded)) {
+        return n00b_result_err(n00b_buffer_t *,
+                               n00b_result_get_err(decoded));
+    }
+
+    n00b_result_t($5 *) resp = $0(n00b_result_get(decoded), ctx);
+    if (n00b_result_is_err(resp)) {
+        return n00b_result_err(n00b_buffer_t *,
+                               n00b_result_get_err(resp));
+    }
+
+    return n00b_result_ok(n00b_buffer_t *,
+                          n00b_cbor_encode(n00b_result_get(resp)));
+}
+
+__attribute__((constructor))
+static void
+_n00b_rpc_register__$1__$2(void)
+{
+    n00b_rpc_register($3, &_n00b_rpc_dispatch__$1__$2);
+}
+
+extern n00b_result_t($5 *)
+n00b_rpc_call_$1__$2(n00b_rpc_ctx_t     *ctx,
+                     n00b_rpc_channel_t *chan,
+                     $4                 *req)
+{
+    n00b_buffer_t *req_buf = n00b_cbor_encode(req);
+
+    n00b_result_t(n00b_buffer_t *) wire =
+        n00b_rpc_call_unary(ctx, chan, $3, req_buf);
+
+    if (n00b_result_is_err(wire)) {
+        return n00b_result_err($5 *, n00b_result_get_err(wire));
+    }
+
+    return _n00b_cbor_decode($5, n00b_result_get(wire));
+}

--- a/templates/rpc_unary.c.tmpl
+++ b/templates/rpc_unary.c.tmpl
@@ -1,52 +1,71 @@
-// Generated from @rpc($3) on $0.
+// Generated from @rpc($4) on $0.
 //
-// Slots:
+// Slot layout (template engine does not token-paste; every identifier
+// the xform constructs by gluing strings together is passed as its own
+// pre-computed slot):
 //   $0 — user handler name
-//   $1 — sanitized service name (e.g., `greet_v1_Greeter`)
-//   $2 — sanitized method name  (e.g., `Hello`)
-//   $3 — full method string literal, including quotes
-//   $4 — request type (T from `T *req` parameter)
-//   $5 — response type (T from `n00b_result_t(T *)` return)
+//   $1 — dispatcher name        (`_n00b_rpc_dispatch__<svc>__<method>`)
+//   $2 — registrar name         (`_n00b_rpc_register__<svc>__<method>`)
+//   $3 — call (client-stub) name (`n00b_rpc_call_<svc>__<method>`)
+//   $4 — full method string literal, including quotes
+//   $5 — request type
+//   $6 — response type
+//   $7 — request decoder identifier
+//   $8 — response decoder identifier
+//
+// Uses raw ncc `_generic_struct typeid(...)` for `n00b_result_t(T *)`
+// (libn00b macros expand to this form before user code reaches ncc;
+// template text is not preprocessed, so it must spell the raw form
+// directly).
 
-static n00b_result_t(n00b_buffer_t *)
-_n00b_rpc_dispatch__$1__$2(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)
+static _generic_struct typeid("result", n00b_buffer_t *)
+$1(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)
 {
-    n00b_result_t($4 *) decoded = _n00b_cbor_decode($4, req_cbor);
-    if (n00b_result_is_err(decoded)) {
-        return n00b_result_err(n00b_buffer_t *,
-                               n00b_result_get_err(decoded));
+    _generic_struct typeid("result", $5 *) decoded = $7(req_cbor);
+    if (!decoded.is_ok) {
+        return (_generic_struct typeid("result", n00b_buffer_t *)){
+            .is_ok = false,
+            .err   = decoded.err,
+        };
     }
 
-    n00b_result_t($5 *) resp = $0(n00b_result_get(decoded), ctx);
-    if (n00b_result_is_err(resp)) {
-        return n00b_result_err(n00b_buffer_t *,
-                               n00b_result_get_err(resp));
+    _generic_struct typeid("result", $6 *) resp = $0(decoded.ok, ctx);
+    if (!resp.is_ok) {
+        return (_generic_struct typeid("result", n00b_buffer_t *)){
+            .is_ok = false,
+            .err   = resp.err,
+        };
     }
 
-    return n00b_result_ok(n00b_buffer_t *,
-                          n00b_cbor_encode(n00b_result_get(resp)));
+    return (_generic_struct typeid("result", n00b_buffer_t *)){
+        .is_ok = true,
+        .ok    = n00b_cbor_encode(resp.ok),
+    };
 }
 
 __attribute__((constructor))
 static void
-_n00b_rpc_register__$1__$2(void)
+$2(void)
 {
-    n00b_rpc_register($3, &_n00b_rpc_dispatch__$1__$2);
+    n00b_rpc_register($4, &$1);
 }
 
-extern n00b_result_t($5 *)
-n00b_rpc_call_$1__$2(n00b_rpc_ctx_t     *ctx,
-                     n00b_rpc_channel_t *chan,
-                     $4                 *req)
+extern _generic_struct typeid("result", $6 *)
+$3(n00b_rpc_ctx_t     *ctx,
+   n00b_rpc_channel_t *chan,
+   $5                 *req)
 {
     n00b_buffer_t *req_buf = n00b_cbor_encode(req);
 
-    n00b_result_t(n00b_buffer_t *) wire =
-        n00b_rpc_call_unary(ctx, chan, $3, req_buf);
+    _generic_struct typeid("result", n00b_buffer_t *) wire =
+        n00b_rpc_call_unary(ctx, chan, $4, req_buf);
 
-    if (n00b_result_is_err(wire)) {
-        return n00b_result_err($5 *, n00b_result_get_err(wire));
+    if (!wire.is_ok) {
+        return (_generic_struct typeid("result", $6 *)){
+            .is_ok = false,
+            .err   = wire.err,
+        };
     }
 
-    return _n00b_cbor_decode($5, n00b_result_get(wire));
+    return $8(wire.ok);
 }

--- a/test/err_rpc_bad_method.c
+++ b/test/err_rpc_bad_method.c
@@ -1,0 +1,21 @@
+// err_rpc_bad_method — the @rpc string must match the form
+// "<package>.<Service>/<Method>"; a single bare word is rejected.
+
+typedef int n00b_err_t;
+typedef struct { int x; } Req_t;
+typedef struct { int y; } Reply_t;
+typedef struct { int p; } n00b_rpc_ctx_t;
+
+_generic_struct typeid("result", Reply_t *) {
+    bool is_ok; union { Reply_t *ok; n00b_err_t err; };
+};
+
+_generic_struct typeid("result", Reply_t *)
+hello(Req_t *req, n00b_rpc_ctx_t *ctx) @rpc("not_a_valid_method")
+{
+    (void)req;
+    (void)ctx;
+    return (_generic_struct typeid("result", Reply_t *)){0};
+}
+
+int main(void) { return 0; }

--- a/test/err_rpc_dup_method.c
+++ b/test/err_rpc_dup_method.c
@@ -1,0 +1,28 @@
+// err_rpc_dup_method — two `@rpc(...)` handlers in the same
+// translation unit binding the same method string conflict;
+// the xform detects + diagnoses the second occurrence.
+
+typedef int n00b_err_t;
+typedef struct { int x; } Req_t;
+typedef struct { int y; } Reply_t;
+typedef struct { int p; } n00b_rpc_ctx_t;
+
+_generic_struct typeid("result", Reply_t *) {
+    bool is_ok; union { Reply_t *ok; n00b_err_t err; };
+};
+
+_generic_struct typeid("result", Reply_t *)
+first(Req_t *req, n00b_rpc_ctx_t *ctx) @rpc("a.b.C/D")
+{
+    (void)req; (void)ctx;
+    return (_generic_struct typeid("result", Reply_t *)){0};
+}
+
+_generic_struct typeid("result", Reply_t *)
+second(Req_t *req, n00b_rpc_ctx_t *ctx) @rpc("a.b.C/D")
+{
+    (void)req; (void)ctx;
+    return (_generic_struct typeid("result", Reply_t *)){0};
+}
+
+int main(void) { return 0; }

--- a/test/err_rpc_no_ctx.c
+++ b/test/err_rpc_no_ctx.c
@@ -1,0 +1,19 @@
+// err_rpc_no_ctx — @rpc handler must take a trailing
+// `n00b_rpc_ctx_t *` parameter; missing it is rejected.
+
+typedef int n00b_err_t;
+typedef struct { int x; } Req_t;
+typedef struct { int y; } Reply_t;
+
+_generic_struct typeid("result", Reply_t *) {
+    bool is_ok; union { Reply_t *ok; n00b_err_t err; };
+};
+
+_generic_struct typeid("result", Reply_t *)
+hello(Req_t *req) @rpc("a.b.C/D")
+{
+    (void)req;
+    return (_generic_struct typeid("result", Reply_t *)){0};
+}
+
+int main(void) { return 0; }

--- a/test/err_rpc_void_return.c
+++ b/test/err_rpc_void_return.c
@@ -1,0 +1,14 @@
+// err_rpc_void_return — @rpc handler must return n00b_result_t(T *);
+// a void return is rejected by the shape-detection diagnostic.
+
+typedef struct { int x; } Req_t;
+typedef struct { int p; } n00b_rpc_ctx_t;
+
+void
+hello(Req_t *req, n00b_rpc_ctx_t *ctx) @rpc("a.b.C/D")
+{
+    (void)req;
+    (void)ctx;
+}
+
+int main(void) { return 0; }

--- a/test/err_rpc_with_kargs.c
+++ b/test/err_rpc_with_kargs.c
@@ -1,0 +1,25 @@
+// err_rpc_with_kargs — `@rpc` and `_kargs` on the same function are
+// rejected at parse time (spec §4); the grammar accepts the
+// combination so the xform can produce a precise diagnostic
+// instead of a generic parse failure.
+
+typedef int n00b_err_t;
+typedef struct { int x; } Req_t;
+typedef struct { int y; } Reply_t;
+typedef struct { int p; } n00b_rpc_ctx_t;
+
+_generic_struct typeid("result", Reply_t *) {
+    bool is_ok; union { Reply_t *ok; n00b_err_t err; };
+};
+
+_generic_struct typeid("result", Reply_t *)
+hello(Req_t *req, n00b_rpc_ctx_t *ctx)
+    _kargs { int extra = 0; }
+    @rpc("a.b.C/D")
+{
+    (void)req;
+    (void)ctx;
+    return (_generic_struct typeid("result", Reply_t *)){0};
+}
+
+int main(void) { return 0; }

--- a/test/test_rpc_bidi.c
+++ b/test/test_rpc_bidi.c
@@ -1,0 +1,111 @@
+// test_rpc_bidi — Phase E bidirectional-stream end-to-end.
+//
+// Handler takes a typed inbound stream and returns a typed
+// outbound stream. Dispatcher via `n00b_rpc_register_bidi`,
+// client stub via `n00b_rpc_call_bidi`.
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef int n00b_err_t;
+typedef struct { int p; } n00b_buffer_t;
+typedef struct { int p; } n00b_rpc_ctx_t;
+typedef struct { int p; } n00b_rpc_channel_t;
+typedef struct { int x; } ChatIn;
+typedef struct { int y; } ChatOut;
+
+_generic_struct typeid("rpc_stream", n00b_buffer_t *) { void *_opaque; };
+_generic_struct typeid("rpc_stream", ChatIn)          { void *_opaque; };
+_generic_struct typeid("rpc_stream", ChatOut)         { void *_opaque; };
+
+_generic_struct typeid("result", _generic_struct typeid("rpc_stream", ChatOut) *) {
+    bool is_ok;
+    union {
+        _generic_struct typeid("rpc_stream", ChatOut) *ok;
+        n00b_err_t err;
+    };
+};
+_generic_struct typeid("result", _generic_struct typeid("rpc_stream", n00b_buffer_t *) *) {
+    bool is_ok;
+    union {
+        _generic_struct typeid("rpc_stream", n00b_buffer_t *) *ok;
+        n00b_err_t err;
+    };
+};
+
+typedef _generic_struct typeid("result",
+                                _generic_struct typeid("rpc_stream", n00b_buffer_t *) *)
+    (*bd_dispatch_fn_t)(_generic_struct typeid("rpc_stream", n00b_buffer_t *) *,
+                        n00b_rpc_ctx_t *);
+
+static const char    *g_registered_method = NULL;
+static bd_dispatch_fn_t g_registered_fn   = NULL;
+
+void
+n00b_rpc_register_bidi(const char *method, bd_dispatch_fn_t fn)
+{
+    g_registered_method = method;
+    g_registered_fn     = fn;
+}
+
+_generic_struct typeid("result", _generic_struct typeid("rpc_stream", n00b_buffer_t *) *)
+n00b_rpc_call_bidi(n00b_rpc_ctx_t     *ctx,
+                   n00b_rpc_channel_t *chan,
+                   const char         *full_method,
+                   _generic_struct typeid("rpc_stream", n00b_buffer_t *) *in)
+{
+    (void)chan;
+    assert(g_registered_method != NULL);
+    assert(strcmp(full_method, g_registered_method) == 0);
+    return g_registered_fn(in, ctx);
+}
+
+static _generic_struct typeid("rpc_stream", ChatOut) g_out_stream;
+
+_generic_struct typeid("result", _generic_struct typeid("rpc_stream", ChatOut) *)
+chat(_generic_struct typeid("rpc_stream", ChatIn) *in, n00b_rpc_ctx_t *ctx)
+    @rpc("a.b.C/Chat")
+{
+    (void)in;
+    (void)ctx;
+    return (_generic_struct typeid("result",
+                                    _generic_struct typeid("rpc_stream", ChatOut) *)){
+        .is_ok = true,
+        .ok    = &g_out_stream,
+    };
+}
+
+extern _generic_struct typeid("result", _generic_struct typeid("rpc_stream", ChatOut) *)
+n00b_rpc_call_a_b_C__Chat(n00b_rpc_ctx_t                                       *ctx,
+                          n00b_rpc_channel_t                                   *chan,
+                          _generic_struct typeid("rpc_stream", ChatIn)         *in);
+
+int
+main(void)
+{
+    if (g_registered_method == NULL
+        || strcmp(g_registered_method, "a.b.C/Chat") != 0) {
+        return 1;
+    }
+    if (g_registered_fn == NULL) {
+        return 2;
+    }
+
+    _generic_struct typeid("rpc_stream", ChatIn) in_stream;
+    n00b_rpc_ctx_t ctx = {0};
+
+    _generic_struct typeid("result",
+                            _generic_struct typeid("rpc_stream", ChatOut) *) r
+        = n00b_rpc_call_a_b_C__Chat(&ctx, NULL, &in_stream);
+
+    if (!r.is_ok) {
+        return 3;
+    }
+    if (r.ok != &g_out_stream) {
+        return 4;
+    }
+
+    printf("OK\n");
+    return 0;
+}

--- a/test/test_rpc_client_stream.c
+++ b/test/test_rpc_client_stream.c
@@ -1,0 +1,120 @@
+// test_rpc_client_stream — Phase E client-stream end-to-end.
+//
+// Handler takes a typed inbound stream and returns a single
+// CBOR-encodable response. Dispatcher registered via
+// `n00b_rpc_register_client_stream`. Client stub goes through
+// `n00b_rpc_call_client_stream`.
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef int n00b_err_t;
+typedef struct { int p; } n00b_buffer_t;
+typedef struct { int p; } n00b_rpc_ctx_t;
+typedef struct { int p; } n00b_rpc_channel_t;
+typedef struct { int x; } Chunk;
+typedef struct { int n; } UploadReply;
+
+_generic_struct typeid("rpc_stream", n00b_buffer_t *) { void *_opaque; };
+_generic_struct typeid("rpc_stream", Chunk)           { void *_opaque; };
+
+_generic_struct typeid("result", UploadReply *) {
+    bool is_ok; union { UploadReply *ok; n00b_err_t err; };
+};
+_generic_struct typeid("result", n00b_buffer_t *) {
+    bool is_ok; union { n00b_buffer_t *ok; n00b_err_t err; };
+};
+
+typedef _generic_struct typeid("result", n00b_buffer_t *)
+    (*cs_dispatch_fn_t)(_generic_struct typeid("rpc_stream", n00b_buffer_t *) *,
+                        n00b_rpc_ctx_t *);
+
+static const char     *g_registered_method = NULL;
+static cs_dispatch_fn_t g_registered_fn    = NULL;
+
+void
+n00b_rpc_register_client_stream(const char *method, cs_dispatch_fn_t fn)
+{
+    g_registered_method = method;
+    g_registered_fn     = fn;
+}
+
+static UploadReply g_decoded_reply;
+
+_generic_struct typeid("result", UploadReply *)
+_n00b_cbor_decode_UploadReply(n00b_buffer_t *buf)
+{
+    g_decoded_reply.n = buf ? buf->p : 0;
+    return (_generic_struct typeid("result", UploadReply *)){
+        .is_ok = true, .ok = &g_decoded_reply,
+    };
+}
+
+static n00b_buffer_t g_enc_buf;
+n00b_buffer_t *
+n00b_cbor_encode(void *thing)
+{
+    UploadReply *r = thing;
+    g_enc_buf.p    = r->n;
+    return &g_enc_buf;
+}
+
+_generic_struct typeid("result", n00b_buffer_t *)
+n00b_rpc_call_client_stream(n00b_rpc_ctx_t     *ctx,
+                            n00b_rpc_channel_t *chan,
+                            const char         *full_method,
+                            _generic_struct typeid("rpc_stream", n00b_buffer_t *) *in)
+{
+    (void)chan;
+    assert(g_registered_method != NULL);
+    assert(strcmp(full_method, g_registered_method) == 0);
+    return g_registered_fn(in, ctx);
+}
+
+static UploadReply g_user_reply = {.n = 99};
+
+_generic_struct typeid("result", UploadReply *)
+upload(_generic_struct typeid("rpc_stream", Chunk) *in, n00b_rpc_ctx_t *ctx)
+    @rpc("a.b.U/Upload")
+{
+    (void)in;
+    (void)ctx;
+    return (_generic_struct typeid("result", UploadReply *)){
+        .is_ok = true, .ok = &g_user_reply,
+    };
+}
+
+extern _generic_struct typeid("result", UploadReply *)
+n00b_rpc_call_a_b_U__Upload(n00b_rpc_ctx_t                                       *ctx,
+                            n00b_rpc_channel_t                                   *chan,
+                            _generic_struct typeid("rpc_stream", Chunk)          *in);
+
+int
+main(void)
+{
+    if (g_registered_method == NULL
+        || strcmp(g_registered_method, "a.b.U/Upload") != 0) {
+        return 1;
+    }
+    if (g_registered_fn == NULL) {
+        return 2;
+    }
+
+    _generic_struct typeid("rpc_stream", Chunk) in_stream;
+    n00b_rpc_ctx_t ctx = {0};
+
+    _generic_struct typeid("result", UploadReply *) r
+        = n00b_rpc_call_a_b_U__Upload(&ctx, NULL, &in_stream);
+
+    if (!r.is_ok) {
+        return 3;
+    }
+    if (r.ok->n != 99) {
+        fprintf(stderr, "FAIL: expected n=99, got %d\n", r.ok->n);
+        return 4;
+    }
+
+    printf("OK\n");
+    return 0;
+}

--- a/test/test_rpc_keyword_collision.c
+++ b/test/test_rpc_keyword_collision.c
@@ -1,0 +1,84 @@
+// test_rpc_keyword_collision — verify the contextual-keyword lookahead
+// preserves `rpc` as a plain identifier in every position user code
+// might use it (variable, struct field, function name, parameter,
+// expression).
+//
+// This guards against the `@rpc(...)` clause's terminal registration
+// regressing existing C source. The companion @rpc tests cover the
+// *keyword* path; this test covers the *identifier* path.
+
+#include <stdio.h>
+
+static int local_var(void)
+{
+    int rpc = 42;
+    return rpc;
+}
+
+struct widget {
+    int rpc;
+    int extra;
+};
+
+static int field_use(void)
+{
+    struct widget w = {.rpc = 7, .extra = 3};
+    return w.rpc + w.extra;
+}
+
+static void rpc(int x);
+static void
+rpc(int x)
+{
+    (void)x;
+}
+
+static int
+param_use(int rpc)
+{
+    return rpc * 2;
+}
+
+static int
+expr_use(void)
+{
+    int rpc = 1;
+    return (rpc + 2) * 3;
+}
+
+static int
+pointer_use(void)
+{
+    int  rpc = 11;
+    int *p   = &rpc;
+    return *p;
+}
+
+int
+main(void)
+{
+    if (local_var() != 42) {
+        return 1;
+    }
+
+    if (field_use() != 10) {
+        return 2;
+    }
+
+    rpc(5);
+
+    if (param_use(21) != 42) {
+        return 3;
+    }
+
+    if (expr_use() != 9) {
+        return 4;
+    }
+
+    if (pointer_use() != 11) {
+        return 5;
+    }
+
+    printf("OK\n");
+    return 0;
+}

--- a/test/test_rpc_server_stream.c
+++ b/test/test_rpc_server_stream.c
@@ -1,0 +1,140 @@
+// test_rpc_server_stream — Phase E server-stream end-to-end.
+//
+// Handler returns a typed stream; dispatcher is registered via
+// `n00b_rpc_register_server_stream`; client stub round-trips
+// through `n00b_rpc_call_server_stream`. The runtime treats typed
+// and buffer streams as structural aliases, so the
+// dispatcher / stub cast at the boundary.
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef int n00b_err_t;
+typedef struct { int p; } n00b_buffer_t;
+typedef struct { int p; } n00b_rpc_ctx_t;
+typedef struct { int p; } n00b_rpc_channel_t;
+typedef struct { int x; } Req_t;
+typedef struct { int y; } StreamItem;
+
+// Stream-of-T bodies. The runtime's stream is a forward-declared
+// struct; here we provide minimal bodies under the same typeid tag
+// the ncc-emitted code references.
+_generic_struct typeid("rpc_stream", n00b_buffer_t *) { void *_opaque; };
+_generic_struct typeid("rpc_stream", StreamItem)      { void *_opaque; };
+
+// Result bodies.
+_generic_struct typeid("result", Req_t *) {
+    bool is_ok; union { Req_t *ok; n00b_err_t err; };
+};
+_generic_struct typeid("result", _generic_struct typeid("rpc_stream", StreamItem) *) {
+    bool is_ok;
+    union {
+        _generic_struct typeid("rpc_stream", StreamItem) *ok;
+        n00b_err_t err;
+    };
+};
+_generic_struct typeid("result", _generic_struct typeid("rpc_stream", n00b_buffer_t *) *) {
+    bool is_ok;
+    union {
+        _generic_struct typeid("rpc_stream", n00b_buffer_t *) *ok;
+        n00b_err_t err;
+    };
+};
+
+typedef _generic_struct typeid("result", _generic_struct typeid("rpc_stream", n00b_buffer_t *) *)
+    (*ss_dispatch_fn_t)(n00b_buffer_t *, n00b_rpc_ctx_t *);
+
+// Runtime stubs.
+static const char     *g_registered_method = NULL;
+static ss_dispatch_fn_t g_registered_fn    = NULL;
+
+void
+n00b_rpc_register_server_stream(const char *method, ss_dispatch_fn_t fn)
+{
+    g_registered_method = method;
+    g_registered_fn     = fn;
+}
+
+static Req_t g_decoded_req;
+
+_generic_struct typeid("result", Req_t *)
+_n00b_cbor_decode_Req_t(n00b_buffer_t *buf)
+{
+    g_decoded_req.x = buf ? buf->p : 0;
+    return (_generic_struct typeid("result", Req_t *)){
+        .is_ok = true, .ok = &g_decoded_req,
+    };
+}
+
+static n00b_buffer_t g_enc_buf;
+n00b_buffer_t *
+n00b_cbor_encode(void *thing)
+{
+    Req_t *r        = thing;
+    g_enc_buf.p     = r->x;
+    return &g_enc_buf;
+}
+
+// Stub transport: invoke the dispatcher directly and echo the result.
+_generic_struct typeid("result", _generic_struct typeid("rpc_stream", n00b_buffer_t *) *)
+n00b_rpc_call_server_stream(n00b_rpc_ctx_t     *ctx,
+                            n00b_rpc_channel_t *chan,
+                            const char         *full_method,
+                            n00b_buffer_t      *req_cbor)
+{
+    (void)chan;
+    assert(g_registered_method != NULL);
+    assert(strcmp(full_method, g_registered_method) == 0);
+    return g_registered_fn(req_cbor, ctx);
+}
+
+// User handler — server-stream shape.
+static _generic_struct typeid("rpc_stream", StreamItem) g_out_stream;
+
+_generic_struct typeid("result", _generic_struct typeid("rpc_stream", StreamItem) *)
+emit_items(Req_t *req, n00b_rpc_ctx_t *ctx) @rpc("a.b.S/Stream")
+{
+    (void)req;
+    (void)ctx;
+    return (_generic_struct typeid("result",
+                                    _generic_struct typeid("rpc_stream", StreamItem) *)){
+        .is_ok = true,
+        .ok    = &g_out_stream,
+    };
+}
+
+extern _generic_struct typeid("result", _generic_struct typeid("rpc_stream", StreamItem) *)
+n00b_rpc_call_a_b_S__Stream(n00b_rpc_ctx_t     *ctx,
+                            n00b_rpc_channel_t *chan,
+                            Req_t              *req);
+
+int
+main(void)
+{
+    if (g_registered_method == NULL
+        || strcmp(g_registered_method, "a.b.S/Stream") != 0) {
+        fprintf(stderr, "FAIL: not registered (got %s)\n",
+                g_registered_method ? g_registered_method : "(null)");
+        return 1;
+    }
+    if (g_registered_fn == NULL) {
+        return 2;
+    }
+
+    Req_t          req = {.x = 7};
+    n00b_rpc_ctx_t ctx = {0};
+    _generic_struct typeid("result",
+                            _generic_struct typeid("rpc_stream", StreamItem) *) r
+        = n00b_rpc_call_a_b_S__Stream(&ctx, NULL, &req);
+
+    if (!r.is_ok) {
+        return 3;
+    }
+    if (r.ok != &g_out_stream) {
+        return 4;
+    }
+
+    printf("OK\n");
+    return 0;
+}

--- a/test/test_rpc_strip_smoke.c
+++ b/test/test_rpc_strip_smoke.c
@@ -1,0 +1,30 @@
+// test_rpc_strip_smoke — Phase B regression: an `@rpc(...)` annotated
+// function must compile and run cleanly even though Phase B does not
+// yet synthesize the dispatcher / ctor / client stub. The xform's
+// job here is just to recognize the clause, validate the method
+// string, and strip the clause so clang sees plain C.
+//
+// Uses simple `int (int)` signatures intentionally — parametric type
+// support (`n00b_result_t(T *)`, `n00b_rpc_stream_t(T) *`) lands with
+// the unary end-to-end test in a later phase.
+
+#include <stdio.h>
+
+int hello(int x) @rpc("foo.v1.Foo/Bar");
+
+int
+hello(int x) @rpc("foo.v1.Foo/Bar")
+{
+    return x + 1;
+}
+
+int
+main(void)
+{
+    if (hello(41) != 42) {
+        return 1;
+    }
+
+    printf("OK\n");
+    return 0;
+}

--- a/test/test_rpc_strip_smoke.c
+++ b/test/test_rpc_strip_smoke.c
@@ -1,30 +1,23 @@
-// test_rpc_strip_smoke — Phase B regression: an `@rpc(...)` annotated
-// function must compile and run cleanly even though Phase B does not
-// yet synthesize the dispatcher / ctor / client stub. The xform's
-// job here is just to recognize the clause, validate the method
-// string, and strip the clause so clang sees plain C.
+// test_rpc_strip_smoke — verify that an @rpc clause attached to a
+// prototype (no body) is stripped from the parent declaration so
+// plain clang accepts the result.
 //
-// Uses simple `int (int)` signatures intentionally — parametric type
-// support (`n00b_result_t(T *)`, `n00b_rpc_stream_t(T) *`) lands with
-// the unary end-to-end test in a later phase.
+// This complements test_rpc_unary, which exercises the full
+// synthesize-on-function-definition path. The strip-on-prototype
+// path runs even when the signature isn't unary (the user may
+// attach @rpc to a forward declaration with whatever types they
+// want; only the function_definition triggers shape validation +
+// synthesis).
 
 #include <stdio.h>
 
-int hello(int x) @rpc("foo.v1.Foo/Bar");
-
-int
-hello(int x) @rpc("foo.v1.Foo/Bar")
-{
-    return x + 1;
-}
+// Prototype with @rpc — gets the clause stripped, then it's a
+// plain extern prototype that we never actually call.
+extern int hello_proto(int x) @rpc("foo.v1.Foo/Bar");
 
 int
 main(void)
 {
-    if (hello(41) != 42) {
-        return 1;
-    }
-
     printf("OK\n");
     return 0;
 }

--- a/test/test_rpc_unary.c
+++ b/test/test_rpc_unary.c
@@ -1,0 +1,172 @@
+// test_rpc_unary — Phase D end-to-end: an @rpc-annotated unary
+// handler compiles + runs through ncc. Verifies:
+//   - the constructor registered the dispatcher under the right
+//     method string,
+//   - the generated dispatcher decodes / dispatches / encodes,
+//   - the generated client stub round-trips against a stubbed
+//     transport.
+//
+// Uses raw ncc constructs (`typeid`, `_generic_struct`) directly —
+// libn00b provides macros that expand to this form, but the test
+// runs without libn00b headers.
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef int n00b_err_t;
+typedef struct { int placeholder; } n00b_buffer_t;
+typedef struct { int placeholder; } n00b_rpc_ctx_t;
+typedef struct { int placeholder; } n00b_rpc_channel_t;
+
+typedef struct { int x; } Req_t;
+typedef struct { int y; } Reply_t;
+
+// Result-type bodies. ncc's `_generic_struct` deduplicates these
+// across the TU; the dispatcher / stub emitted by ncc references
+// them by tag.
+_generic_struct typeid("result", Req_t *) {
+    bool is_ok;
+    union { Req_t *ok; n00b_err_t err; };
+};
+_generic_struct typeid("result", Reply_t *) {
+    bool is_ok;
+    union { Reply_t *ok; n00b_err_t err; };
+};
+_generic_struct typeid("result", n00b_buffer_t *) {
+    bool is_ok;
+    union { n00b_buffer_t *ok; n00b_err_t err; };
+};
+
+// Dispatcher function-pointer type — matches what ncc's emitted
+// `_n00b_rpc_dispatch__*` will look like.
+typedef _generic_struct typeid("result", n00b_buffer_t *)
+    (*dispatch_fn_t)(n00b_buffer_t *, n00b_rpc_ctx_t *);
+
+// --- Runtime stubs ---
+
+static const char *g_registered_method = NULL;
+static dispatch_fn_t g_registered_fn   = NULL;
+
+void
+n00b_rpc_register(const char *method, dispatch_fn_t fn)
+{
+    g_registered_method = method;
+    g_registered_fn     = fn;
+}
+
+// The dispatcher receives a CBOR-encoded request buffer and returns a
+// CBOR-encoded response buffer (or err). We use the buffer's
+// `placeholder` field as a stand-in payload.
+static Req_t g_last_req_seen;
+
+_generic_struct typeid("result", Req_t *)
+_n00b_cbor_decode_Req_t(n00b_buffer_t *buf)
+{
+    g_last_req_seen.x = buf ? buf->placeholder : -1;
+    return (_generic_struct typeid("result", Req_t *)){
+        .is_ok = true,
+        .ok    = &g_last_req_seen,
+    };
+}
+
+static Reply_t g_decoded_reply;
+
+_generic_struct typeid("result", Reply_t *)
+_n00b_cbor_decode_Reply_t(n00b_buffer_t *buf)
+{
+    g_decoded_reply.y = buf ? buf->placeholder : -1;
+    return (_generic_struct typeid("result", Reply_t *)){
+        .is_ok = true,
+        .ok    = &g_decoded_reply,
+    };
+}
+
+// `n00b_cbor_encode` is generic in real n00b. Here we stub a single
+// signature — `void *` in, returning a buffer whose `placeholder`
+// holds the `y` field for replies or the `x` field for requests.
+static n00b_buffer_t g_encoded_buf;
+
+n00b_buffer_t *
+n00b_cbor_encode(void *thing)
+{
+    Reply_t *r = thing;
+    g_encoded_buf.placeholder = r->y;
+    return &g_encoded_buf;
+}
+
+// Stubbed transport: echoes the request buffer as the response.
+// Real n00b_rpc_call_unary issues an H3 POST and awaits the reply;
+// here we just route through the registered dispatcher directly so
+// the test exercises both the client stub and the dispatcher in one
+// run.
+_generic_struct typeid("result", n00b_buffer_t *)
+n00b_rpc_call_unary(n00b_rpc_ctx_t     *ctx,
+                    n00b_rpc_channel_t *chan,
+                    const char         *full_method,
+                    n00b_buffer_t      *req_cbor)
+{
+    (void)chan;
+    assert(g_registered_method != NULL);
+    assert(strcmp(full_method, g_registered_method) == 0);
+    return g_registered_fn(req_cbor, ctx);
+}
+
+// --- User handler with @rpc annotation ---
+
+_generic_struct typeid("result", Reply_t *)
+hello(Req_t *req, n00b_rpc_ctx_t *ctx) @rpc("a.b.C/D")
+{
+    (void)ctx;
+    static Reply_t r;
+    r.y = req->x * 2;
+    return (_generic_struct typeid("result", Reply_t *)){
+        .is_ok = true,
+        .ok    = &r,
+    };
+}
+
+// --- Forward declarations for the ncc-emitted stubs ---
+
+extern _generic_struct typeid("result", Reply_t *)
+n00b_rpc_call_a_b_C__D(n00b_rpc_ctx_t     *ctx,
+                       n00b_rpc_channel_t *chan,
+                       Req_t              *req);
+
+int
+main(void)
+{
+    // Constructor should have fired at process start.
+    if (g_registered_method == NULL
+        || strcmp(g_registered_method, "a.b.C/D") != 0) {
+        fprintf(stderr, "FAIL: dispatcher not registered as a.b.C/D "
+                        "(got %s)\n",
+                g_registered_method ? g_registered_method : "(null)");
+        return 1;
+    }
+
+    if (g_registered_fn == NULL) {
+        fprintf(stderr, "FAIL: dispatcher function pointer is null\n");
+        return 2;
+    }
+
+    // Round-trip through the generated client stub.
+    Req_t req = {.x = 21};
+    n00b_rpc_ctx_t ctx = {0};
+
+    _generic_struct typeid("result", Reply_t *) reply =
+        n00b_rpc_call_a_b_C__D(&ctx, NULL, &req);
+
+    if (!reply.is_ok) {
+        fprintf(stderr, "FAIL: client stub returned err\n");
+        return 3;
+    }
+
+    if (reply.ok->y != 42) {
+        fprintf(stderr, "FAIL: expected y=42, got y=%d\n", reply.ok->y);
+        return 4;
+    }
+
+    printf("OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Introduces `@rpc` as a contextual annotation in ncc, with full grammar, tokenizer, transform pass, code-generation templates, and diagnostics. Authored on May 18 by a prior Claude Code session; rebased onto current `main` here (one trivial `c_ncc.bnf` conflict against #10 resolved additively, and a stray `a.out` test artifact stripped).

The chain is split into reviewable commits:

- `ncc: gitignore AGENTS.md + .agents/` — AI-assisted-work state
- `xform: lay groundwork for @rpc — grammar + contextual-keyword tokenizer`
- `xform: implement @rpc clause recognition + strip (no codegen yet)`
- `templates: add the four @rpc dispatcher / ctor / client-stub templates`
- `xform: implement unary @rpc dispatcher / ctor / client-stub synthesis`
- `xform: add server-stream, client-stream, and bidi @rpc shapes`
- `xform: add @rpc trailing-ctx + duplicate-method diagnostics; add err_rpc_*.c`
- `docs: document @rpc annotation in README`

## Test plan

- [x] `meson compile -C build` clean
- [x] `meson test -C build` — 51/51 pass, including `test_rpc_*` smoke tests and `err_rpc_*` diagnostic tests
- [ ] Review grammar change in `c_ncc.bnf` (declaration rule) for interaction with #10's `_kargs` attribute prefix work — currently rpc clauses do not accept the C23 attribute prefix; matches @rpc's pre-#10 design intent