### PR TITLE
xform: emit typed CBOR hooks for @rpc

### DIFF
--- a/src/xform/xform_rpc.c
+++ b/src/xform/xform_rpc.c
@@ -2,9 +2,8 @@
 //
 // Recognizes `@rpc(...)` on a function declaration or definition.
 // Validates the method string, strips the clause so plain clang
-// accepts the source, and (for unary shape) instantiates the
-// `rpc_unary` template to emit the dispatcher + constructor +
-// client-stub trio.
+// accepts the source, and emits the dispatcher + constructor +
+// client-stub trio for the matching unary / streaming shape.
 //
 // Operates pre-order on "translation_unit". We flatten the TU's
 // `$$group_*` wrapper, walk the external_declarations, strip + maybe
@@ -975,14 +974,14 @@ static void
 build_unary_source(ncc_buffer_t *src, const char *handler,
                    const char *dispatcher, const char *registrar,
                    const char *call_, const char *quoted_method,
-                   const char *req_t, const char *resp_t,
-                   const char *dec_req, const char *dec_resp)
+                   const char *req_t, const char *resp_t)
 {
     ncc_buffer_printf(src,
         "static _generic_struct typeid(\"result\", n00b_buffer_t *)\n"
         "%s(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)\n"
         "{\n"
-        "  _generic_struct typeid(\"result\", %s *) decoded = %s(req_cbor);\n"
+        "  _generic_struct typeid(\"result\", %s *) decoded =\n"
+        "    typeid(\"cbor_decode\", %s *)(req_cbor);\n"
         "  if (!decoded.is_ok) {\n"
         "    return (_generic_struct typeid(\"result\", n00b_buffer_t *)){\n"
         "      .is_ok = false, .err = decoded.err,\n"
@@ -995,7 +994,8 @@ build_unary_source(ncc_buffer_t *src, const char *handler,
         "    };\n"
         "  }\n"
         "  return (_generic_struct typeid(\"result\", n00b_buffer_t *)){\n"
-        "    .is_ok = true, .ok = n00b_cbor_encode(resp.ok),\n"
+        "    .is_ok = true,\n"
+        "    .ok = typeid(\"cbor_encode\", %s *)(resp.ok),\n"
         "  };\n"
         "}\n"
         "__attribute__((constructor))\n"
@@ -1003,7 +1003,7 @@ build_unary_source(ncc_buffer_t *src, const char *handler,
         "extern _generic_struct typeid(\"result\", %s *)\n"
         "%s(n00b_rpc_ctx_t *ctx, n00b_rpc_channel_t *chan, %s *req)\n"
         "{\n"
-        "  n00b_buffer_t *req_buf = n00b_cbor_encode(req);\n"
+        "  n00b_buffer_t *req_buf = typeid(\"cbor_encode\", %s *)(req);\n"
         "  _generic_struct typeid(\"result\", n00b_buffer_t *) wire =\n"
         "    n00b_rpc_call_unary(ctx, chan, %s, req_buf);\n"
         "  if (!wire.is_ok) {\n"
@@ -1011,16 +1011,17 @@ build_unary_source(ncc_buffer_t *src, const char *handler,
         "      .is_ok = false, .err = wire.err,\n"
         "    };\n"
         "  }\n"
-        "  return %s(wire.ok);\n"
+        "  return typeid(\"cbor_decode\", %s *)(wire.ok);\n"
         "}\n",
         dispatcher,
-        req_t, dec_req,
+        req_t, req_t,
         resp_t, handler,
+        resp_t,
         registrar, quoted_method, dispatcher,
-        resp_t, call_, req_t,
+        resp_t, call_, req_t, req_t,
         quoted_method,
         resp_t,
-        dec_resp);
+        resp_t);
 }
 
 // Shorthand used in the streaming builders below. `n00b_rpc_stream_t(T)`
@@ -1035,14 +1036,14 @@ static void
 build_server_stream_source(ncc_buffer_t *src, const char *handler,
                             const char *dispatcher, const char *registrar,
                             const char *call_, const char *quoted_method,
-                            const char *req_t, const char *resp_t,
-                            const char *dec_req)
+                            const char *req_t, const char *resp_t)
 {
     ncc_buffer_printf(src,
         "static _generic_struct typeid(\"result\", " STREAM_OF_BUF " *)\n"
         "%s(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)\n"
         "{\n"
-        "  _generic_struct typeid(\"result\", %s *) decoded = %s(req_cbor);\n"
+        "  _generic_struct typeid(\"result\", %s *) decoded =\n"
+        "    typeid(\"cbor_decode\", %s *)(req_cbor);\n"
         "  if (!decoded.is_ok) {\n"
         "    return (_generic_struct typeid(\"result\", " STREAM_OF_BUF " *)){\n"
         "      .is_ok = false, .err = decoded.err,\n"
@@ -1065,7 +1066,7 @@ build_server_stream_source(ncc_buffer_t *src, const char *handler,
         "extern _generic_struct typeid(\"result\", " STREAM_OF " *)\n"
         "%s(n00b_rpc_ctx_t *ctx, n00b_rpc_channel_t *chan, %s *req)\n"
         "{\n"
-        "  n00b_buffer_t *req_buf = n00b_cbor_encode(req);\n"
+        "  n00b_buffer_t *req_buf = typeid(\"cbor_encode\", %s *)(req);\n"
         "  _generic_struct typeid(\"result\", " STREAM_OF_BUF " *) wire =\n"
         "    n00b_rpc_call_server_stream(ctx, chan, %s, req_buf);\n"
         "  if (!wire.is_ok) {\n"
@@ -1079,10 +1080,10 @@ build_server_stream_source(ncc_buffer_t *src, const char *handler,
         "  };\n"
         "}\n",
         dispatcher,
-        req_t, dec_req,
+        req_t, req_t,
         resp_t, handler,
         registrar, quoted_method, dispatcher,
-        resp_t, call_, req_t,
+        resp_t, call_, req_t, req_t,
         quoted_method,
         resp_t,
         resp_t, resp_t);
@@ -1092,8 +1093,7 @@ static void
 build_client_stream_source(ncc_buffer_t *src, const char *handler,
                             const char *dispatcher, const char *registrar,
                             const char *call_, const char *quoted_method,
-                            const char *req_t, const char *resp_t,
-                            const char *dec_resp)
+                            const char *req_t, const char *resp_t)
 {
     ncc_buffer_printf(src,
         "static _generic_struct typeid(\"result\", n00b_buffer_t *)\n"
@@ -1107,7 +1107,8 @@ build_client_stream_source(ncc_buffer_t *src, const char *handler,
         "    };\n"
         "  }\n"
         "  return (_generic_struct typeid(\"result\", n00b_buffer_t *)){\n"
-        "    .is_ok = true, .ok = n00b_cbor_encode(resp.ok),\n"
+        "    .is_ok = true,\n"
+        "    .ok = typeid(\"cbor_encode\", %s *)(resp.ok),\n"
         "  };\n"
         "}\n"
         "__attribute__((constructor))\n"
@@ -1122,15 +1123,16 @@ build_client_stream_source(ncc_buffer_t *src, const char *handler,
         "      .is_ok = false, .err = wire.err,\n"
         "    };\n"
         "  }\n"
-        "  return %s(wire.ok);\n"
+        "  return typeid(\"cbor_decode\", %s *)(wire.ok);\n"
         "}\n",
         dispatcher,
         resp_t, handler, req_t,
+        resp_t,
         registrar, quoted_method, dispatcher,
         resp_t, call_, req_t,
         quoted_method,
         resp_t,
-        dec_resp);
+        resp_t);
 }
 
 static void
@@ -1243,50 +1245,23 @@ synthesize_for_shape(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *inner,
     BUILD_NAME("n00b_rpc_call_",       call_name);
     #undef BUILD_NAME
 
-    // Decoder identifiers — `_n00b_cbor_decode_<TypeName>`. Only
-    // request decoder for unary / server-stream; only response
-    // decoder for unary / client-stream; bidi needs neither
-    // (handler + runtime handle per-item CBOR themselves).
-    size_t pfx_len = strlen("_n00b_cbor_decode_");
-
-    char *dec_req  = nullptr;
-    char *dec_resp = nullptr;
-
-    if (shape == RPC_SHAPE_UNARY || shape == RPC_SHAPE_SERVER_STREAM) {
-        size_t r_len = strlen(req_inner);
-        dec_req      = ncc_alloc_size(1, pfx_len + r_len + 1);
-        memcpy(dec_req, "_n00b_cbor_decode_", pfx_len);
-        memcpy(dec_req + pfx_len, req_inner, r_len);
-        dec_req[pfx_len + r_len] = '\0';
-    }
-
-    if (shape == RPC_SHAPE_UNARY || shape == RPC_SHAPE_CLIENT_STREAM) {
-        size_t r_len = strlen(resp_inner);
-        dec_resp     = ncc_alloc_size(1, pfx_len + r_len + 1);
-        memcpy(dec_resp, "_n00b_cbor_decode_", pfx_len);
-        memcpy(dec_resp + pfx_len, resp_inner, r_len);
-        dec_resp[pfx_len + r_len] = '\0';
-    }
-
     ncc_buffer_t *src = ncc_buffer_empty();
 
     switch (shape) {
     case RPC_SHAPE_UNARY:
         build_unary_source(src, func_name, dispatcher_name,
                             registrar_name, call_name, quoted_ms,
-                            req_inner, resp_inner, dec_req, dec_resp);
+                            req_inner, resp_inner);
         break;
     case RPC_SHAPE_SERVER_STREAM:
         build_server_stream_source(src, func_name, dispatcher_name,
                                     registrar_name, call_name,
-                                    quoted_ms, req_inner, resp_inner,
-                                    dec_req);
+                                    quoted_ms, req_inner, resp_inner);
         break;
     case RPC_SHAPE_CLIENT_STREAM:
         build_client_stream_source(src, func_name, dispatcher_name,
                                     registrar_name, call_name,
-                                    quoted_ms, req_inner, resp_inner,
-                                    dec_resp);
+                                    quoted_ms, req_inner, resp_inner);
         break;
     case RPC_SHAPE_BIDI:
         build_bidi_source(src, func_name, dispatcher_name,
@@ -1335,8 +1310,6 @@ synthesize_for_shape(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *inner,
     ncc_free(dispatcher_name);
     ncc_free(registrar_name);
     ncc_free(call_name);
-    ncc_free(dec_req);
-    ncc_free(dec_resp);
 }
 
 // ============================================================================
@@ -1346,8 +1319,8 @@ synthesize_for_shape(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *inner,
 //   1. Flatten the TU's `$$group_*` wrapper into a flat list of
 //      external_declarations.
 //   2. For each: strip @rpc (validates, diagnoses, removes the
-//      clause from the parent). If unary shape, instantiate the
-//      `rpc_unary` template and queue its declarations for append.
+//      clause from the parent), synthesize the matching dispatcher /
+//      registrar / client stub, and queue its declarations for append.
 //   3. Rebuild the TU as `[originals... ; appended...]`, wrapped in
 //      a single fresh `$$group_rpc` node — the standard ncc idiom
 //      for replacing TU children in bulk.

--- a/templates/rpc_client_stream.c.tmpl
+++ b/templates/rpc_client_stream.c.tmpl
@@ -19,8 +19,9 @@ _n00b_rpc_dispatch__$1__$2(n00b_rpc_stream_t(n00b_buffer_t *) *in,
                                n00b_result_get_err(resp));
     }
 
-    return n00b_result_ok(n00b_buffer_t *,
-                          n00b_cbor_encode(n00b_result_get(resp)));
+    return n00b_result_ok(
+        n00b_buffer_t *,
+        typeid("cbor_encode", $5 *)(n00b_result_get(resp)));
 }
 
 __attribute__((constructor))
@@ -42,5 +43,5 @@ n00b_rpc_call_$1__$2(n00b_rpc_ctx_t        *ctx,
         return n00b_result_err($5 *, n00b_result_get_err(wire));
     }
 
-    return _n00b_cbor_decode($5, n00b_result_get(wire));
+    return typeid("cbor_decode", $5 *)(n00b_result_get(wire));
 }

--- a/templates/rpc_server_stream.c.tmpl
+++ b/templates/rpc_server_stream.c.tmpl
@@ -10,7 +10,8 @@
 static n00b_result_t(n00b_rpc_stream_t(n00b_buffer_t *) *)
 _n00b_rpc_dispatch__$1__$2(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)
 {
-    n00b_result_t($4 *) decoded = _n00b_cbor_decode($4, req_cbor);
+    n00b_result_t($4 *) decoded =
+        typeid("cbor_decode", $4 *)(req_cbor);
     if (n00b_result_is_err(decoded)) {
         return n00b_result_err(n00b_rpc_stream_t(n00b_buffer_t *) *,
                                n00b_result_get_err(decoded));
@@ -41,7 +42,7 @@ n00b_rpc_call_$1__$2(n00b_rpc_ctx_t     *ctx,
                      n00b_rpc_channel_t *chan,
                      $4                 *req)
 {
-    n00b_buffer_t *req_buf = n00b_cbor_encode(req);
+    n00b_buffer_t *req_buf = typeid("cbor_encode", $4 *)(req);
 
     n00b_result_t(n00b_rpc_stream_t(n00b_buffer_t *) *) wire =
         n00b_rpc_call_server_stream(ctx, chan, $3, req_buf);

--- a/templates/rpc_unary.c.tmpl
+++ b/templates/rpc_unary.c.tmpl
@@ -10,8 +10,6 @@
 //   $4 — full method string literal, including quotes
 //   $5 — request type
 //   $6 — response type
-//   $7 — request decoder identifier
-//   $8 — response decoder identifier
 //
 // Uses raw ncc `_generic_struct typeid(...)` for `n00b_result_t(T *)`
 // (libn00b macros expand to this form before user code reaches ncc;
@@ -21,7 +19,8 @@
 static _generic_struct typeid("result", n00b_buffer_t *)
 $1(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)
 {
-    _generic_struct typeid("result", $5 *) decoded = $7(req_cbor);
+    _generic_struct typeid("result", $5 *) decoded =
+        typeid("cbor_decode", $5 *)(req_cbor);
     if (!decoded.is_ok) {
         return (_generic_struct typeid("result", n00b_buffer_t *)){
             .is_ok = false,
@@ -39,7 +38,7 @@ $1(n00b_buffer_t *req_cbor, n00b_rpc_ctx_t *ctx)
 
     return (_generic_struct typeid("result", n00b_buffer_t *)){
         .is_ok = true,
-        .ok    = n00b_cbor_encode(resp.ok),
+        .ok    = typeid("cbor_encode", $6 *)(resp.ok),
     };
 }
 
@@ -55,7 +54,7 @@ $3(n00b_rpc_ctx_t     *ctx,
    n00b_rpc_channel_t *chan,
    $5                 *req)
 {
-    n00b_buffer_t *req_buf = n00b_cbor_encode(req);
+    n00b_buffer_t *req_buf = typeid("cbor_encode", $5 *)(req);
 
     _generic_struct typeid("result", n00b_buffer_t *) wire =
         n00b_rpc_call_unary(ctx, chan, $4, req_buf);
@@ -67,5 +66,5 @@ $3(n00b_rpc_ctx_t     *ctx,
         };
     }
 
-    return $8(wire.ok);
+    return typeid("cbor_decode", $6 *)(wire.ok);
 }

--- a/test/test_rpc_client_stream.c
+++ b/test/test_rpc_client_stream.c
@@ -43,7 +43,7 @@ n00b_rpc_register_client_stream(const char *method, cs_dispatch_fn_t fn)
 static UploadReply g_decoded_reply;
 
 _generic_struct typeid("result", UploadReply *)
-_n00b_cbor_decode_UploadReply(n00b_buffer_t *buf)
+typeid("cbor_decode", UploadReply *)(n00b_buffer_t *buf)
 {
     g_decoded_reply.n = buf ? buf->p : 0;
     return (_generic_struct typeid("result", UploadReply *)){
@@ -53,10 +53,9 @@ _n00b_cbor_decode_UploadReply(n00b_buffer_t *buf)
 
 static n00b_buffer_t g_enc_buf;
 n00b_buffer_t *
-n00b_cbor_encode(void *thing)
+typeid("cbor_encode", UploadReply *)(UploadReply *thing)
 {
-    UploadReply *r = thing;
-    g_enc_buf.p    = r->n;
+    g_enc_buf.p    = thing->n;
     return &g_enc_buf;
 }
 

--- a/test/test_rpc_server_stream.c
+++ b/test/test_rpc_server_stream.c
@@ -59,7 +59,7 @@ n00b_rpc_register_server_stream(const char *method, ss_dispatch_fn_t fn)
 static Req_t g_decoded_req;
 
 _generic_struct typeid("result", Req_t *)
-_n00b_cbor_decode_Req_t(n00b_buffer_t *buf)
+typeid("cbor_decode", Req_t *)(n00b_buffer_t *buf)
 {
     g_decoded_req.x = buf ? buf->p : 0;
     return (_generic_struct typeid("result", Req_t *)){
@@ -69,10 +69,9 @@ _n00b_cbor_decode_Req_t(n00b_buffer_t *buf)
 
 static n00b_buffer_t g_enc_buf;
 n00b_buffer_t *
-n00b_cbor_encode(void *thing)
+typeid("cbor_encode", Req_t *)(Req_t *thing)
 {
-    Req_t *r        = thing;
-    g_enc_buf.p     = r->x;
+    g_enc_buf.p     = thing->x;
     return &g_enc_buf;
 }
 

--- a/test/test_rpc_unary.c
+++ b/test/test_rpc_unary.c
@@ -61,7 +61,7 @@ n00b_rpc_register(const char *method, dispatch_fn_t fn)
 static Req_t g_last_req_seen;
 
 _generic_struct typeid("result", Req_t *)
-_n00b_cbor_decode_Req_t(n00b_buffer_t *buf)
+typeid("cbor_decode", Req_t *)(n00b_buffer_t *buf)
 {
     g_last_req_seen.x = buf ? buf->placeholder : -1;
     return (_generic_struct typeid("result", Req_t *)){
@@ -73,7 +73,7 @@ _n00b_cbor_decode_Req_t(n00b_buffer_t *buf)
 static Reply_t g_decoded_reply;
 
 _generic_struct typeid("result", Reply_t *)
-_n00b_cbor_decode_Reply_t(n00b_buffer_t *buf)
+typeid("cbor_decode", Reply_t *)(n00b_buffer_t *buf)
 {
     g_decoded_reply.y = buf ? buf->placeholder : -1;
     return (_generic_struct typeid("result", Reply_t *)){
@@ -82,16 +82,19 @@ _n00b_cbor_decode_Reply_t(n00b_buffer_t *buf)
     };
 }
 
-// `n00b_cbor_encode` is generic in real n00b. Here we stub a single
-// signature — `void *` in, returning a buffer whose `placeholder`
-// holds the `y` field for replies or the `x` field for requests.
 static n00b_buffer_t g_encoded_buf;
 
 n00b_buffer_t *
-n00b_cbor_encode(void *thing)
+typeid("cbor_encode", Req_t *)(Req_t *thing)
 {
-    Reply_t *r = thing;
-    g_encoded_buf.placeholder = r->y;
+    g_encoded_buf.placeholder = thing->x;
+    return &g_encoded_buf;
+}
+
+n00b_buffer_t *
+typeid("cbor_encode", Reply_t *)(Reply_t *thing)
+{
+    g_encoded_buf.placeholder = thing->y;
     return &g_encoded_buf;
 }
 


### PR DESCRIPTION
Summary:
- Emit typed CBOR hooks directly in generated @rpc dispatcher/stub code: typeid("cbor_decode", T *)(...) and typeid("cbor_encode", T *)(...).
- Remove synthesized _n00b_cbor_decode_<Type> helper-name generation and generic n00b_cbor_encode(...) calls from @rpc codegen.
- Update RPC templates and @rpc transform tests to match the typed hook contract.

Validation:
- PATH="/opt/homebrew/opt/llvm/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion.app/Contents/Public:/Users/viega/.codex/tmp/arg0/codex-arg0JFrRJ3:/Users/viega/.nvm/versions/node/v22.17.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/viega/.local/bin:/Users/viega/.nvm/versions/node/v22.17.0/bin:/opt/homebrew/opt/llvm@21/bin:/Users/viega/Library/Python/3.9/bin:/Users/viega/n00b/bin:/Applications/Ghostty.app/Contents/MacOS:/opt/homebrew/bin:/Users/viega/.cargo/bin" CC=/opt/homebrew/opt/llvm/bin/clang meson setup build
- PATH="/opt/homebrew/opt/llvm/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion.app/Contents/Public:/Users/viega/.codex/tmp/arg0/codex-arg0JFrRJ3:/Users/viega/.nvm/versions/node/v22.17.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/viega/.local/bin:/Users/viega/.nvm/versions/node/v22.17.0/bin:/opt/homebrew/opt/llvm@21/bin:/Users/viega/Library/Python/3.9/bin:/Users/viega/n00b/bin:/Applications/Ghostty.app/Contents/MacOS:/opt/homebrew/bin:/Users/viega/.cargo/bin" meson compile -C build
- Focused @rpc transform tests: 11/11 passed
- PATH="/opt/homebrew/opt/llvm/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion.app/Contents/Public:/Users/viega/.codex/tmp/arg0/codex-arg0JFrRJ3:/Users/viega/.nvm/versions/node/v22.17.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/viega/.local/bin:/Users/viega/.nvm/versions/node/v22.17.0/bin:/opt/homebrew/opt/llvm@21/bin:/Users/viega/Library/Python/3.9/bin:/Users/viega/n00b/bin:/Applications/Ghostty.app/Contents/MacOS:/opt/homebrew/bin:/Users/viega/.cargo/bin" meson test -C build --print-errorlogs: 51/51 passed
- Downstream n00b native focused validation with patched ncc passed for parquet_flat, http_service, json_contract, http_json_parquet, quic_rpc_demo_smoke, and quic_phase5_demo_smoke.