### PR TITLE
feat: emit precise n00b GC stack maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,48 @@ value with `.data`, `.len`, `.cap`, `.lock`, `.allocator`,
 override the backing-storage templates to wrap the static data in their
 own allocation headers for GC and memory-introspection support.
 
+### n00b GC Stack Maps
+
+ncc can emit n00b-compatible exact stack-map metadata for stack roots:
+
+```sh
+ncc --ncc-gc-stack-maps -c module.c
+```
+
+This feature is off by default in upstream ncc because the generated C
+references the n00b GC stack ABI. Embedding runtimes that enable it must
+make these names visible before transformed code is compiled:
+`n00b_gc_stack_slot_t`, `n00b_gc_stack_map_t`,
+`n00b_gc_stack_frame_t`, `n00b_gc_stack_push()`, and
+`n00b_gc_stack_pop()`.
+
+Generated code publishes root addresses, not root values. ncc emits
+static slot/map records, an array of root-slot addresses, a stack frame,
+and a cleanup-backed pop so ordinary C exits such as return, break,
+continue, and goto-out unwind frames in LIFO order.
+
+Supported roots are named pointer or aggregate parameters, local pointer
+variables, fixed-size local pointer arrays, and local aggregate values.
+Lexical scope is the lifetime boundary. This can retain objects longer
+than minimal liveness would, but it avoids losing a declared root before
+the block exits.
+
+Strict mode rejects unsupported root shapes with diagnostics, including
+unnamed pointer/aggregate parameters, variable-length or incomplete
+arrays, parenthesized pointer-array declarators, and roots declared in
+statement contexts such as `for` initializers. `--ncc-gc-stack-maps-relaxed`
+enables the same transform but skips unsupported local root shapes instead
+of failing the translation unit; this is intended for bootstrapping large
+runtimes while coverage is still incomplete.
+
+The transform intentionally skips functions that would make exact stack
+publication unsafe or recursive: the generated/manual `n00b_gc_stack_*`
+API, n00b thread/safepoint/futex helpers, computed-goto functions,
+system-header functions, selected runtime helpers, and functions that
+manually call `n00b_gc_stack_push()` or `n00b_gc_stack_pop()`. Exact-only
+collection across arbitrary uninstrumented C boundaries, non-local exits,
+and precise field maps for arbitrary aggregate values remain future work.
+
 
 ## Customization
 
@@ -612,6 +654,7 @@ Pass these with `meson setup -Doption=value`:
 | `rstr_static_ref_expr_plain` | (built-in) | Address expression template for plain `r""` literals embedded in static array literal initializers |
 | `array_literal_data_template` | (built-in) | Declaration template for array literal backing storage |
 | `array_literal_data_expr` | (built-in) | Expression used as the generated array `.data` pointer |
+| `gc_stack_maps` | `false` | Enable n00b GC stack-map emission by default for this ncc binary |
 | `coverage` | `false` | Enable clang source-based code coverage |
 
 These same options can be overridden per-invocation via CLI flags (see
@@ -638,6 +681,9 @@ arguments reach clang.
 | `--ncc-rstr-static-ref-expr-plain=EXPR` | Override plain rstr address expression for static array literal initializers |
 | `--ncc-array-literal-data-template=TMPL` | Override array literal backing storage declaration template |
 | `--ncc-array-literal-data-expr=EXPR` | Override expression used as the generated array `.data` pointer |
+| `--ncc-gc-stack-maps` | Emit n00b GC stack-map metadata in strict mode |
+| `--ncc-gc-stack-maps-relaxed` | Emit n00b GC stack maps while skipping unsupported local roots |
+| `--ncc-no-gc-stack-maps` | Disable n00b GC stack-map metadata for this invocation |
 | `--ncc-constexpr-include=HDRS` | Headers for constexpr eval programs |
 | `--ncc-dump-tokens` | Dump token stream to stderr |
 | `--ncc-dump-tree` | Dump parse tree to stderr |

--- a/README.md
+++ b/README.md
@@ -605,15 +605,18 @@ static slot/map records, an array of root-slot addresses, a stack frame,
 and a cleanup-backed pop so ordinary C exits such as return, break,
 continue, and goto-out unwind frames in LIFO order.
 
-Supported roots are named pointer or aggregate parameters, local pointer
-variables, fixed-size local pointer arrays, and local aggregate values.
-Lexical scope is the lifetime boundary. This can retain objects longer
-than minimal liveness would, but it avoids losing a declared root before
-the block exits.
+Supported roots are named pointer or pointer-bearing aggregate parameters,
+local pointer variables, fixed-size local pointer arrays, and local aggregate
+values. Aggregate roots expand to pointer-bearing field slots, including
+nested aggregate fields and fixed arrays of aggregates; ncc does not publish
+the whole aggregate object as a `sizeof(root)` word range. Lexical scope is the
+lifetime boundary. This can retain objects longer than minimal liveness would,
+but it avoids losing a declared root before the block exits.
 
 Strict mode rejects unsupported root shapes with diagnostics, including
 unnamed pointer/aggregate parameters, variable-length or incomplete
-arrays, parenthesized pointer-array declarators, and roots declared in
+arrays, aggregate arrays with non-literal bounds, parenthesized
+pointer-array declarators, and roots declared in
 statement contexts such as `for` initializers. `--ncc-gc-stack-maps-relaxed`
 enables the same transform but skips unsupported local root shapes instead
 of failing the translation unit; this is intended for bootstrapping large
@@ -622,10 +625,11 @@ runtimes while coverage is still incomplete.
 The transform intentionally skips functions that would make exact stack
 publication unsafe or recursive: the generated/manual `n00b_gc_stack_*`
 API, n00b thread/safepoint/futex helpers, computed-goto functions,
-system-header functions, selected runtime helpers, and functions that
+functions declared in system headers, selected runtime helpers, and functions that
 manually call `n00b_gc_stack_push()` or `n00b_gc_stack_pop()`. Exact-only
 collection across arbitrary uninstrumented C boundaries, non-local exits,
-and precise field maps for arbitrary aggregate values remain future work.
+minimal last-use liveness, and active-member precision for unions remain
+future work.
 
 
 ## Customization

--- a/include/xform/xform_data.h
+++ b/include/xform/xform_data.h
@@ -66,6 +66,7 @@ typedef struct {
     const char                *array_literal_data_template;
     const char                *array_literal_data_expr;
     bool                       gc_stack_maps;
+    bool                       gc_stack_maps_relaxed;
     bool                       gc_stack_maps_helper_inserted;
     ncc_gc_stack_root_t       *gc_stack_roots;
     size_t                     gc_stack_root_count;

--- a/include/xform/xform_data.h
+++ b/include/xform/xform_data.h
@@ -35,6 +35,8 @@ typedef struct ncc_gc_stack_root_t {
     char                       *function_name;
     char                       *name;
     char                       *type_text;
+    char                       *address_expr;
+    char                       *num_words_expr;
     ncc_gc_stack_root_kind_t    kind;
     ncc_gc_stack_root_shape_t   shape;
     uint64_t                    num_words;
@@ -53,6 +55,8 @@ typedef struct {
     ncc_dict_t                 option_decls;
     ncc_dict_t                 generic_struct_decls;
     ncc_dict_t                 array_types;
+    ncc_dict_t                 gc_aggregate_types;
+    ncc_dict_t                 gc_pointer_typedefs;
     ncc_template_registry_t   *template_reg;
     const char                *vargs_type;
     const char                *once_prefix;
@@ -67,7 +71,6 @@ typedef struct {
     const char                *array_literal_data_expr;
     bool                       gc_stack_maps;
     bool                       gc_stack_maps_relaxed;
-    bool                       gc_stack_maps_helper_inserted;
     ncc_gc_stack_root_t       *gc_stack_roots;
     size_t                     gc_stack_root_count;
 } ncc_xform_data_t;

--- a/include/xform/xform_data.h
+++ b/include/xform/xform_data.h
@@ -40,6 +40,7 @@ typedef struct {
     const char                *rstr_static_ref_expr_plain;
     const char                *array_literal_data_template;
     const char                *array_literal_data_expr;
+    bool                       gc_stack_maps;
 } ncc_xform_data_t;
 
 static inline ncc_xform_data_t *ncc_xform_get_data(ncc_xform_ctx_t *ctx) {

--- a/include/xform/xform_data.h
+++ b/include/xform/xform_data.h
@@ -66,6 +66,7 @@ typedef struct {
     const char                *array_literal_data_template;
     const char                *array_literal_data_expr;
     bool                       gc_stack_maps;
+    bool                       gc_stack_maps_helper_inserted;
     ncc_gc_stack_root_t       *gc_stack_roots;
     size_t                     gc_stack_root_count;
 } ncc_xform_data_t;

--- a/include/xform/xform_data.h
+++ b/include/xform/xform_data.h
@@ -20,6 +20,31 @@ typedef struct {
     ncc_meta_entry_t entries[NCC_META_TABLE_SIZE];
 } ncc_meta_table_t;
 
+typedef enum {
+    NCC_GC_STACK_ROOT_PARAM,
+    NCC_GC_STACK_ROOT_LOCAL,
+} ncc_gc_stack_root_kind_t;
+
+typedef enum {
+    NCC_GC_STACK_ROOT_POINTER,
+    NCC_GC_STACK_ROOT_POINTER_ARRAY,
+    NCC_GC_STACK_ROOT_AGGREGATE,
+} ncc_gc_stack_root_shape_t;
+
+typedef struct ncc_gc_stack_root_t {
+    char                       *function_name;
+    char                       *name;
+    char                       *type_text;
+    ncc_gc_stack_root_kind_t    kind;
+    ncc_gc_stack_root_shape_t   shape;
+    uint64_t                    num_words;
+    uint32_t                    line;
+    uint32_t                    col;
+    ncc_parse_tree_t           *scope;
+    ncc_parse_tree_t           *declaration;
+    struct ncc_gc_stack_root_t *next;
+} ncc_gc_stack_root_t;
+
 typedef struct {
     const char                *compiler;
     const char                *constexpr_headers;
@@ -41,6 +66,8 @@ typedef struct {
     const char                *array_literal_data_template;
     const char                *array_literal_data_expr;
     bool                       gc_stack_maps;
+    ncc_gc_stack_root_t       *gc_stack_roots;
+    size_t                     gc_stack_root_count;
 } ncc_xform_data_t;
 
 static inline ncc_xform_data_t *ncc_xform_get_data(ncc_xform_ctx_t *ctx) {

--- a/meson.build
+++ b/meson.build
@@ -391,7 +391,8 @@ test('ncc_gc_stack_maps_default_off', test_runner,
 )
 
 test('ncc_gc_stack_maps_flag_accepted', test_runner,
-  args : [ncc_exe, 'preprocess', test_dir / 'test_gc_stack_maps_flag.c']
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_flag.c', 'n00b_gc_stack_push']
          + ncc_test_flags + ['--ncc-gc-stack-maps'],
   suite : 'ncc',
   depends : ncc_exe,
@@ -399,6 +400,46 @@ test('ncc_gc_stack_maps_flag_accepted', test_runner,
 
 test('ncc_gc_stack_maps_root_discovery', test_runner,
   args : [ncc_exe, 'preprocess', test_dir / 'test_gc_stack_maps_roots.c']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_pointer_array_words', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', '.num_words = 3']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_cleanup_attr', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_roots.c',
+          'cleanup (__ncc_gc_stack_pop_cleanup)']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_scalar_array_not_root', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_scalar_array.c', '& values']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_empty_body_param', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_empty_body.c', 'n00b_gc_stack_push']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_runtime_compile', test_runner,
+  args : [ncc_exe, 'compile_run', test_dir / 'test_gc_stack_maps_runtime.c']
          + ncc_test_flags + ['--ncc-gc-stack-maps'],
   suite : 'ncc',
   depends : ncc_exe,
@@ -560,6 +601,11 @@ ncc_error_contains_tests = {
   'err_gc_stack_maps_vla': [
     test_dir / 'err_gc_stack_maps_vla.c',
     'variable-length or incomplete array',
+    '--ncc-gc-stack-maps',
+  ],
+  'err_gc_stack_maps_for_init': [
+    test_dir / 'err_gc_stack_maps_for_init.c',
+    'unsupported statement context',
     '--ncc-gc-stack-maps',
   ],
 }

--- a/meson.build
+++ b/meson.build
@@ -445,6 +445,14 @@ test('ncc_gc_stack_maps_runtime_compile', test_runner,
   depends : ncc_exe,
 )
 
+test('ncc_gc_stack_maps_control_flow', test_runner,
+  args : [ncc_exe, 'compile_run',
+          test_dir / 'test_gc_stack_maps_control_flow.c']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
 test('ncc_verbose_binary_output', test_runner,
   args : [ncc_exe, 'verbose_binary_output', test_dir / 'test_bang.c'],
   env : {'NCC_COMPILER' : test_fake_binary_compiler.full_path()},

--- a/meson.build
+++ b/meson.build
@@ -176,6 +176,7 @@ src_xform = files(
   'src/xform/xform_constexpr.c',
   'src/xform/xform_constexpr_paste.c',
   'src/xform/xform_generic_struct.c',
+  'src/xform/xform_gc_stack_maps.c',
   'src/xform/xform_kargs_vargs.c',
   'src/xform/xform_once.c',
   'src/xform/xform_option.c',
@@ -396,6 +397,13 @@ test('ncc_gc_stack_maps_flag_accepted', test_runner,
   depends : ncc_exe,
 )
 
+test('ncc_gc_stack_maps_root_discovery', test_runner,
+  args : [ncc_exe, 'preprocess', test_dir / 'test_gc_stack_maps_roots.c']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
 test('ncc_verbose_binary_output', test_runner,
   args : [ncc_exe, 'verbose_binary_output', test_dir / 'test_bang.c'],
   env : {'NCC_COMPILER' : test_fake_binary_compiler.full_path()},
@@ -544,12 +552,26 @@ ncc_error_contains_tests = {
     test_dir / 'err_array_literal_unsupported_elem.c',
     'is not supported for static initialization yet',
   ],
+  'err_gc_stack_maps_unnamed_param': [
+    test_dir / 'err_gc_stack_maps_unnamed_param.c',
+    'pointer or aggregate parameter has no name',
+    '--ncc-gc-stack-maps',
+  ],
+  'err_gc_stack_maps_vla': [
+    test_dir / 'err_gc_stack_maps_vla.c',
+    'variable-length or incomplete array',
+    '--ncc-gc-stack-maps',
+  ],
 }
 
 foreach name, params : ncc_error_contains_tests
+  extra_args = []
+  if params.length() > 2
+    extra_args = [params[2]]
+  endif
   test('ncc_' + name, test_runner,
     args : [ncc_exe, 'expect_error_contains', params[0], params[1]]
-           + ncc_test_flags,
+           + ncc_test_flags + extra_args,
     suite : 'ncc',
     depends : ncc_exe,
   )

--- a/meson.build
+++ b/meson.build
@@ -438,6 +438,67 @@ test('ncc_gc_stack_maps_empty_body_param', test_runner,
   depends : ncc_exe,
 )
 
+test('ncc_gc_stack_maps_function_pointer_name', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_function_pointer.c', '& fn']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_qualified_pointer_name', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_qualified_pointer.c', '& state']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_array_sizeof_bounds', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_array_sizeof.c',
+          'sizeof (vecs) / sizeof (void *)']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_computed_goto_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_computed_goto.c',
+          'n00b_gc_stack_push']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_relaxed_for_init_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'err_gc_stack_maps_for_init.c',
+          '& cursor']
+         + ncc_test_flags + ['--ncc-gc-stack-maps-relaxed'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_system_header_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_system_header.c',
+          '.function_name = "__sputc"']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_thread_runtime_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_thread_runtime_skip.c',
+          'n00b_gc_stack_push']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
 test('ncc_gc_stack_maps_runtime_compile', test_runner,
   args : [ncc_exe, 'compile_run', test_dir / 'test_gc_stack_maps_runtime.c']
          + ncc_test_flags + ['--ncc-gc-stack-maps'],
@@ -449,6 +510,13 @@ test('ncc_gc_stack_maps_control_flow', test_runner,
   args : [ncc_exe, 'compile_run',
           test_dir / 'test_gc_stack_maps_control_flow.c']
          + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_force_include_not_replayed', test_runner,
+  args : [ncc_exe, 'compile_run', test_dir / 'test_force_include_once.c']
+         + ncc_test_flags + ['-include', test_dir / 'force_include_once.h'],
   suite : 'ncc',
   depends : ncc_exe,
 )

--- a/meson.build
+++ b/meson.build
@@ -413,10 +413,90 @@ test('ncc_gc_stack_maps_pointer_array_words', test_runner,
   depends : ncc_exe,
 )
 
+test('ncc_gc_stack_maps_aggregate_field_roots', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', '& box.nested.inner']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_aggregate_not_word_range', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', 'sizeof (box)']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_aggregate_array_field_roots', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', 'filters [0].ctx']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_aggregate_array_not_pointer_array', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', 'sizeof (filters)']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_flexible_member_field_root', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', '& flex.known']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_flexible_member_not_sized', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', 'flex.opaque']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_atomic_pointer_field', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', '& holder.store']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_atomic_not_pointee_fields', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', 'holder.store.next']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_atomic_aggregate_offset', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', '__builtin_offsetof']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_atomic_aggregate_not_member_access', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_roots.c', 'atomic_store.next']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
 test('ncc_gc_stack_maps_cleanup_attr', test_runner,
   args : [ncc_exe, 'preprocess_contains',
           test_dir / 'test_gc_stack_maps_roots.c',
-          'cleanup (__ncc_gc_stack_pop_cleanup)']
+          'cleanup (n00b_gc_stack_pop)']
          + ncc_test_flags + ['--ncc-gc-stack-maps'],
   suite : 'ncc',
   depends : ncc_exe,
@@ -485,6 +565,15 @@ test('ncc_gc_stack_maps_system_header_skipped', test_runner,
   args : [ncc_exe, 'preprocess_not_contains',
           test_dir / 'test_gc_stack_maps_system_header.c',
           '.function_name = "__sputc"']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_system_header_user_function_kept', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_stack_maps_system_header.c',
+          '.function_name = "gc_stack_maps_system_header_fixture"']
          + ncc_test_flags + ['--ncc-gc-stack-maps'],
   suite : 'ncc',
   depends : ncc_exe,

--- a/meson.build
+++ b/meson.build
@@ -118,6 +118,13 @@ if mem_debug_enabled
   c_args += ['-DNCC_MEM_DEBUG']
 endif
 
+# Build-time default for n00b GC stack-map emission. The upstream ncc default
+# remains off; n00b can opt its compiler build into stack maps explicitly.
+gc_stack_maps_default = get_option('gc_stack_maps')
+if gc_stack_maps_default
+  c_args += ['-DNCC_GC_STACK_MAPS_DEFAULT']
+endif
+
 # Clang source-based code coverage
 coverage_enabled = get_option('coverage')
 coverage_args = []
@@ -372,6 +379,21 @@ test('ncc_rstr_ansi', test_runner,
          + ncc_test_flags + [libncc.full_path()],
   suite : 'ncc',
   depends : [ncc_exe, libncc],
+)
+
+test('ncc_gc_stack_maps_default_off', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_flag.c', 'n00b_gc_stack_']
+         + ncc_test_flags,
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_flag_accepted', test_runner,
+  args : [ncc_exe, 'preprocess', test_dir / 'test_gc_stack_maps_flag.c']
+         + ncc_test_flags + ['--ncc-gc-stack-maps'],
+  suite : 'ncc',
+  depends : ncc_exe,
 )
 
 test('ncc_verbose_binary_output', test_runner,

--- a/meson.options
+++ b/meson.options
@@ -62,3 +62,7 @@ option('mem_debug',
        type: 'boolean',
        value: false,
        description: 'Enable memory allocation tracking and per-stage reporting')
+option('gc_stack_maps',
+       type: 'boolean',
+       value: false,
+       description: 'Enable n00b GC stack-map emission by default for this ncc binary')

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${NCC_BUILD_DIR:-${ROOT_DIR}/build}"
+
+if [[ -z "${SDKROOT:-}" && "$(uname -s)" == "Darwin" ]] \
+    && command -v xcrun >/dev/null 2>&1; then
+    sdkroot="$(xcrun --show-sdk-path 2>/dev/null || true)"
+    if [[ -n "${sdkroot}" ]]; then
+        export SDKROOT="${sdkroot}"
+    fi
+fi
+
+split_words() {
+    local input="${1:-}"
+    if [[ -z "${input}" ]]; then
+        return
+    fi
+    # shellcheck disable=SC2206
+    local words=(${input})
+    printf '%s\n' "${words[@]}"
+}
+
+setup_args=()
+compile_args=()
+test_args=(--print-errorlogs)
+
+while IFS= read -r arg; do
+    setup_args+=("${arg}")
+done < <(split_words "${NCC_SETUP_ARGS:-}")
+
+while IFS= read -r arg; do
+    compile_args+=("${arg}")
+done < <(split_words "${NCC_COMPILE_ARGS:-}")
+
+while IFS= read -r arg; do
+    test_args+=("${arg}")
+done < <(split_words "${NCC_TEST_ARGS:-}")
+
+if [[ ! -f "${BUILD_DIR}/build.ninja" ]]; then
+    meson setup "${setup_args[@]}" "${BUILD_DIR}" "${ROOT_DIR}"
+elif [[ "${NCC_RECONFIGURE:-0}" != "0" ]]; then
+    meson setup --reconfigure "${setup_args[@]}" "${BUILD_DIR}"
+fi
+
+meson compile -C "${BUILD_DIR}" "${compile_args[@]}"
+
+if [[ "${NCC_TEST:-1}" != "0" ]]; then
+    meson test -C "${BUILD_DIR}" "${test_args[@]}"
+fi

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -61,6 +61,7 @@ extern void ncc_register_typehash_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_once_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_bang_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_rstr_xform(ncc_xform_registry_t *reg);
+extern void ncc_register_gc_stack_maps_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_constexpr_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_constexpr_paste_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_kargs_vargs_xform(ncc_xform_registry_t *reg);
@@ -266,6 +267,19 @@ typedef struct {
 } ncc_opts_t;
 
 #include "xform/xform_data.h"
+
+static void
+free_gc_stack_roots(ncc_gc_stack_root_t *root)
+{
+    while (root) {
+        ncc_gc_stack_root_t *next = root->next;
+        ncc_free(root->function_name);
+        ncc_free(root->name);
+        ncc_free(root->type_text);
+        ncc_free(root);
+        root = next;
+    }
+}
 
 static void
 add_clang_arg(ncc_opts_t *opts, const char *arg)
@@ -1910,6 +1924,7 @@ compile_file(ncc_opts_t *opts)
     ncc_register_once_xform(&xreg);
     ncc_register_bang_xform(&xreg);
     ncc_register_rstr_xform(&xreg);
+    ncc_register_gc_stack_maps_xform(&xreg);
     ncc_register_constexpr_xform(&xreg);
     ncc_register_constexpr_paste_xform(&xreg);
 
@@ -2128,6 +2143,7 @@ compile_file(ncc_opts_t *opts)
     ncc_dict_free(&xdata.option_decls);
     ncc_dict_free(&xdata.generic_struct_decls);
     ncc_dict_free(&xdata.array_types);
+    free_gc_stack_roots(xdata.gc_stack_roots);
     ncc_template_registry_free(&tmpl_reg);
     ncc_xform_registry_free(&xreg);
 

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -277,6 +277,8 @@ free_gc_stack_roots(ncc_gc_stack_root_t *root)
         ncc_free(root->function_name);
         ncc_free(root->name);
         ncc_free(root->type_text);
+        ncc_free(root->address_expr);
+        ncc_free(root->num_words_expr);
         ncc_free(root);
         root = next;
     }
@@ -2140,6 +2142,10 @@ compile_file(ncc_opts_t *opts)
                             ncc_hash_cstring, ncc_dict_cstr_eq);
     ncc_dict_init(&xdata.array_types,
                             ncc_hash_cstring, ncc_dict_cstr_eq);
+    ncc_dict_init(&xdata.gc_aggregate_types,
+                            ncc_hash_cstring, ncc_dict_cstr_eq);
+    ncc_dict_init(&xdata.gc_pointer_typedefs,
+                            ncc_hash_cstring, ncc_dict_cstr_eq);
     xctx.user_data = &xdata;
     ncc_verbose("applying transforms");
     tree = ncc_xform_apply(&xreg, &xctx);
@@ -2156,6 +2162,8 @@ compile_file(ncc_opts_t *opts)
     ncc_dict_free(&xdata.option_decls);
     ncc_dict_free(&xdata.generic_struct_decls);
     ncc_dict_free(&xdata.array_types);
+    ncc_dict_free(&xdata.gc_aggregate_types);
+    ncc_dict_free(&xdata.gc_pointer_typedefs);
     free_gc_stack_roots(xdata.gc_stack_roots);
     ncc_template_registry_free(&tmpl_reg);
     ncc_xform_registry_free(&xreg);

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -232,6 +232,7 @@ typedef struct {
     bool         dump_tree_raw;
     bool         dump_output;
     bool         gc_stack_maps;
+    bool         gc_stack_maps_relaxed;
 
     // Dependency file generation (handled separately from compilation).
     bool         has_dep_flags; // -MD or -MMD present
@@ -491,8 +492,14 @@ parse_argv(ncc_opts_t *opts, int argc, const char **argv)
             opts->gc_stack_maps = true;
             continue;
         }
+        if (strcmp(arg, "--ncc-gc-stack-maps-relaxed") == 0) {
+            opts->gc_stack_maps         = true;
+            opts->gc_stack_maps_relaxed = true;
+            continue;
+        }
         if (strcmp(arg, "--ncc-no-gc-stack-maps") == 0) {
-            opts->gc_stack_maps = false;
+            opts->gc_stack_maps         = false;
+            opts->gc_stack_maps_relaxed = false;
             continue;
         }
         if (strcmp(arg, "--ncc-constexpr-include") == 0) {
@@ -744,6 +751,8 @@ print_help(void)
         "  --ncc-dump-tree-raw  Dump parse tree showing group wrapper nodes\n"
         "  --ncc-dump-output    Dump emitted C to stderr\n"
         "  --ncc-gc-stack-maps  Emit n00b GC stack-map metadata\n"
+        "  --ncc-gc-stack-maps-relaxed\n"
+        "                       Emit n00b GC stack maps, skipping unsupported roots\n"
         "  --ncc-no-gc-stack-maps\n"
         "                       Disable n00b GC stack-map metadata\n"
         "  --ncc-constexpr-include HDRS\n"
@@ -1519,6 +1528,9 @@ pipe_to_compiler(const ncc_opts_t *opts, const char *c_source, size_t c_len)
                 argv[ai++] = opts->clang_args[++i];
             }
         }
+        else if (strcmp(opts->clang_args[i], "-include") == 0) {
+            i++;
+        }
         else if (!is_linker_input(opts->clang_args[i])) {
             argv[ai++] = opts->clang_args[i];
         }
@@ -2118,6 +2130,7 @@ compile_file(ncc_opts_t *opts)
         .array_literal_data_template = array_literal_data_template,
         .array_literal_data_expr     = array_literal_data_expr,
         .gc_stack_maps               = opts->gc_stack_maps,
+        .gc_stack_maps_relaxed       = opts->gc_stack_maps_relaxed,
     };
     ncc_dict_init(&xdata.option_meta,
                             ncc_hash_cstring, ncc_dict_cstr_eq);

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -9,6 +9,7 @@
 //   --ncc-dump-tree        Dump parse tree (pre-transform)
 //   --ncc-dump-tree-raw    Dump parse tree with group wrapper nodes visible
 //   --ncc-dump-output      Dump emitted C to stderr
+//   --ncc-gc-stack-maps    Emit n00b GC stack-map metadata
 //   -E                     Preprocess + transform, emit to stdout
 //   -c                     Compile only (pipe to clang)
 //   -o FILE                Output file
@@ -229,6 +230,7 @@ typedef struct {
     bool         dump_tree;
     bool         dump_tree_raw;
     bool         dump_output;
+    bool         gc_stack_maps;
 
     // Dependency file generation (handled separately from compilation).
     bool         has_dep_flags; // -MD or -MMD present
@@ -389,6 +391,10 @@ parse_argv(ncc_opts_t *opts, int argc, const char **argv)
 
     verbose = env_var_enabled("NCC_VERBOSE");
 
+#ifdef NCC_GC_STACK_MAPS_DEFAULT
+    opts->gc_stack_maps = true;
+#endif
+
     opts->compiler = getenv("NCC_COMPILER");
     if (opts->compiler) {
         ncc_verbose("using NCC_COMPILER=%s", opts->compiler);
@@ -465,6 +471,14 @@ parse_argv(ncc_opts_t *opts, int argc, const char **argv)
         }
         if (strcmp(arg, "--ncc-dump-output") == 0) {
             opts->dump_output = true;
+            continue;
+        }
+        if (strcmp(arg, "--ncc-gc-stack-maps") == 0) {
+            opts->gc_stack_maps = true;
+            continue;
+        }
+        if (strcmp(arg, "--ncc-no-gc-stack-maps") == 0) {
+            opts->gc_stack_maps = false;
             continue;
         }
         if (strcmp(arg, "--ncc-constexpr-include") == 0) {
@@ -680,9 +694,10 @@ parse_argv(ncc_opts_t *opts, int argc, const char **argv)
                                            : opts->has_c ? "compile-only"
                                                          : "compile-and-link",
                 opts->compiler, opts->n_clang_args);
-    ncc_verbose("flags: -E=%d -c=%d std=%d dep=%d dump_tokens=%d dump_tree=%d dump_output=%d",
+    ncc_verbose("flags: -E=%d -c=%d std=%d dep=%d dump_tokens=%d dump_tree=%d dump_output=%d gc_stack_maps=%d",
                 opts->has_E, opts->has_c, opts->has_std, opts->has_dep_flags,
-                opts->dump_tokens, opts->dump_tree, opts->dump_output);
+                opts->dump_tokens, opts->dump_tree, opts->dump_output,
+                opts->gc_stack_maps);
     if (opts->constexpr_headers) {
         ncc_verbose("constexpr headers=%s", opts->constexpr_headers);
     }
@@ -714,6 +729,9 @@ print_help(void)
         "  --ncc-dump-tree      Dump parse tree (pre-transform)\n"
         "  --ncc-dump-tree-raw  Dump parse tree showing group wrapper nodes\n"
         "  --ncc-dump-output    Dump emitted C to stderr\n"
+        "  --ncc-gc-stack-maps  Emit n00b GC stack-map metadata\n"
+        "  --ncc-no-gc-stack-maps\n"
+        "                       Disable n00b GC stack-map metadata\n"
         "  --ncc-constexpr-include HDRS\n"
         "                       Comma-separated headers for constexpr eval\n"
         "                       (e.g. '<myheader.h>,\"local.h\"')\n"
@@ -2084,6 +2102,7 @@ compile_file(ncc_opts_t *opts)
         .rstr_static_ref_expr_plain  = rstr_static_ref_expr_plain,
         .array_literal_data_template = array_literal_data_template,
         .array_literal_data_expr     = array_literal_data_expr,
+        .gc_stack_maps               = opts->gc_stack_maps,
     };
     ncc_dict_init(&xdata.option_meta,
                             ncc_hash_cstring, ncc_dict_cstr_eq);

--- a/src/xform/xform_gc_stack_maps.c
+++ b/src/xform/xform_gc_stack_maps.c
@@ -95,6 +95,167 @@ count_leaf_text(ncc_parse_tree_t *node, const char *text)
     return result;
 }
 
+typedef struct {
+    ncc_parse_tree_t **data;
+    size_t             len;
+    size_t             cap;
+} parse_tree_list_t;
+
+static void
+parse_tree_list_push(parse_tree_list_t *list, ncc_parse_tree_t *node)
+{
+    if (list->len == list->cap) {
+        size_t new_cap = list->cap ? list->cap * 2 : 8;
+        list->data = ncc_realloc(list->data,
+                                  new_cap * sizeof(ncc_parse_tree_t *));
+        list->cap = new_cap;
+    }
+
+    list->data[list->len++] = node;
+}
+
+static void
+collect_nt_children(ncc_parse_tree_t *node, const char *name,
+                    parse_tree_list_t *out)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, name)) {
+        parse_tree_list_push(out, node);
+        return;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        collect_nt_children(ncc_tree_child(node, i), name, out);
+    }
+}
+
+static bool
+child_index(ncc_parse_tree_t *parent, ncc_parse_tree_t *child,
+            size_t *idx_out)
+{
+    if (!parent || !child || ncc_tree_is_leaf(parent)) {
+        return false;
+    }
+
+    size_t nc = ncc_tree_num_children(parent);
+    for (size_t i = 0; i < nc; i++) {
+        if (ncc_tree_child(parent, i) == child) {
+            if (idx_out) {
+                *idx_out = i;
+            }
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static ncc_token_info_t *
+first_leaf_token(ncc_parse_tree_t *node)
+{
+    if (!node) {
+        return nullptr;
+    }
+
+    if (ncc_tree_is_leaf(node)) {
+        return ncc_tree_leaf_value(node);
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_token_info_t *tok = first_leaf_token(ncc_tree_child(node, i));
+        if (tok) {
+            return tok;
+        }
+    }
+
+    return nullptr;
+}
+
+static void
+add_token_trivia(ncc_token_info_t *tok, const char *text, bool leading)
+{
+    if (!tok || !text) {
+        return;
+    }
+
+    ncc_trivia_t *trivia = ncc_alloc(ncc_trivia_t);
+    trivia->text = ncc_string_from_cstr(text);
+
+    if (leading) {
+        trivia->next = tok->leading_trivia;
+        tok->leading_trivia = trivia;
+    }
+    else {
+        trivia->next = tok->trailing_trivia;
+        tok->trailing_trivia = trivia;
+    }
+}
+
+static void
+add_generated_spacing(ncc_parse_tree_t *node, bool leading)
+{
+    if (leading) {
+        add_token_trivia(first_leaf_token(node), "\n", true);
+    }
+
+    add_token_trivia(ncc_xform_find_last_leaf_token(node), "\n", false);
+}
+
+static bool
+is_group_node(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+
+    ncc_nt_node_t pn = ncc_tree_node_value(node);
+    return pn.group_top || pn.group_item
+        || (pn.name.data && pn.name.data[0] == '$' && pn.name.data[1] == '$');
+}
+
+static ncc_parse_tree_t *
+node_parent(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return nullptr;
+    }
+
+    ncc_nt_node_t pn = ncc_tree_node_value(node);
+    return (ncc_parse_tree_t *)pn.parent;
+}
+
+static ncc_parse_tree_t *
+declaration_block_item(ncc_parse_tree_t *node)
+{
+    ncc_parse_tree_t *decl = ncc_xform_find_ancestor(node, "declaration");
+    if (!decl) {
+        return nullptr;
+    }
+
+    ncc_parse_tree_t *cur = decl;
+    for (;;) {
+        ncc_parse_tree_t *parent = node_parent(cur);
+        if (!parent) {
+            return nullptr;
+        }
+
+        if (ncc_xform_nt_name_is(parent, "block_item")) {
+            return parent;
+        }
+
+        if (!is_group_node(parent)) {
+            return nullptr;
+        }
+
+        cur = parent;
+    }
+}
+
 static ncc_parse_tree_t *
 first_descendant_nt(ncc_parse_tree_t *node, const char *name)
 {
@@ -386,6 +547,10 @@ classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
         return;
     }
 
+    if (is_array && ptr_depth == 0 && !aggregate) {
+        return;
+    }
+
     char *name = declarator_name(declarator);
     if (!name) {
         gc_stack_errorf(declarator,
@@ -424,6 +589,15 @@ classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
     else if (aggregate) {
         shape     = NCC_GC_STACK_ROOT_AGGREGATE;
         num_words = 0;
+    }
+
+    if (kind == NCC_GC_STACK_ROOT_LOCAL
+        && !declaration_block_item(declarator)) {
+        gc_stack_errorf(declarator,
+                        "GC stack-map root '%s' in function '%s' is declared "
+                        "in an unsupported statement context; declare the root "
+                        "as a block item before the statement",
+                        name, function);
     }
 
     record_root(ctx, function, name, decl_specs, kind, shape, num_words,
@@ -538,6 +712,12 @@ xform_gc_stack_function(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *fn)
     }
 
     char *fname = function_name(declarator);
+    if (strncmp(fname, "n00b_gc_stack_", 14) == 0
+        || strncmp(fname, "__ncc_gc_stack_", 16) == 0) {
+        ncc_free(fname);
+        return nullptr;
+    }
+
     ncc_parse_tree_t *params = first_descendant_nt(declarator,
                                                    "parameter_type_list");
     if (params) {
@@ -549,9 +729,401 @@ xform_gc_stack_function(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *fn)
     return nullptr;
 }
 
+typedef enum {
+    GC_FRAME_GROUP_PARAMS,
+    GC_FRAME_GROUP_LOCAL,
+} gc_frame_group_kind_t;
+
+typedef struct {
+    gc_frame_group_kind_t kind;
+    ncc_parse_tree_t     *anchor;
+    ncc_parse_tree_t     *scope;
+    int                   id;
+} gc_frame_group_t;
+
+typedef struct {
+    gc_frame_group_t *data;
+    size_t            len;
+    size_t            cap;
+} gc_frame_group_list_t;
+
+static void
+gc_frame_group_list_push(gc_frame_group_list_t *list, gc_frame_group_t group)
+{
+    if (list->len == list->cap) {
+        size_t new_cap = list->cap ? list->cap * 2 : 8;
+        list->data = ncc_realloc(list->data,
+                                  new_cap * sizeof(gc_frame_group_t));
+        list->cap = new_cap;
+    }
+
+    list->data[list->len++] = group;
+}
+
+static ncc_parse_tree_t *
+root_group_anchor(ncc_gc_stack_root_t *root, gc_frame_group_kind_t *kind)
+{
+    if (root->kind == NCC_GC_STACK_ROOT_PARAM) {
+        *kind = GC_FRAME_GROUP_PARAMS;
+        return root->scope;
+    }
+
+    *kind = GC_FRAME_GROUP_LOCAL;
+    return declaration_block_item(root->declaration);
+}
+
+static bool
+group_matches_root(gc_frame_group_t *group, ncc_gc_stack_root_t *root)
+{
+    gc_frame_group_kind_t kind   = GC_FRAME_GROUP_LOCAL;
+    ncc_parse_tree_t     *anchor = root_group_anchor(root, &kind);
+
+    return group->kind == kind && group->anchor == anchor;
+}
+
+static void
+ensure_group_for_root(ncc_xform_ctx_t *ctx, gc_frame_group_list_t *groups,
+                      ncc_gc_stack_root_t *root)
+{
+    gc_frame_group_kind_t kind   = GC_FRAME_GROUP_LOCAL;
+    ncc_parse_tree_t     *anchor = root_group_anchor(root, &kind);
+
+    if (!anchor) {
+        gc_stack_errorf(root->declaration,
+                        "GC stack-map root '%s' in function '%s' has no "
+                        "supported insertion point",
+                        root->name, root->function_name);
+    }
+
+    for (size_t i = 0; i < groups->len; i++) {
+        if (groups->data[i].kind == kind && groups->data[i].anchor == anchor) {
+            return;
+        }
+    }
+
+    gc_frame_group_list_push(groups, (gc_frame_group_t){
+        .kind   = kind,
+        .anchor = anchor,
+        .scope  = root->scope,
+        .id     = ctx->unique_id++,
+    });
+}
+
+static size_t
+count_group_roots(gc_frame_group_t *group, ncc_gc_stack_root_t *roots)
+{
+    size_t count = 0;
+
+    for (ncc_gc_stack_root_t *root = roots; root; root = root->next) {
+        if (group_matches_root(group, root)) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+static char *
+c_string_literal(const char *text)
+{
+    ncc_buffer_t *buf = ncc_buffer_empty();
+    ncc_buffer_putc(buf, '"');
+
+    for (const unsigned char *p = (const unsigned char *)text; p && *p; p++) {
+        switch (*p) {
+        case '\\':
+            ncc_buffer_puts(buf, "\\\\");
+            break;
+        case '"':
+            ncc_buffer_puts(buf, "\\\"");
+            break;
+        case '\n':
+            ncc_buffer_puts(buf, "\\n");
+            break;
+        case '\r':
+            ncc_buffer_puts(buf, "\\r");
+            break;
+        case '\t':
+            ncc_buffer_puts(buf, "\\t");
+            break;
+        default:
+            if (*p < 0x20 || *p == 0x7f) {
+                ncc_buffer_printf(buf, "\\x%02x", (unsigned)*p);
+            }
+            else {
+                ncc_buffer_putc(buf, (char)*p);
+            }
+            break;
+        }
+    }
+
+    ncc_buffer_putc(buf, '"');
+    return ncc_buffer_take(buf);
+}
+
+static void
+append_slot_num_words(ncc_buffer_t *buf, ncc_gc_stack_root_t *root)
+{
+    if (root->shape == NCC_GC_STACK_ROOT_AGGREGATE) {
+        ncc_buffer_printf(buf,
+                          "((sizeof(%s)+sizeof(void *)-1)/sizeof(void *))",
+                          root->name);
+        return;
+    }
+
+    ncc_buffer_printf(buf, "%llu", (unsigned long long)root->num_words);
+}
+
+static char *
+build_frame_source(gc_frame_group_t *group, ncc_gc_stack_root_t *roots)
+{
+    size_t        count    = count_group_roots(group, roots);
+    ncc_buffer_t *buf      = ncc_buffer_empty();
+    const char   *function = "<unknown>";
+    uint32_t      line     = 0;
+
+    for (ncc_gc_stack_root_t *root = roots; root; root = root->next) {
+        if (group_matches_root(group, root)) {
+            function = root->function_name;
+            line     = root->line;
+            break;
+        }
+    }
+
+    char *function_lit = c_string_literal(function);
+
+    ncc_buffer_printf(buf,
+                      "static const n00b_gc_stack_slot_t "
+                      "__ncc_gc_slots_%d[] = {",
+                      group->id);
+
+    size_t root_index = 0;
+    for (ncc_gc_stack_root_t *root = roots; root; root = root->next) {
+        if (!group_matches_root(group, root)) {
+            continue;
+        }
+
+        ncc_buffer_printf(buf, "{.root_index=%zu,.num_words=", root_index);
+        append_slot_num_words(buf, root);
+        ncc_buffer_puts(buf, "},");
+        root_index++;
+    }
+
+    ncc_buffer_puts(buf, "};");
+    ncc_buffer_printf(buf,
+                      "static const n00b_gc_stack_map_t __ncc_gc_map_%d="
+                      "{.num_roots=%zu,.num_slots=%zu,"
+                      ".slots=__ncc_gc_slots_%d,"
+                      ".function_name=%s,.file_name=__FILE__,.line=%u};",
+                      group->id, count, count, group->id, function_lit, line);
+    ncc_buffer_printf(buf, "void *__ncc_gc_roots_%d[]={", group->id);
+
+    for (ncc_gc_stack_root_t *root = roots; root; root = root->next) {
+        if (!group_matches_root(group, root)) {
+            continue;
+        }
+
+        ncc_buffer_printf(buf, "(void *)&%s,", root->name);
+    }
+
+    ncc_buffer_puts(buf, "};");
+    ncc_buffer_printf(buf,
+                      "n00b_gc_stack_frame_t __ncc_gc_frame_%d "
+                      "__attribute__((cleanup(__ncc_gc_stack_pop_cleanup)));",
+                      group->id);
+    ncc_buffer_printf(buf,
+                      "n00b_gc_stack_push(&__ncc_gc_frame_%d,"
+                      "&__ncc_gc_map_%d,__ncc_gc_roots_%d);",
+                      group->id, group->id, group->id);
+
+    ncc_free(function_lit);
+    return ncc_buffer_take(buf);
+}
+
+static parse_tree_list_t
+parse_generated_block_items(ncc_xform_ctx_t *ctx, const char *src)
+{
+    parse_tree_list_t result = {0};
+    ncc_parse_tree_t *tree = ncc_xform_parse_source(ctx->grammar,
+                                                    "block_item_list", src,
+                                                    "xform_gc_stack_maps");
+    if (!tree) {
+        fprintf(stderr,
+                "ncc: error: failed to parse generated GC stack-map block:\n"
+                "%s\n",
+                src);
+        exit(1);
+    }
+
+    collect_nt_children(tree, "block_item", &result);
+    if (result.len == 0 && ncc_xform_nt_name_is(tree, "block_item")) {
+        parse_tree_list_push(&result, tree);
+    }
+
+    for (size_t i = 0; i < result.len; i++) {
+        add_generated_spacing(result.data[i], i == 0);
+    }
+
+    return result;
+}
+
+static void
+insert_block_items_at(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *compound,
+                      size_t index,
+                      parse_tree_list_t *items)
+{
+    ncc_parse_tree_t *bil = ncc_xform_find_child_nt(compound,
+                                                    "block_item_list");
+
+    if (!bil) {
+        ncc_parse_tree_t **children = ncc_alloc_size(
+            items->len, sizeof(ncc_parse_tree_t *));
+        for (size_t i = 0; i < items->len; i++) {
+            children[i] = items->data[i];
+        }
+
+        bil = ncc_xform_make_node_with_children(ctx->grammar,
+                                                "block_item_list", 0,
+                                                children, items->len);
+        ncc_free(children);
+
+        size_t nc = ncc_tree_num_children(compound);
+        ncc_xform_insert_child(compound, nc > 0 ? nc - 1 : 0, bil);
+        return;
+    }
+
+    for (size_t i = 0; i < items->len; i++) {
+        ncc_xform_insert_child(bil, index + i, items->data[i]);
+    }
+}
+
+static void
+insert_frame_group(ncc_xform_ctx_t *ctx, gc_frame_group_t *group,
+                   ncc_gc_stack_root_t *roots)
+{
+    char *src = build_frame_source(group, roots);
+    parse_tree_list_t items = parse_generated_block_items(ctx, src);
+    ncc_free(src);
+
+    if (group->kind == GC_FRAME_GROUP_PARAMS) {
+        insert_block_items_at(ctx, group->anchor, 0, &items);
+        ncc_free(items.data);
+        return;
+    }
+
+    ncc_nt_node_t    pn        = ncc_tree_node_value(group->anchor);
+    ncc_parse_tree_t *container = (ncc_parse_tree_t *)pn.parent;
+    size_t            anchor_ix = 0;
+
+    if (!container || !child_index(container, group->anchor, &anchor_ix)) {
+        gc_stack_errorf(group->anchor,
+                        "GC stack-map frame insertion failed: local root "
+                        "declaration is not in a block item list");
+    }
+
+    for (size_t i = 0; i < items.len; i++) {
+        ncc_xform_insert_child(container, anchor_ix + 1 + i, items.data[i]);
+    }
+
+    ncc_free(items.data);
+}
+
+static void
+insert_helper_before_first_rooted_function(ncc_xform_ctx_t *ctx,
+                                           ncc_gc_stack_root_t *roots)
+{
+    ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+    if (data->gc_stack_maps_helper_inserted) {
+        return;
+    }
+
+    ncc_parse_tree_t *best_container = nullptr;
+    ncc_parse_tree_t *best_ext       = nullptr;
+    size_t            best_ix        = 0;
+    int32_t           best_start     = 0;
+
+    for (ncc_gc_stack_root_t *root = roots; root; root = root->next) {
+        ncc_parse_tree_t *ext = ncc_xform_find_ancestor(root->scope,
+                                                        "external_declaration");
+        if (!ext) {
+            continue;
+        }
+
+        ncc_nt_node_t    epn       = ncc_tree_node_value(ext);
+        ncc_parse_tree_t *container = epn.parent
+                                          ? (ncc_parse_tree_t *)epn.parent
+                                          : ctx->root;
+        size_t ix = 0;
+        if (!child_index(container, ext, &ix)) {
+            continue;
+        }
+
+        if (!best_ext || epn.start < best_start) {
+            best_container = container;
+            best_ext       = ext;
+            best_ix        = ix;
+            best_start     = epn.start;
+        }
+    }
+
+    if (!best_ext || !best_container) {
+        gc_stack_errorf(ctx->root,
+                        "GC stack-map helper insertion failed: no rooted "
+                        "function was found in the translation unit");
+    }
+
+    const char *src =
+        "static inline void "
+        "__ncc_gc_stack_pop_cleanup(n00b_gc_stack_frame_t *frame)"
+        "{n00b_gc_stack_pop(frame);}";
+    ncc_parse_tree_t *helper = ncc_xform_parse_source(ctx->grammar,
+                                                      "external_declaration",
+                                                      src,
+                                                      "xform_gc_stack_maps");
+    if (!helper) {
+        fprintf(stderr,
+                "ncc: error: failed to parse generated GC stack-map helper:\n"
+                "%s\n",
+                src);
+        exit(1);
+    }
+
+    add_generated_spacing(helper, true);
+    ncc_xform_insert_child(best_container, best_ix, helper);
+    data->gc_stack_maps_helper_inserted = true;
+}
+
+static ncc_parse_tree_t *
+xform_gc_stack_translation_unit(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu)
+{
+    ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+    if (!data || !data->gc_stack_maps || !data->gc_stack_roots) {
+        return nullptr;
+    }
+
+    insert_helper_before_first_rooted_function(ctx, data->gc_stack_roots);
+
+    gc_frame_group_list_t groups = {0};
+    for (ncc_gc_stack_root_t *root = data->gc_stack_roots; root;
+         root = root->next) {
+        ensure_group_for_root(ctx, &groups, root);
+    }
+
+    for (size_t i = 0; i < groups.len; i++) {
+        insert_frame_group(ctx, &groups.data[i], data->gc_stack_roots);
+    }
+
+    ncc_free(groups.data);
+    (void)tu;
+    return nullptr;
+}
+
 void
 ncc_register_gc_stack_maps_xform(ncc_xform_registry_t *reg)
 {
     ncc_xform_register(reg, "function_definition", xform_gc_stack_function,
                        "gc_stack_maps");
+    ncc_xform_register(reg, "translation_unit",
+                       xform_gc_stack_translation_unit,
+                       "gc_stack_maps_emit");
 }

--- a/src/xform/xform_gc_stack_maps.c
+++ b/src/xform/xform_gc_stack_maps.c
@@ -1,0 +1,557 @@
+// xform_gc_stack_maps.c -- Discover n00b GC stack roots for later emission.
+
+#include "lib/alloc.h"
+#include "lib/buffer.h"
+#include "xform/xform_data.h"
+#include "xform/xform_helpers.h"
+
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static char *
+copy_cstr(const char *s)
+{
+    size_t len = s ? strlen(s) : 0;
+    char  *r   = ncc_alloc_size(1, len + 1);
+    if (len > 0) {
+        memcpy(r, s, len);
+    }
+    r[len] = '\0';
+    return r;
+}
+
+static char *
+trim_copy(const char *s)
+{
+    if (!s) {
+        return copy_cstr("");
+    }
+
+    while (isspace((unsigned char)*s)) {
+        s++;
+    }
+
+    size_t len = strlen(s);
+    while (len > 0 && isspace((unsigned char)s[len - 1])) {
+        len--;
+    }
+
+    char *result = ncc_alloc_size(1, len + 1);
+    memcpy(result, s, len);
+    result[len] = '\0';
+    return result;
+}
+
+static char *
+node_text(ncc_parse_tree_t *node)
+{
+    ncc_string_t s = ncc_xform_node_to_text(node);
+    char        *r = trim_copy(s.data);
+    ncc_free(s.data);
+    return r;
+}
+
+static bool
+contains_leaf_text(ncc_parse_tree_t *node, const char *text)
+{
+    if (!node) {
+        return false;
+    }
+
+    if (ncc_tree_is_leaf(node)) {
+        return ncc_xform_leaf_text_eq(node, text);
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (contains_leaf_text(ncc_tree_child(node, i), text)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static int
+count_leaf_text(ncc_parse_tree_t *node, const char *text)
+{
+    if (!node) {
+        return 0;
+    }
+
+    if (ncc_tree_is_leaf(node)) {
+        return ncc_xform_leaf_text_eq(node, text) ? 1 : 0;
+    }
+
+    int    result = 0;
+    size_t nc     = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        result += count_leaf_text(ncc_tree_child(node, i), text);
+    }
+
+    return result;
+}
+
+static ncc_parse_tree_t *
+first_descendant_nt(ncc_parse_tree_t *node, const char *name)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return nullptr;
+    }
+
+    if (ncc_xform_nt_name_is(node, name)) {
+        return node;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *found = first_descendant_nt(ncc_tree_child(node, i),
+                                                      name);
+        if (found) {
+            return found;
+        }
+    }
+
+    return nullptr;
+}
+
+static char *
+declarator_name(ncc_parse_tree_t *node)
+{
+    if (!node) {
+        return nullptr;
+    }
+
+    if (ncc_tree_is_leaf(node)) {
+        const char *text = ncc_xform_leaf_text(node);
+        if (text && (isalpha((unsigned char)text[0]) || text[0] == '_')) {
+            return copy_cstr(text);
+        }
+        return nullptr;
+    }
+
+    char  *last = nullptr;
+    size_t nc   = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        char *candidate = declarator_name(ncc_tree_child(node, i));
+        if (candidate) {
+            ncc_free(last);
+            last = candidate;
+        }
+    }
+    return last;
+}
+
+static bool
+is_ident_start_char(char c)
+{
+    return isalpha((unsigned char)c) || c == '_';
+}
+
+static bool
+is_ident_char(char c)
+{
+    return isalnum((unsigned char)c) || c == '_';
+}
+
+static char *
+copy_last_identifier_before(const char *text, size_t end)
+{
+    size_t i = end;
+
+    while (i > 0) {
+        while (i > 0 && !is_ident_char(text[i - 1])) {
+            i--;
+        }
+        size_t ident_end = i;
+        while (i > 0 && is_ident_char(text[i - 1])) {
+            i--;
+        }
+        if (ident_end > i && is_ident_start_char(text[i])) {
+            size_t len  = ident_end - i;
+            char  *name = ncc_alloc_size(1, len + 1);
+            memcpy(name, text + i, len);
+            name[len] = '\0';
+            return name;
+        }
+    }
+
+    return nullptr;
+}
+
+static size_t
+find_last_top_level_param_open(const char *text)
+{
+    int    depth = 0;
+    size_t last  = (size_t)-1;
+
+    for (size_t i = 0; text[i]; i++) {
+        if (text[i] == '(') {
+            if (depth == 0) {
+                last = i;
+            }
+            depth++;
+        }
+        else if (text[i] == ')' && depth > 0) {
+            depth--;
+        }
+    }
+
+    return last;
+}
+
+static char *
+function_name(ncc_parse_tree_t *declarator)
+{
+    char *text = node_text(declarator);
+    if (!text) {
+        return copy_cstr("<unknown>");
+    }
+
+    size_t param_open = find_last_top_level_param_open(text);
+    size_t name_end   = param_open == (size_t)-1 ? strlen(text) : param_open;
+    char  *name       = copy_last_identifier_before(text, name_end);
+
+    ncc_free(text);
+    return name ? name : copy_cstr("<unknown>");
+}
+
+static void
+gc_stack_errorf(ncc_parse_tree_t *node, const char *fmt, ...)
+{
+    uint32_t line = 0;
+    uint32_t col  = 0;
+    ncc_xform_first_leaf_pos(node, &line, &col);
+
+    fprintf(stderr, "ncc: error: ");
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fprintf(stderr, " (line %u, col %u)\n", line, col);
+    exit(1);
+}
+
+static bool
+decl_is_stack_storage(ncc_parse_tree_t *decl_specs)
+{
+    return !contains_leaf_text(decl_specs, "static")
+        && !contains_leaf_text(decl_specs, "extern")
+        && !contains_leaf_text(decl_specs, "typedef");
+}
+
+static bool
+decl_specs_are_aggregate(ncc_parse_tree_t *decl_specs)
+{
+    return first_descendant_nt(decl_specs, "struct_or_union_specifier")
+        != nullptr;
+}
+
+static bool
+parse_positive_integer_literal(const char *text, uint64_t *out)
+{
+    char *trimmed = trim_copy(text);
+    if (!trimmed[0]) {
+        ncc_free(trimmed);
+        return false;
+    }
+
+    for (char *p = trimmed; *p; p++) {
+        if (!isdigit((unsigned char)*p)) {
+            ncc_free(trimmed);
+            return false;
+        }
+    }
+
+    char    *end = nullptr;
+    uint64_t val = strtoull(trimmed, &end, 10);
+    bool     ok  = end && *end == '\0' && val > 0;
+    ncc_free(trimmed);
+
+    if (ok) {
+        *out = val;
+    }
+    return ok;
+}
+
+static bool
+array_bound_product(ncc_parse_tree_t *node, uint64_t *product,
+                    ncc_parse_tree_t **bad_array)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return true;
+    }
+
+    if (ncc_xform_nt_name_is(node, "array_declarator")) {
+        ncc_parse_tree_t *bound = ncc_xform_find_child_nt(
+            node, "assignment_expression");
+        uint64_t count = 0;
+
+        if (!bound) {
+            *bad_array = node;
+            return false;
+        }
+
+        char *text = node_text(bound);
+        bool  ok   = parse_positive_integer_literal(text, &count);
+        ncc_free(text);
+
+        if (!ok) {
+            *bad_array = node;
+            return false;
+        }
+
+        *product *= count;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (!array_bound_product(ncc_tree_child(node, i), product,
+                                 bad_array)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool
+has_parenthesized_pointer_array(ncc_parse_tree_t *declarator)
+{
+    char *text = node_text(declarator);
+    bool  result = strstr(text, "(*") != nullptr || strstr(text, "( *")
+                                                     != nullptr;
+    ncc_free(text);
+    return result;
+}
+
+static ncc_gc_stack_root_t *
+record_root(ncc_xform_ctx_t *ctx, const char *function, const char *name,
+            ncc_parse_tree_t *type_node, ncc_gc_stack_root_kind_t kind,
+            ncc_gc_stack_root_shape_t shape, uint64_t num_words,
+            ncc_parse_tree_t *scope, ncc_parse_tree_t *decl_node)
+{
+    ncc_xform_data_t    *data = ncc_xform_get_data(ctx);
+    ncc_gc_stack_root_t *root = ncc_alloc(ncc_gc_stack_root_t);
+
+    uint32_t line = 0;
+    uint32_t col  = 0;
+    ncc_xform_first_leaf_pos(decl_node, &line, &col);
+
+    *root = (ncc_gc_stack_root_t){
+        .function_name = copy_cstr(function),
+        .name          = copy_cstr(name),
+        .type_text     = node_text(type_node),
+        .kind          = kind,
+        .shape         = shape,
+        .num_words     = num_words,
+        .line          = line,
+        .col           = col,
+        .scope         = scope,
+        .declaration   = decl_node,
+        .next          = data->gc_stack_roots,
+    };
+
+    data->gc_stack_roots = root;
+    data->gc_stack_root_count++;
+    return root;
+}
+
+static void
+classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
+                    ncc_parse_tree_t *decl_specs,
+                    ncc_parse_tree_t *declarator,
+                    ncc_gc_stack_root_kind_t kind, ncc_parse_tree_t *scope,
+                    ncc_parse_tree_t *decl_node)
+{
+    if (!decl_specs || !declarator) {
+        return;
+    }
+
+    int  ptr_depth = count_leaf_text(declarator, "*")
+                   + count_leaf_text(declarator, "^");
+    bool is_array  = first_descendant_nt(declarator, "array_declarator")
+                  != nullptr;
+    bool aggregate = decl_specs_are_aggregate(decl_specs);
+
+    if (kind == NCC_GC_STACK_ROOT_PARAM && is_array) {
+        ptr_depth = ptr_depth > 0 ? ptr_depth : 1;
+        is_array  = false;
+    }
+
+    if (ptr_depth == 0 && !is_array && !aggregate) {
+        return;
+    }
+
+    char *name = declarator_name(declarator);
+    if (!name) {
+        gc_stack_errorf(declarator,
+                        "GC stack-map root in function '%s' is unsupported: "
+                        "pointer or aggregate parameter has no name",
+                        function);
+    }
+
+    ncc_gc_stack_root_shape_t shape     = NCC_GC_STACK_ROOT_POINTER;
+    uint64_t                  num_words = 1;
+
+    if (is_array) {
+        if (ptr_depth > 0 && has_parenthesized_pointer_array(declarator)) {
+            gc_stack_errorf(declarator,
+                            "GC stack-map root '%s' in function '%s' uses a "
+                            "parenthesized pointer/array declarator; spell the "
+                            "root as a direct fixed-size pointer array or a "
+                            "single pointer",
+                            name, function);
+        }
+
+        ncc_parse_tree_t *bad_array = nullptr;
+        uint64_t          product   = 1;
+        if (!array_bound_product(declarator, &product, &bad_array)) {
+            gc_stack_errorf(bad_array ? bad_array : declarator,
+                            "GC stack-map root '%s' in function '%s' uses a "
+                            "variable-length or incomplete array; only "
+                            "fixed-size stack roots are supported",
+                            name, function);
+        }
+
+        num_words = product;
+        shape     = ptr_depth > 0 ? NCC_GC_STACK_ROOT_POINTER_ARRAY
+                                  : NCC_GC_STACK_ROOT_AGGREGATE;
+    }
+    else if (aggregate) {
+        shape     = NCC_GC_STACK_ROOT_AGGREGATE;
+        num_words = 0;
+    }
+
+    record_root(ctx, function, name, decl_specs, kind, shape, num_words,
+                scope, decl_node);
+    ncc_free(name);
+}
+
+static void
+scan_parameter_node(ncc_xform_ctx_t *ctx, const char *function,
+                    ncc_parse_tree_t *scope, ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "parameter_declaration")) {
+        ncc_parse_tree_t *decl_specs = ncc_xform_find_child_nt(
+            node, "declaration_specifiers");
+        ncc_parse_tree_t *declarator = ncc_xform_find_child_nt(
+            node, "declarator");
+        if (!declarator) {
+            declarator = ncc_xform_find_child_nt(node,
+                                                 "abstract_declarator");
+        }
+
+        classify_declarator(ctx, function, decl_specs, declarator,
+                            NCC_GC_STACK_ROOT_PARAM, scope, node);
+        return;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        scan_parameter_node(ctx, function, scope, ncc_tree_child(node, i));
+    }
+}
+
+static void
+scan_init_declarators(ncc_xform_ctx_t *ctx, const char *function,
+                      ncc_parse_tree_t *decl_specs, ncc_parse_tree_t *scope,
+                      ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "init_declarator")) {
+        ncc_parse_tree_t *declarator = ncc_xform_find_child_nt(
+            node, "declarator");
+        classify_declarator(ctx, function, decl_specs, declarator,
+                            NCC_GC_STACK_ROOT_LOCAL, scope, node);
+        return;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        scan_init_declarators(ctx, function, decl_specs, scope,
+                              ncc_tree_child(node, i));
+    }
+}
+
+static void
+scan_declaration(ncc_xform_ctx_t *ctx, const char *function,
+                 ncc_parse_tree_t *decl)
+{
+    ncc_parse_tree_t *decl_specs = ncc_xform_find_child_nt(
+        decl, "declaration_specifiers");
+    ncc_parse_tree_t *list = ncc_xform_find_child_nt(decl,
+                                                     "init_declarator_list");
+    if (!decl_specs || !list || !decl_is_stack_storage(decl_specs)) {
+        return;
+    }
+
+    ncc_parse_tree_t *scope = ncc_xform_find_ancestor(decl,
+                                                      "compound_statement");
+    scan_init_declarators(ctx, function, decl_specs, scope, list);
+}
+
+static void
+scan_compound(ncc_xform_ctx_t *ctx, const char *function,
+              ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "declaration")) {
+        scan_declaration(ctx, function, node);
+        return;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        scan_compound(ctx, function, ncc_tree_child(node, i));
+    }
+}
+
+static ncc_parse_tree_t *
+xform_gc_stack_function(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *fn)
+{
+    ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+    if (!data || !data->gc_stack_maps) {
+        return nullptr;
+    }
+
+    ncc_parse_tree_t *declarator = ncc_xform_find_child_nt(fn, "declarator");
+    ncc_parse_tree_t *body       = ncc_xform_find_child_nt(fn,
+                                                           "function_body");
+    ncc_parse_tree_t *compound   = ncc_xform_find_child_nt(body,
+                                                           "compound_statement");
+    if (!declarator || !compound) {
+        return nullptr;
+    }
+
+    char *fname = function_name(declarator);
+    ncc_parse_tree_t *params = first_descendant_nt(declarator,
+                                                   "parameter_type_list");
+    if (params) {
+        scan_parameter_node(ctx, fname, compound, params);
+    }
+
+    scan_compound(ctx, fname, compound);
+    ncc_free(fname);
+    return nullptr;
+}
+
+void
+ncc_register_gc_stack_maps_xform(ncc_xform_registry_t *reg)
+{
+    ncc_xform_register(reg, "function_definition", xform_gc_stack_function,
+                       "gc_stack_maps");
+}

--- a/src/xform/xform_gc_stack_maps.c
+++ b/src/xform/xform_gc_stack_maps.c
@@ -7,6 +7,7 @@
 
 #include <ctype.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,6 +47,27 @@ trim_copy(const char *s)
 }
 
 static char *
+format_cstr(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    va_list ap2;
+    va_copy(ap2, ap);
+    int needed = vsnprintf(nullptr, 0, fmt, ap2);
+    va_end(ap2);
+
+    if (needed < 0) {
+        va_end(ap);
+        return copy_cstr("");
+    }
+
+    char *result = ncc_alloc_size(1, (size_t)needed + 1);
+    vsnprintf(result, (size_t)needed + 1, fmt, ap);
+    va_end(ap);
+    return result;
+}
+
+static char *
 node_text(ncc_parse_tree_t *node)
 {
     ncc_string_t s = ncc_xform_node_to_text(node);
@@ -75,11 +97,31 @@ contains_leaf_text(ncc_parse_tree_t *node, const char *text)
     return false;
 }
 
+static bool
+cstr_has_prefix(const char *s, const char *prefix)
+{
+    return s && prefix && strncmp(s, prefix, strlen(prefix)) == 0;
+}
+
 typedef struct {
     ncc_parse_tree_t **data;
     size_t             len;
     size_t             cap;
 } parse_tree_list_t;
+
+typedef struct {
+    uint64_t *data;
+    size_t    len;
+    size_t    cap;
+} uint64_list_t;
+
+typedef struct {
+    char             *key;
+    ncc_parse_tree_t *specifier;
+    char             *offset_type;
+    bool              is_atomic;
+    bool              is_union;
+} aggregate_type_info_t;
 
 static void
 parse_tree_list_push(parse_tree_list_t *list, ncc_parse_tree_t *node)
@@ -92,6 +134,18 @@ parse_tree_list_push(parse_tree_list_t *list, ncc_parse_tree_t *node)
     }
 
     list->data[list->len++] = node;
+}
+
+static void
+uint64_list_push(uint64_list_t *list, uint64_t value)
+{
+    if (list->len == list->cap) {
+        size_t new_cap = list->cap ? list->cap * 2 : 4;
+        list->data = ncc_realloc(list->data, new_cap * sizeof(uint64_t));
+        list->cap = new_cap;
+    }
+
+    list->data[list->len++] = value;
 }
 
 static void
@@ -187,28 +241,6 @@ node_starts_in_system_header(ncc_parse_tree_t *node)
 {
     ncc_token_info_t *tok = first_leaf_token(node);
     return tok && (tok->system_header || token_file_looks_system_header(tok));
-}
-
-static bool
-node_has_system_header_token(ncc_parse_tree_t *node)
-{
-    if (!node) {
-        return false;
-    }
-
-    if (ncc_tree_is_leaf(node)) {
-        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
-        return tok && (tok->system_header || token_file_looks_system_header(tok));
-    }
-
-    size_t nc = ncc_tree_num_children(node);
-    for (size_t i = 0; i < nc; i++) {
-        if (node_has_system_header_token(ncc_tree_child(node, i))) {
-            return true;
-        }
-    }
-
-    return false;
 }
 
 static bool
@@ -565,7 +597,7 @@ block_has_case_label_item(ncc_parse_tree_t *anchor)
 }
 
 static int
-pointer_depth_in_declarator(ncc_parse_tree_t *node)
+pointer_depth_in_type_node(ncc_parse_tree_t *node)
 {
     if (!node || ncc_tree_is_leaf(node)) {
         return 0;
@@ -584,7 +616,38 @@ pointer_depth_in_declarator(ncc_parse_tree_t *node)
 
     size_t nc = ncc_tree_num_children(node);
     for (size_t i = 0; i < nc; i++) {
-        count += pointer_depth_in_declarator(ncc_tree_child(node, i));
+        count += pointer_depth_in_type_node(ncc_tree_child(node, i));
+    }
+
+    return count;
+}
+
+static int
+pointer_depth_in_declarator(ncc_parse_tree_t *node)
+{
+    return pointer_depth_in_type_node(node);
+}
+
+static int
+pointer_depth_in_decl_specs(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return 0;
+    }
+
+    if (ncc_xform_nt_name_is(node, "member_declaration_list")) {
+        return 0;
+    }
+
+    int count = 0;
+    if (ncc_xform_nt_name_is(node, "pointer")) {
+        count += node_direct_child_leaf_text(node, "*") ? 1 : 0;
+        count += node_direct_child_leaf_text(node, "^") ? 1 : 0;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        count += pointer_depth_in_decl_specs(ncc_tree_child(node, i));
     }
 
     return count;
@@ -714,7 +777,7 @@ function_name(ncc_parse_tree_t *declarator)
     return name ? name : copy_cstr("<unknown>");
 }
 
-static void
+[[noreturn]] static void
 gc_stack_errorf(ncc_parse_tree_t *node, const char *fmt, ...)
 {
     uint32_t line = 0;
@@ -736,13 +799,6 @@ decl_is_stack_storage(ncc_parse_tree_t *decl_specs)
     return !contains_leaf_text(decl_specs, "static")
         && !contains_leaf_text(decl_specs, "extern")
         && !contains_leaf_text(decl_specs, "typedef");
-}
-
-static bool
-decl_specs_are_aggregate(ncc_parse_tree_t *decl_specs)
-{
-    return first_descendant_nt(decl_specs, "struct_or_union_specifier")
-        != nullptr;
 }
 
 static bool
@@ -844,6 +900,28 @@ array_bound_product(ncc_parse_tree_t *node, uint64_t *product,
 }
 
 static bool
+has_unbounded_array_declarator(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+
+    if (ncc_xform_nt_name_is(node, "array_declarator")
+        && ncc_xform_find_child_nt(node, "assignment_expression") == nullptr) {
+        return true;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (has_unbounded_array_declarator(ncc_tree_child(node, i))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool
 has_parenthesized_pointer_array(ncc_parse_tree_t *declarator)
 {
     char *text = node_text(declarator);
@@ -853,10 +931,611 @@ has_parenthesized_pointer_array(ncc_parse_tree_t *declarator)
     return result;
 }
 
+static ncc_dict_t *
+gc_aggregate_types(ncc_xform_ctx_t *ctx)
+{
+    ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+    return data ? &data->gc_aggregate_types : nullptr;
+}
+
+static ncc_dict_t *
+gc_pointer_typedefs(ncc_xform_ctx_t *ctx)
+{
+    ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+    return data ? &data->gc_pointer_typedefs : nullptr;
+}
+
+static char *
+struct_or_union_kind_text(ncc_parse_tree_t *su)
+{
+    ncc_parse_tree_t *kind = first_descendant_nt(su,
+                                                 "_kw_kw_struct_or_union");
+    return kind ? node_text(kind) : nullptr;
+}
+
+static bool
+struct_or_union_is_union(ncc_parse_tree_t *su)
+{
+    char *kind = struct_or_union_kind_text(su);
+    bool  r    = kind && strcmp(kind, "union") == 0;
+    ncc_free(kind);
+    return r;
+}
+
+static char *
+aggregate_key_from_specifier(ncc_parse_tree_t *su)
+{
+    ncc_parse_tree_t *tag = ncc_xform_find_child_nt(su, "tag_name");
+    if (!tag) {
+        return nullptr;
+    }
+
+    char *kind = struct_or_union_kind_text(su);
+    char *name = node_text(tag);
+    if (!kind || !name || !*name) {
+        ncc_free(kind);
+        ncc_free(name);
+        return nullptr;
+    }
+
+    char *key = format_cstr("%s %s", kind, name);
+    ncc_free(kind);
+    ncc_free(name);
+    return key;
+}
+
+static bool
+aggregate_specifier_has_members(ncc_parse_tree_t *su)
+{
+    return su
+        && ncc_xform_find_child_nt(su, "member_declaration_list") != nullptr;
+}
+
+static aggregate_type_info_t *
+lookup_aggregate_type(ncc_xform_ctx_t *ctx, const char *key)
+{
+    ncc_dict_t *types = gc_aggregate_types(ctx);
+    if (!types || !key) {
+        return nullptr;
+    }
+
+    bool found = false;
+    aggregate_type_info_t *info = ncc_dict_get(types, (void *)key, &found);
+    return found ? info : nullptr;
+}
+
+static void
+record_aggregate_type(ncc_xform_ctx_t *ctx, const char *key,
+                      ncc_parse_tree_t *specifier, bool is_atomic,
+                      const char *offset_type)
+{
+    ncc_dict_t *types = gc_aggregate_types(ctx);
+    if (!types || !key || !specifier) {
+        return;
+    }
+
+    aggregate_type_info_t *info = ncc_alloc(aggregate_type_info_t);
+    info->key         = copy_cstr(key);
+    info->specifier   = specifier;
+    info->offset_type = copy_cstr(offset_type ? offset_type : key);
+    info->is_atomic   = is_atomic;
+    info->is_union    = struct_or_union_is_union(specifier);
+    ncc_dict_put(types, info->key, info);
+}
+
+static ncc_parse_tree_t *
+resolve_aggregate_specifier(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *su)
+{
+    if (!su) {
+        return nullptr;
+    }
+
+    if (aggregate_specifier_has_members(su)) {
+        return su;
+    }
+
+    char *key = aggregate_key_from_specifier(su);
+    aggregate_type_info_t *info = lookup_aggregate_type(ctx, key);
+    ncc_free(key);
+    return info ? info->specifier : nullptr;
+}
+
+static char *
+first_typedef_name_text(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return nullptr;
+    }
+
+    if (ncc_xform_nt_name_is(node, "member_declaration_list")) {
+        return nullptr;
+    }
+
+    if (ncc_xform_nt_name_is(node, "typedef_name")) {
+        return node_text(node);
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        char *candidate = first_typedef_name_text(ncc_tree_child(node, i));
+        if (candidate) {
+            return candidate;
+        }
+    }
+
+    return nullptr;
+}
+
+static bool typedef_name_is_pointer(ncc_xform_ctx_t *ctx, const char *name);
+
+static char *
+first_known_type_alias_text(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node,
+                            bool want_pointer, bool want_aggregate)
+{
+    if (!node) {
+        return nullptr;
+    }
+
+    if (!ncc_tree_is_leaf(node)
+        && ncc_xform_nt_name_is(node, "member_declaration_list")) {
+        return nullptr;
+    }
+
+    if (ncc_tree_is_leaf(node)) {
+        const char *text = ncc_xform_leaf_text(node);
+        if (!text || !is_ident_start_char(text[0])) {
+            return nullptr;
+        }
+
+        if (want_pointer && typedef_name_is_pointer(ctx, text)) {
+            return copy_cstr(text);
+        }
+
+        if (want_aggregate && lookup_aggregate_type(ctx, text)) {
+            return copy_cstr(text);
+        }
+
+        return nullptr;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        char *candidate = first_known_type_alias_text(
+            ctx, ncc_tree_child(node, i), want_pointer, want_aggregate);
+        if (candidate) {
+            return candidate;
+        }
+    }
+
+    return nullptr;
+}
+
+static ncc_parse_tree_t *
+aggregate_spec_from_specs(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *specs)
+{
+    ncc_parse_tree_t *su = first_descendant_nt(specs,
+                                               "struct_or_union_specifier");
+    if (su) {
+        return resolve_aggregate_specifier(ctx, su);
+    }
+
+    char *td_name = first_typedef_name_text(specs);
+    aggregate_type_info_t *info = lookup_aggregate_type(ctx, td_name);
+    if (!info && !td_name) {
+        td_name = first_known_type_alias_text(ctx, specs, false, true);
+        info    = lookup_aggregate_type(ctx, td_name);
+    }
+    ncc_free(td_name);
+    return info ? info->specifier : nullptr;
+}
+
+static aggregate_type_info_t *
+aggregate_info_from_specs(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *specs)
+{
+    ncc_parse_tree_t *su = first_descendant_nt(specs,
+                                               "struct_or_union_specifier");
+    if (su) {
+        char *key = aggregate_key_from_specifier(su);
+        aggregate_type_info_t *info = lookup_aggregate_type(ctx, key);
+        ncc_free(key);
+        if (info) {
+            return info;
+        }
+    }
+
+    char *td_name = first_typedef_name_text(specs);
+    aggregate_type_info_t *info = lookup_aggregate_type(ctx, td_name);
+    if (!info && !td_name) {
+        td_name = first_known_type_alias_text(ctx, specs, false, true);
+        info    = lookup_aggregate_type(ctx, td_name);
+    }
+    ncc_free(td_name);
+    return info;
+}
+
+static bool
+specs_have_atomic_type_wrapper(ncc_parse_tree_t *node)
+{
+    if (!node) {
+        return false;
+    }
+
+    if (ncc_tree_is_leaf(node)) {
+        return ncc_xform_leaf_text_eq(node, "_Atomic");
+    }
+
+    if (ncc_xform_nt_name_is(node, "member_declaration_list")) {
+        return false;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (specs_have_atomic_type_wrapper(ncc_tree_child(node, i))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static char *
+aggregate_offset_type_from_specs(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *specs)
+{
+    ncc_parse_tree_t *su = first_descendant_nt(specs,
+                                               "struct_or_union_specifier");
+    if (su) {
+        char *key = aggregate_key_from_specifier(su);
+        if (key) {
+            return key;
+        }
+    }
+
+    char *td_name = first_typedef_name_text(specs);
+    if (td_name) {
+        return td_name;
+    }
+
+    return first_known_type_alias_text(ctx, specs, false, true);
+}
+
+static bool
+specs_are_unnamed_inline_aggregate(ncc_parse_tree_t *specs)
+{
+    ncc_parse_tree_t *su = first_descendant_nt(specs,
+                                               "struct_or_union_specifier");
+    return su && aggregate_specifier_has_members(su)
+        && ncc_xform_find_child_nt(su, "tag_name") == nullptr;
+}
+
+static char *
+implicit_member_field_name(ncc_parse_tree_t *member,
+                           ncc_parse_tree_t *member_specs)
+{
+    char  *text = node_text(member);
+    size_t end  = strlen(text);
+    char  *semi = strrchr(text, ';');
+    if (semi) {
+        end = (size_t)(semi - text);
+    }
+
+    if (specs_are_unnamed_inline_aggregate(member_specs)) {
+        char *close = nullptr;
+        for (size_t i = 0; i < end; i++) {
+            if (text[i] == '}') {
+                close = text + i;
+            }
+        }
+
+        if (!close || (size_t)(close - text + 1) >= end) {
+            ncc_free(text);
+            return nullptr;
+        }
+
+        size_t start = (size_t)(close - text + 1);
+        size_t len   = end - start;
+        char  *tail  = ncc_alloc_size(1, len + 1);
+        memcpy(tail, text + start, len);
+        tail[len] = '\0';
+        char *name = copy_last_identifier_before(tail, len);
+        ncc_free(tail);
+        ncc_free(text);
+        return name;
+    }
+
+    char *name = copy_last_identifier_before(text, end);
+    ncc_free(text);
+    if (!name) {
+        return nullptr;
+    }
+
+    ncc_parse_tree_t *su = first_descendant_nt(member_specs,
+                                               "struct_or_union_specifier");
+    char *td_name = first_typedef_name_text(member_specs);
+    if (!su && td_name && strcmp(td_name, name) == 0) {
+        ncc_free(td_name);
+        ncc_free(name);
+        return nullptr;
+    }
+    ncc_free(td_name);
+
+    ncc_parse_tree_t *tag = su ? ncc_xform_find_child_nt(su, "tag_name")
+                               : nullptr;
+    if (tag) {
+        char *tag_name = node_text(tag);
+        if (tag_name && strcmp(tag_name, name) == 0) {
+            ncc_free(tag_name);
+            ncc_free(name);
+            return nullptr;
+        }
+        ncc_free(tag_name);
+    }
+
+    return name;
+}
+
+static bool
+typedef_name_is_pointer(ncc_xform_ctx_t *ctx, const char *name)
+{
+    ncc_dict_t *ptrs = gc_pointer_typedefs(ctx);
+    if (!ptrs || !name) {
+        return false;
+    }
+
+    bool found = false;
+    (void)ncc_dict_get(ptrs, (void *)name, &found);
+    return found;
+}
+
+static bool
+decl_specs_use_pointer_typedef(ncc_xform_ctx_t *ctx,
+                               ncc_parse_tree_t *specs)
+{
+    char *td_name = first_typedef_name_text(specs);
+    bool  result  = typedef_name_is_pointer(ctx, td_name);
+    if (!result && !td_name) {
+        td_name = first_known_type_alias_text(ctx, specs, true, false);
+        result  = typedef_name_is_pointer(ctx, td_name);
+    }
+    ncc_free(td_name);
+    return result;
+}
+
+static int
+pointer_depth_for_specs(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *specs)
+{
+    int ptr_depth = pointer_depth_in_decl_specs(specs);
+    if (decl_specs_use_pointer_typedef(ctx, specs)) {
+        ptr_depth++;
+    }
+    return ptr_depth;
+}
+
+static int
+pointer_depth_for_declarator(ncc_xform_ctx_t *ctx,
+                             ncc_parse_tree_t *specs,
+                             ncc_parse_tree_t *declarator)
+{
+    return pointer_depth_in_declarator(declarator)
+         + pointer_depth_for_specs(ctx, specs);
+}
+
+static void
+record_pointer_typedef(ncc_xform_ctx_t *ctx, const char *name)
+{
+    ncc_dict_t *ptrs = gc_pointer_typedefs(ctx);
+    if (!ptrs || !name || !*name) {
+        return;
+    }
+
+    ncc_dict_put(ptrs, copy_cstr(name), (void *)(uintptr_t)1);
+}
+
+static uint64_t
+count_top_level_initializers(ncc_parse_tree_t *list)
+{
+    if (!list || ncc_tree_is_leaf(list)) {
+        return 0;
+    }
+
+    uint64_t count = 0;
+    size_t   nc    = ncc_tree_num_children(list);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *child = ncc_tree_child(list, i);
+        if (ncc_xform_nt_name_is(child, "initializer")) {
+            count++;
+        }
+        else if (is_group_node(child)) {
+            count += count_top_level_initializers(child);
+        }
+    }
+
+    return count;
+}
+
+static bool
+infer_array_bound_from_initializer(ncc_parse_tree_t *decl_node,
+                                   uint64_t *count_out)
+{
+    ncc_parse_tree_t *initializer = ncc_xform_find_child_nt(decl_node,
+                                                            "initializer");
+    ncc_parse_tree_t *braced = ncc_xform_find_child_nt(initializer,
+                                                       "braced_initializer");
+    ncc_parse_tree_t *list = ncc_xform_find_child_nt(braced,
+                                                     "initializer_list");
+    uint64_t count = count_top_level_initializers(list);
+    if (count == 0) {
+        return false;
+    }
+
+    *count_out = count;
+    return true;
+}
+
+static bool
+array_literal_dimensions(ncc_parse_tree_t *declarator,
+                         ncc_parse_tree_t *decl_node,
+                         uint64_list_t *dims)
+{
+    char *text = node_text(declarator);
+    char *p    = text;
+
+    while ((p = strchr(p, '[')) != nullptr) {
+        char *close = strchr(p + 1, ']');
+        if (!close) {
+            ncc_free(text);
+            return false;
+        }
+
+        size_t len = (size_t)(close - (p + 1));
+        char  *bound = ncc_alloc_size(1, len + 1);
+        memcpy(bound, p + 1, len);
+        bound[len] = '\0';
+
+        uint64_t count = 0;
+        bool ok = false;
+        char *trimmed = trim_copy(bound);
+        if (trimmed[0] == '\0' && dims->len == 0) {
+            ok = infer_array_bound_from_initializer(decl_node, &count);
+        }
+        else {
+            ok = parse_positive_integer_literal(trimmed, &count);
+        }
+        ncc_free(trimmed);
+        ncc_free(bound);
+        if (!ok) {
+            ncc_free(text);
+            return false;
+        }
+
+        uint64_list_push(dims, count);
+        p = close + 1;
+    }
+
+    ncc_free(text);
+    return dims->len > 0;
+}
+
+static char *
+num_words_expr_for_pointer_array(ncc_parse_tree_t *declarator,
+                                 const char *expr,
+                                 ncc_parse_tree_t **bad_array)
+{
+    uint64_t product    = 1;
+    bool     use_sizeof = false;
+    if (!array_bound_product(declarator, &product, &use_sizeof, bad_array)) {
+        return nullptr;
+    }
+
+    if (use_sizeof) {
+        return format_cstr("(sizeof(%s)/sizeof(void *))", expr);
+    }
+
+    return format_cstr("%llu", (unsigned long long)product);
+}
+
+static void
+collect_aggregate_definitions(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "struct_or_union_specifier")
+        && aggregate_specifier_has_members(node)) {
+        if (!node_starts_in_system_header(node)) {
+            char *key = aggregate_key_from_specifier(node);
+            if (key) {
+                record_aggregate_type(ctx, key, node, false, key);
+                ncc_free(key);
+            }
+        }
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        collect_aggregate_definitions(ctx, ncc_tree_child(node, i));
+    }
+}
+
+static void
+collect_typedef_aliases_from_decl(ncc_xform_ctx_t *ctx,
+                                  ncc_parse_tree_t *decl)
+{
+    ncc_parse_tree_t *decl_specs = ncc_xform_find_child_nt(
+        decl, "declaration_specifiers");
+    ncc_parse_tree_t *list = ncc_xform_find_child_nt(decl,
+                                                     "init_declarator_list");
+    if (!decl_specs || !list || !contains_leaf_text(decl_specs, "typedef")) {
+        return;
+    }
+
+    parse_tree_list_t inits = {0};
+    collect_nt_children(list, "init_declarator", &inits);
+
+    for (size_t i = 0; i < inits.len; i++) {
+        ncc_parse_tree_t *declarator = ncc_xform_find_child_nt(
+            inits.data[i], "declarator");
+        char *name = declarator_name(declarator);
+        if (!name) {
+            continue;
+        }
+
+        if (pointer_depth_in_declarator(declarator) > 0
+            || decl_specs_use_pointer_typedef(ctx, decl_specs)) {
+            record_pointer_typedef(ctx, name);
+            ncc_free(name);
+            continue;
+        }
+
+        ncc_parse_tree_t *aggregate = aggregate_spec_from_specs(ctx,
+                                                                decl_specs);
+        if (aggregate) {
+            bool  is_atomic   = specs_have_atomic_type_wrapper(decl_specs);
+            char *offset_type = is_atomic
+                                  ? aggregate_offset_type_from_specs(ctx,
+                                                                     decl_specs)
+                                  : nullptr;
+            record_aggregate_type(ctx, name, aggregate, is_atomic,
+                                  offset_type ? offset_type : name);
+            ncc_free(offset_type);
+        }
+
+        ncc_free(name);
+    }
+
+    ncc_free(inits.data);
+}
+
+static void
+collect_typedef_aliases(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "declaration")
+        && !node_starts_in_system_header(node)) {
+        collect_typedef_aliases_from_decl(ctx, node);
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        collect_typedef_aliases(ctx, ncc_tree_child(node, i));
+    }
+}
+
+static void
+collect_gc_type_info(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu)
+{
+    collect_aggregate_definitions(ctx, tu);
+    collect_typedef_aliases(ctx, tu);
+}
+
 static ncc_gc_stack_root_t *
 record_root(ncc_xform_ctx_t *ctx, const char *function, const char *name,
             ncc_parse_tree_t *type_node, ncc_gc_stack_root_kind_t kind,
             ncc_gc_stack_root_shape_t shape, uint64_t num_words,
+            const char *address_expr, const char *num_words_expr,
             ncc_parse_tree_t *scope, ncc_parse_tree_t *decl_node)
 {
     ncc_xform_data_t    *data = ncc_xform_get_data(ctx);
@@ -870,6 +1549,9 @@ record_root(ncc_xform_ctx_t *ctx, const char *function, const char *name,
         .function_name = copy_cstr(function),
         .name          = copy_cstr(name),
         .type_text     = node_text(type_node),
+        .address_expr  = copy_cstr(address_expr ? address_expr : name),
+        .num_words_expr = num_words_expr ? copy_cstr(num_words_expr)
+                                         : nullptr,
         .kind          = kind,
         .shape         = shape,
         .num_words     = num_words,
@@ -885,6 +1567,468 @@ record_root(ncc_xform_ctx_t *ctx, const char *function, const char *name,
     return root;
 }
 
+static ncc_gc_stack_root_t *
+record_root_expr(ncc_xform_ctx_t *ctx, const char *function,
+                 const char *name, ncc_parse_tree_t *type_node,
+                 ncc_gc_stack_root_kind_t kind,
+                 ncc_gc_stack_root_shape_t shape,
+                 const char *address_expr, const char *num_words_expr,
+                 ncc_parse_tree_t *scope, ncc_parse_tree_t *decl_node)
+{
+    uint64_t num_words = 0;
+
+    if (!num_words_expr || parse_positive_integer_literal(num_words_expr,
+                                                          &num_words)) {
+        if (!num_words_expr) {
+            num_words = 1;
+        }
+    }
+
+    return record_root(ctx, function, name, type_node, kind, shape,
+                       num_words, address_expr, num_words_expr, scope,
+                       decl_node);
+}
+
+static char *
+append_offset_field(const char *path, const char *field)
+{
+    if (path && *path) {
+        return format_cstr("%s.%s", path, field);
+    }
+
+    return copy_cstr(field);
+}
+
+static char *
+field_address_expr(const char *field_expr, const char *atomic_base_expr,
+                   const char *atomic_type, const char *atomic_field_path)
+{
+    if (atomic_base_expr && atomic_type && atomic_field_path
+        && *atomic_field_path) {
+        return format_cstr("((char *)&%s + __builtin_offsetof(%s, %s))",
+                           atomic_base_expr, atomic_type, atomic_field_path);
+    }
+
+    return format_cstr("&%s", field_expr);
+}
+
+static char *
+atomic_offset_type_for_specs(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *specs,
+                             aggregate_type_info_t *info)
+{
+    if (info && info->is_atomic) {
+        return copy_cstr(info->offset_type);
+    }
+
+    if (specs_have_atomic_type_wrapper(specs)) {
+        return aggregate_offset_type_from_specs(ctx, specs);
+    }
+
+    return nullptr;
+}
+
+typedef struct {
+    const char *base_expr;
+    const char *type;
+    const char *path;
+    char       *owned_type;
+} atomic_child_context_t;
+
+static atomic_child_context_t
+atomic_child_context_for_field(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *specs,
+                               aggregate_type_info_t *info,
+                               const char *parent_base_expr,
+                               const char *parent_type,
+                               const char *parent_path,
+                               const char *field_expr,
+                               const char *field_path)
+{
+    atomic_child_context_t result = {
+        .base_expr  = parent_base_expr,
+        .type       = parent_type,
+        .path       = parent_path,
+        .owned_type = atomic_offset_type_for_specs(ctx, specs, info),
+    };
+
+    if (result.owned_type) {
+        result.base_expr = field_expr;
+        result.type      = result.owned_type;
+        result.path      = "";
+    }
+    else if (parent_base_expr) {
+        result.path = field_path;
+    }
+
+    return result;
+}
+
+static size_t expand_aggregate_fields(ncc_xform_ctx_t *ctx,
+                                      const char *function,
+                                      const char *root_name,
+                                      const char *base_expr,
+                                      ncc_parse_tree_t *aggregate_spec,
+                                      ncc_gc_stack_root_kind_t kind,
+                                      ncc_parse_tree_t *scope,
+                                      ncc_parse_tree_t *decl_node,
+                                      int depth,
+                                      const char *atomic_base_expr,
+                                      const char *atomic_type,
+                                      const char *atomic_path);
+
+static size_t
+expand_aggregate_array_elements(ncc_xform_ctx_t *ctx, const char *function,
+                                const char *root_name, const char *array_expr,
+                                ncc_parse_tree_t *aggregate_spec,
+                                uint64_list_t *dims, size_t dim_index,
+                                ncc_gc_stack_root_kind_t kind,
+                                ncc_parse_tree_t *scope,
+                                ncc_parse_tree_t *decl_node,
+                                int depth,
+                                const char *atomic_base_expr,
+                                const char *atomic_type,
+                                const char *atomic_path)
+{
+    if (dim_index == dims->len) {
+        const char *field_atomic_base = atomic_base_expr;
+        const char *field_atomic_path = atomic_path;
+        if (!field_atomic_base && atomic_type) {
+            field_atomic_base = array_expr;
+            field_atomic_path = "";
+        }
+
+        return expand_aggregate_fields(ctx, function, root_name, array_expr,
+                                       aggregate_spec, kind, scope, decl_node,
+                                       depth + 1, field_atomic_base,
+                                       atomic_type, field_atomic_path);
+    }
+
+    size_t total = 0;
+    for (uint64_t i = 0; i < dims->data[dim_index]; i++) {
+        char *element = format_cstr("%s[%llu]", array_expr,
+                                    (unsigned long long)i);
+        total += expand_aggregate_array_elements(ctx, function, root_name,
+                                                 element, aggregate_spec,
+                                                 dims, dim_index + 1, kind,
+                                                 scope, decl_node, depth,
+                                                 atomic_base_expr, atomic_type,
+                                                 atomic_path);
+        ncc_free(element);
+    }
+
+    return total;
+}
+
+static size_t
+expand_aggregate_array(ncc_xform_ctx_t *ctx, const char *function,
+                       const char *root_name, const char *array_expr,
+                       ncc_parse_tree_t *aggregate_spec,
+                       ncc_parse_tree_t *declarator,
+                       ncc_gc_stack_root_kind_t kind,
+                       ncc_parse_tree_t *scope,
+                       ncc_parse_tree_t *decl_node,
+                       int depth,
+                       const char *atomic_base_expr,
+                       const char *atomic_type,
+                       const char *atomic_path)
+{
+    uint64_list_t dims = {0};
+    if (!array_literal_dimensions(declarator, decl_node, &dims)) {
+        ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+        ncc_free(dims.data);
+        if (data && data->gc_stack_maps_relaxed) {
+            return 0;
+        }
+        gc_stack_errorf(declarator,
+                        "GC stack-map aggregate root '%s' in function '%s' "
+                        "uses an aggregate array with non-literal bounds; "
+                        "pointer-bearing aggregate arrays need fixed literal "
+                        "bounds so field roots can be enumerated",
+                        root_name, function);
+    }
+
+    size_t total = expand_aggregate_array_elements(ctx, function, root_name,
+                                                   array_expr, aggregate_spec,
+                                                   &dims, 0, kind, scope,
+                                                   decl_node, depth,
+                                                   atomic_base_expr,
+                                                   atomic_type, atomic_path);
+    ncc_free(dims.data);
+    return total;
+}
+
+static size_t
+expand_member_declarator(ncc_xform_ctx_t *ctx, const char *function,
+                         const char *root_name, const char *base_expr,
+                         ncc_parse_tree_t *member_specs,
+                         ncc_parse_tree_t *member_declarator,
+                         ncc_gc_stack_root_kind_t kind,
+                         ncc_parse_tree_t *scope,
+                         ncc_parse_tree_t *decl_node,
+                         int depth,
+                         const char *atomic_base_expr,
+                         const char *atomic_type,
+                         const char *atomic_path)
+{
+    ncc_parse_tree_t *declarator = ncc_xform_find_child_nt(member_declarator,
+                                                           "declarator");
+    if (!declarator) {
+        return 0;
+    }
+
+    char *field_name = declarator_name(declarator);
+    if (!field_name) {
+        return 0;
+    }
+
+    char *field_expr = format_cstr("%s.%s", base_expr, field_name);
+    char *field_path = append_offset_field(atomic_path, field_name);
+    int   ptr_depth  = pointer_depth_for_declarator(ctx, member_specs,
+                                                    declarator);
+
+    bool is_array = first_descendant_nt(declarator, "array_declarator")
+                 != nullptr;
+    size_t roots = 0;
+
+    if (ptr_depth > 0) {
+        char *addr = field_address_expr(field_expr, atomic_base_expr,
+                                        atomic_type, field_path);
+        char *words = nullptr;
+        ncc_gc_stack_root_shape_t shape = NCC_GC_STACK_ROOT_POINTER;
+
+        if (is_array) {
+            // Flexible array members have no by-value stack storage to scan.
+            if (has_unbounded_array_declarator(declarator)) {
+                ncc_free(addr);
+                ncc_free(field_path);
+                ncc_free(field_expr);
+                ncc_free(field_name);
+                return 0;
+            }
+
+            ncc_parse_tree_t *bad_array = nullptr;
+            words = num_words_expr_for_pointer_array(declarator, field_expr,
+                                                     &bad_array);
+            if (!words) {
+                ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+                if (data && data->gc_stack_maps_relaxed) {
+                    ncc_free(addr);
+                    ncc_free(field_path);
+                    ncc_free(field_expr);
+                    ncc_free(field_name);
+                    return 0;
+                }
+                gc_stack_errorf(bad_array ? bad_array : declarator,
+                                "GC stack-map root '%s' in function '%s' uses "
+                                "a variable-length or incomplete pointer array "
+                                "field; only fixed-size stack roots are "
+                                "supported",
+                                field_expr, function);
+            }
+            shape = NCC_GC_STACK_ROOT_POINTER_ARRAY;
+        }
+        else {
+            words = copy_cstr("1");
+        }
+
+        record_root_expr(ctx, function, field_expr, member_specs, kind, shape,
+                         addr, words, scope, decl_node);
+        roots++;
+        ncc_free(addr);
+        ncc_free(words);
+    }
+    else {
+        aggregate_type_info_t *nested_info = aggregate_info_from_specs(
+            ctx, member_specs);
+        ncc_parse_tree_t *nested = nested_info
+                                     ? nested_info->specifier
+                                     : aggregate_spec_from_specs(ctx,
+                                                                member_specs);
+        if (nested) {
+            atomic_child_context_t child = atomic_child_context_for_field(
+                ctx, member_specs, nested_info, atomic_base_expr, atomic_type,
+                atomic_path, field_expr, field_path);
+
+            if (is_array) {
+                roots += expand_aggregate_array(ctx, function, root_name,
+                                                field_expr, nested,
+                                                declarator, kind, scope,
+                                                decl_node, depth + 1,
+                                                child.base_expr,
+                                                child.type,
+                                                child.path);
+            }
+            else {
+                roots += expand_aggregate_fields(ctx, function, root_name,
+                                                 field_expr, nested, kind,
+                                                 scope, decl_node, depth + 1,
+                                                 child.base_expr,
+                                                 child.type,
+                                                 child.path);
+            }
+            ncc_free(child.owned_type);
+        }
+    }
+
+    ncc_free(field_expr);
+    ncc_free(field_path);
+    ncc_free(field_name);
+    return roots;
+}
+
+static size_t
+expand_member_declaration(ncc_xform_ctx_t *ctx, const char *function,
+                          const char *root_name, const char *base_expr,
+                          ncc_parse_tree_t *member,
+                          ncc_gc_stack_root_kind_t kind,
+                          ncc_parse_tree_t *scope,
+                          ncc_parse_tree_t *decl_node,
+                          int depth,
+                          const char *atomic_base_expr,
+                          const char *atomic_type,
+                          const char *atomic_path)
+{
+    ncc_parse_tree_t *member_specs = ncc_xform_find_child_nt(
+        member, "specifier_qualifier_list");
+    if (!member_specs) {
+        return 0;
+    }
+
+    ncc_parse_tree_t *member_list = ncc_xform_find_child_nt(
+        member, "member_declarator_list");
+    if (!member_list) {
+        int ptr_depth = pointer_depth_for_specs(ctx, member_specs);
+
+        if (ptr_depth > 0) {
+            char *field_name = implicit_member_field_name(member, member_specs);
+            if (!field_name) {
+                return 0;
+            }
+
+            char *field_expr = format_cstr("%s.%s", base_expr, field_name);
+            char *field_path = append_offset_field(atomic_path, field_name);
+            char *addr       = field_address_expr(field_expr, atomic_base_expr,
+                                                  atomic_type, field_path);
+            char *words      = copy_cstr("1");
+
+            record_root_expr(ctx, function, field_expr, member_specs, kind,
+                             NCC_GC_STACK_ROOT_POINTER, addr, words, scope,
+                             decl_node);
+
+            ncc_free(words);
+            ncc_free(addr);
+            ncc_free(field_path);
+            ncc_free(field_expr);
+            ncc_free(field_name);
+            return 1;
+        }
+
+        aggregate_type_info_t *anonymous_info = aggregate_info_from_specs(
+            ctx, member_specs);
+        ncc_parse_tree_t *anonymous = anonymous_info
+                                        ? anonymous_info->specifier
+                                        : aggregate_spec_from_specs(ctx,
+                                                                   member_specs);
+        if (!anonymous) {
+            return 0;
+        }
+
+        char *field_name = implicit_member_field_name(member, member_specs);
+        if (!field_name) {
+            return expand_aggregate_fields(ctx, function, root_name,
+                                           base_expr, anonymous, kind, scope,
+                                           decl_node, depth + 1,
+                                           atomic_base_expr, atomic_type,
+                                           atomic_path);
+        }
+
+        char *field_expr = format_cstr("%s.%s", base_expr, field_name);
+        char *field_path = append_offset_field(atomic_path, field_name);
+        atomic_child_context_t child = atomic_child_context_for_field(
+            ctx, member_specs, anonymous_info, atomic_base_expr, atomic_type,
+            atomic_path, field_expr, field_path);
+
+        size_t roots = expand_aggregate_fields(ctx, function, root_name,
+                                               field_expr, anonymous, kind,
+                                               scope, decl_node, depth + 1,
+                                               child.base_expr,
+                                               child.type,
+                                               child.path);
+        ncc_free(child.owned_type);
+        ncc_free(field_path);
+        ncc_free(field_expr);
+        ncc_free(field_name);
+        return roots;
+    }
+
+    parse_tree_list_t declarators = {0};
+    collect_nt_children(member_list, "member_declarator", &declarators);
+
+    size_t roots = 0;
+    for (size_t i = 0; i < declarators.len; i++) {
+        roots += expand_member_declarator(ctx, function, root_name, base_expr,
+                                          member_specs, declarators.data[i],
+                                          kind, scope, decl_node, depth,
+                                          atomic_base_expr, atomic_type,
+                                          atomic_path);
+    }
+
+    ncc_free(declarators.data);
+    return roots;
+}
+
+static size_t
+expand_aggregate_fields(ncc_xform_ctx_t *ctx, const char *function,
+                        const char *root_name, const char *base_expr,
+                        ncc_parse_tree_t *aggregate_spec,
+                        ncc_gc_stack_root_kind_t kind,
+                        ncc_parse_tree_t *scope,
+                        ncc_parse_tree_t *decl_node,
+                        int depth,
+                        const char *atomic_base_expr,
+                        const char *atomic_type,
+                        const char *atomic_path)
+{
+    if (depth > 64) {
+        ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+        if (data && data->gc_stack_maps_relaxed) {
+            return 0;
+        }
+        gc_stack_errorf(decl_node,
+                        "GC stack-map aggregate root '%s' in function '%s' "
+                        "has recursively nested aggregate fields",
+                        root_name, function);
+    }
+
+    aggregate_spec = resolve_aggregate_specifier(ctx, aggregate_spec);
+    ncc_parse_tree_t *members = ncc_xform_find_child_nt(
+        aggregate_spec, "member_declaration_list");
+    if (!members) {
+        ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+        if (data && data->gc_stack_maps_relaxed) {
+            return 0;
+        }
+        gc_stack_errorf(decl_node,
+                        "GC stack-map aggregate root '%s' in function '%s' "
+                        "uses an incomplete or unresolved aggregate type",
+                        root_name, function);
+    }
+
+    parse_tree_list_t member_decls = {0};
+    collect_nt_children(members, "member_declaration", &member_decls);
+
+    size_t roots = 0;
+    for (size_t i = 0; i < member_decls.len; i++) {
+        roots += expand_member_declaration(ctx, function, root_name, base_expr,
+                                           member_decls.data[i], kind, scope,
+                                           decl_node, depth,
+                                           atomic_base_expr, atomic_type,
+                                           atomic_path);
+    }
+
+    ncc_free(member_decls.data);
+    return roots;
+}
+
 static void
 classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
                     ncc_parse_tree_t *decl_specs,
@@ -898,18 +2042,26 @@ classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
 
     ncc_xform_data_t *data = ncc_xform_get_data(ctx);
 
-    if (function && strncmp(function, "ncplane_", 8) == 0) {
+    if (cstr_has_prefix(function, "ncplane_")) {
         return;
     }
 
-    int  ptr_depth = pointer_depth_in_declarator(declarator);
+    int  ptr_depth = pointer_depth_for_declarator(ctx, decl_specs,
+                                                  declarator);
+
     bool is_array  = first_descendant_nt(declarator, "array_declarator")
                   != nullptr;
-    bool aggregate = decl_specs_are_aggregate(decl_specs);
+    aggregate_type_info_t *aggregate_info = aggregate_info_from_specs(ctx,
+                                                                      decl_specs);
+    ncc_parse_tree_t *aggregate = aggregate_info
+                                    ? aggregate_info->specifier
+                                    : aggregate_spec_from_specs(ctx,
+                                                               decl_specs);
 
     if (kind == NCC_GC_STACK_ROOT_PARAM && is_array) {
         ptr_depth = ptr_depth > 0 ? ptr_depth : 1;
         is_array  = false;
+        aggregate = nullptr;
     }
 
     if (ptr_depth == 0 && !is_array && !aggregate) {
@@ -926,48 +2078,6 @@ classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
                         "GC stack-map root in function '%s' is unsupported: "
                         "pointer or aggregate parameter has no name",
                         function);
-    }
-
-    ncc_gc_stack_root_shape_t shape     = NCC_GC_STACK_ROOT_POINTER;
-    uint64_t                  num_words = 1;
-
-    if (is_array) {
-        if (ptr_depth > 0 && has_parenthesized_pointer_array(declarator)) {
-            if (data && data->gc_stack_maps_relaxed) {
-                ncc_free(name);
-                return;
-            }
-            gc_stack_errorf(declarator,
-                            "GC stack-map root '%s' in function '%s' uses a "
-                            "parenthesized pointer/array declarator; spell the "
-                            "root as a direct fixed-size pointer array or a "
-                            "single pointer",
-                            name, function);
-        }
-
-        ncc_parse_tree_t *bad_array = nullptr;
-        uint64_t          product   = 1;
-        bool              use_sizeof = false;
-        if (!array_bound_product(declarator, &product, &use_sizeof,
-                                 &bad_array)) {
-            if (data && data->gc_stack_maps_relaxed) {
-                ncc_free(name);
-                return;
-            }
-            gc_stack_errorf(bad_array ? bad_array : declarator,
-                            "GC stack-map root '%s' in function '%s' uses a "
-                            "variable-length or incomplete array; only "
-                            "fixed-size stack roots are supported",
-                            name, function);
-        }
-
-        num_words = use_sizeof ? 0 : product;
-        shape     = ptr_depth > 0 ? NCC_GC_STACK_ROOT_POINTER_ARRAY
-                                  : NCC_GC_STACK_ROOT_AGGREGATE;
-    }
-    else if (aggregate) {
-        shape     = NCC_GC_STACK_ROOT_AGGREGATE;
-        num_words = 0;
     }
 
     if (kind == NCC_GC_STACK_ROOT_LOCAL) {
@@ -993,8 +2103,73 @@ classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
         }
     }
 
-    record_root(ctx, function, name, decl_specs, kind, shape, num_words,
-                scope, decl_node);
+    if (ptr_depth > 0) {
+        ncc_gc_stack_root_shape_t shape = NCC_GC_STACK_ROOT_POINTER;
+        char *num_words_expr = copy_cstr("1");
+
+        if (is_array && ptr_depth > 0
+            && has_parenthesized_pointer_array(declarator)) {
+            if (data && data->gc_stack_maps_relaxed) {
+                ncc_free(name);
+                ncc_free(num_words_expr);
+                return;
+            }
+            gc_stack_errorf(declarator,
+                            "GC stack-map root '%s' in function '%s' uses a "
+                            "parenthesized pointer/array declarator; spell the "
+                            "root as a direct fixed-size pointer array or a "
+                            "single pointer",
+                            name, function);
+        }
+
+        if (is_array) {
+            ncc_parse_tree_t *bad_array = nullptr;
+            ncc_free(num_words_expr);
+            num_words_expr = num_words_expr_for_pointer_array(declarator,
+                                                              name,
+                                                              &bad_array);
+            if (!num_words_expr) {
+                if (data && data->gc_stack_maps_relaxed) {
+                    ncc_free(name);
+                    return;
+                }
+                gc_stack_errorf(bad_array ? bad_array : declarator,
+                                "GC stack-map root '%s' in function '%s' uses a "
+                                "variable-length or incomplete array; only "
+                                "fixed-size stack roots are supported",
+                                name, function);
+            }
+            shape = NCC_GC_STACK_ROOT_POINTER_ARRAY;
+        }
+
+        char *address_expr = format_cstr("&%s", name);
+        record_root_expr(ctx, function, name, decl_specs, kind, shape,
+                         address_expr, num_words_expr, scope, decl_node);
+        ncc_free(address_expr);
+        ncc_free(num_words_expr);
+        ncc_free(name);
+        return;
+    }
+
+    if (aggregate) {
+        char *atomic_type = atomic_offset_type_for_specs(ctx, decl_specs,
+                                                        aggregate_info);
+        if (is_array) {
+            expand_aggregate_array(ctx, function, name, name, aggregate,
+                                   declarator, kind, scope, decl_node, 0,
+                                   nullptr, atomic_type,
+                                   atomic_type ? "" : nullptr);
+        }
+        else {
+            expand_aggregate_fields(ctx, function, name, name, aggregate,
+                                    kind, scope, decl_node, 0,
+                                    atomic_type ? name : nullptr,
+                                    atomic_type,
+                                    atomic_type ? "" : nullptr);
+        }
+        ncc_free(atomic_type);
+    }
+
     ncc_free(name);
 }
 
@@ -1055,6 +2230,10 @@ static void
 scan_declaration(ncc_xform_ctx_t *ctx, const char *function,
                  ncc_parse_tree_t *decl)
 {
+    if (node_starts_in_system_header(decl)) {
+        return;
+    }
+
     ncc_parse_tree_t *decl_specs = ncc_xform_find_child_nt(
         decl, "declaration_specifiers");
     ncc_parse_tree_t *list = ncc_xform_find_child_nt(decl,
@@ -1087,12 +2266,12 @@ scan_compound(ncc_xform_ctx_t *ctx, const char *function,
     }
 }
 
-static ncc_parse_tree_t *
-xform_gc_stack_function(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *fn)
+static void
+scan_function_definition(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *fn)
 {
     ncc_xform_data_t *data = ncc_xform_get_data(ctx);
     if (!data || !data->gc_stack_maps) {
-        return nullptr;
+        return;
     }
 
     ncc_parse_tree_t *declarator = ncc_xform_find_child_nt(fn, "declarator");
@@ -1101,29 +2280,28 @@ xform_gc_stack_function(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *fn)
     ncc_parse_tree_t *compound   = ncc_xform_find_child_nt(body,
                                                            "compound_statement");
     if (!declarator || !compound) {
-        return nullptr;
+        return;
     }
 
-    if (node_starts_in_system_header(fn) || node_has_system_header_token(fn)
-        || node_uses_computed_goto(fn)
+    if (node_starts_in_system_header(fn) || node_uses_computed_goto(fn)
         || node_mentions_manual_gc_stack_api(compound)) {
-        return nullptr;
+        return;
     }
 
     char *fname = function_name(declarator);
-    if (strncmp(fname, "n00b_gc_stack_", 14) == 0
-        || strncmp(fname, "n00b_thread_", 12) == 0
-        || strncmp(fname, "_n00b_thread_", 13) == 0
-        || strncmp(fname, "n00b_capture_stack_", 18) == 0
-        || strncmp(fname, "n00b_futex_", 11) == 0
+    if (cstr_has_prefix(fname, "n00b_gc_stack_")
+        || cstr_has_prefix(fname, "n00b_thread_")
+        || cstr_has_prefix(fname, "_n00b_thread_")
+        || cstr_has_prefix(fname, "n00b_capture_stack_")
+        || cstr_has_prefix(fname, "n00b_futex_")
         || strcmp(fname, "_n00b_stop_the_world") == 0
         || strcmp(fname, "_n00b_restart_the_world") == 0
         || strcmp(fname, "n00b_wait_for_stw_release") == 0
-        || strncmp(fname, "__ncc_gc_stack_", 16) == 0
-        || strncmp(fname, "__", 2) == 0
-        || strncmp(fname, "ncplane_", 8) == 0) {
+        || cstr_has_prefix(fname, "__ncc_gc_stack_")
+        || cstr_has_prefix(fname, "__")
+        || cstr_has_prefix(fname, "ncplane_")) {
         ncc_free(fname);
-        return nullptr;
+        return;
     }
 
     ncc_parse_tree_t *params = first_descendant_nt(declarator,
@@ -1134,7 +2312,26 @@ xform_gc_stack_function(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *fn)
 
     scan_compound(ctx, fname, compound);
     ncc_free(fname);
-    return nullptr;
+}
+
+static void
+scan_function_definitions(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "function_definition")) {
+        if (!node_starts_in_system_header(node)) {
+            scan_function_definition(ctx, node);
+        }
+        return;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        scan_function_definitions(ctx, ncc_tree_child(node, i));
+    }
 }
 
 typedef enum {
@@ -1272,6 +2469,11 @@ c_string_literal(const char *text)
 static void
 append_slot_num_words(ncc_buffer_t *buf, ncc_gc_stack_root_t *root)
 {
+    if (root->num_words_expr) {
+        ncc_buffer_puts(buf, root->num_words_expr);
+        return;
+    }
+
     if (root->shape == NCC_GC_STACK_ROOT_AGGREGATE) {
         ncc_buffer_printf(buf,
                           "((sizeof(%s)+sizeof(void *)-1)/sizeof(void *))",
@@ -1337,13 +2539,13 @@ build_frame_source(gc_frame_group_t *group, ncc_gc_stack_root_t *roots)
             continue;
         }
 
-        ncc_buffer_printf(buf, "(void *)&%s,", root->name);
+        ncc_buffer_printf(buf, "(void *)%s,", root->address_expr);
     }
 
     ncc_buffer_puts(buf, "};");
     ncc_buffer_printf(buf,
                       "n00b_gc_stack_frame_t __ncc_gc_frame_%d "
-                      "__attribute__((cleanup(__ncc_gc_stack_pop_cleanup)));",
+                      "__attribute__((cleanup(n00b_gc_stack_pop)));",
                       group->id);
     ncc_buffer_printf(buf,
                       "n00b_gc_stack_push(&__ncc_gc_frame_%d,"
@@ -1442,80 +2644,20 @@ insert_frame_group(ncc_xform_ctx_t *ctx, gc_frame_group_t *group,
     ncc_free(items.data);
 }
 
-static void
-insert_helper_before_first_rooted_function(ncc_xform_ctx_t *ctx,
-                                           ncc_gc_stack_root_t *roots)
-{
-    ncc_xform_data_t *data = ncc_xform_get_data(ctx);
-    if (data->gc_stack_maps_helper_inserted) {
-        return;
-    }
-
-    ncc_parse_tree_t *best_container = nullptr;
-    ncc_parse_tree_t *best_ext       = nullptr;
-    size_t            best_ix        = 0;
-    int32_t           best_start     = 0;
-
-    for (ncc_gc_stack_root_t *root = roots; root; root = root->next) {
-        ncc_parse_tree_t *ext = ncc_xform_find_ancestor(root->scope,
-                                                        "external_declaration");
-        if (!ext) {
-            continue;
-        }
-
-        ncc_nt_node_t    epn       = ncc_tree_node_value(ext);
-        ncc_parse_tree_t *container = epn.parent
-                                          ? (ncc_parse_tree_t *)epn.parent
-                                          : ctx->root;
-        size_t ix = 0;
-        if (!child_index(container, ext, &ix)) {
-            continue;
-        }
-
-        if (!best_ext || epn.start < best_start) {
-            best_container = container;
-            best_ext       = ext;
-            best_ix        = ix;
-            best_start     = epn.start;
-        }
-    }
-
-    if (!best_ext || !best_container) {
-        gc_stack_errorf(ctx->root,
-                        "GC stack-map helper insertion failed: no rooted "
-                        "function was found in the translation unit");
-    }
-
-    const char *src =
-        "static inline void "
-        "__ncc_gc_stack_pop_cleanup(n00b_gc_stack_frame_t *frame)"
-        "{n00b_gc_stack_pop(frame);}";
-    ncc_parse_tree_t *helper = ncc_xform_parse_source(ctx->grammar,
-                                                      "external_declaration",
-                                                      src,
-                                                      "xform_gc_stack_maps");
-    if (!helper) {
-        fprintf(stderr,
-                "ncc: error: failed to parse generated GC stack-map helper:\n"
-                "%s\n",
-                src);
-        exit(1);
-    }
-
-    add_generated_spacing(helper, true);
-    ncc_xform_insert_child(best_container, best_ix, helper);
-    data->gc_stack_maps_helper_inserted = true;
-}
-
 static ncc_parse_tree_t *
 xform_gc_stack_translation_unit(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu)
 {
     ncc_xform_data_t *data = ncc_xform_get_data(ctx);
-    if (!data || !data->gc_stack_maps || !data->gc_stack_roots) {
+    if (!data || !data->gc_stack_maps) {
         return nullptr;
     }
 
-    insert_helper_before_first_rooted_function(ctx, data->gc_stack_roots);
+    collect_gc_type_info(ctx, tu);
+    scan_function_definitions(ctx, tu);
+
+    if (!data->gc_stack_roots) {
+        return nullptr;
+    }
 
     gc_frame_group_list_t groups = {0};
     for (ncc_gc_stack_root_t *root = data->gc_stack_roots; root;
@@ -1535,8 +2677,6 @@ xform_gc_stack_translation_unit(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu)
 void
 ncc_register_gc_stack_maps_xform(ncc_xform_registry_t *reg)
 {
-    ncc_xform_register(reg, "function_definition", xform_gc_stack_function,
-                       "gc_stack_maps");
     ncc_xform_register(reg, "translation_unit",
                        xform_gc_stack_translation_unit,
                        "gc_stack_maps_emit");

--- a/src/xform/xform_gc_stack_maps.c
+++ b/src/xform/xform_gc_stack_maps.c
@@ -75,26 +75,6 @@ contains_leaf_text(ncc_parse_tree_t *node, const char *text)
     return false;
 }
 
-static int
-count_leaf_text(ncc_parse_tree_t *node, const char *text)
-{
-    if (!node) {
-        return 0;
-    }
-
-    if (ncc_tree_is_leaf(node)) {
-        return ncc_xform_leaf_text_eq(node, text) ? 1 : 0;
-    }
-
-    int    result = 0;
-    size_t nc     = ncc_tree_num_children(node);
-    for (size_t i = 0; i < nc; i++) {
-        result += count_leaf_text(ncc_tree_child(node, i), text);
-    }
-
-    return result;
-}
-
 typedef struct {
     ncc_parse_tree_t **data;
     size_t             len;
@@ -174,6 +154,142 @@ first_leaf_token(ncc_parse_tree_t *node)
     }
 
     return nullptr;
+}
+
+static const char *
+token_file(ncc_token_info_t *tok)
+{
+    if (!tok || !ncc_option_is_set(tok->file)) {
+        return nullptr;
+    }
+
+    ncc_string_t file = ncc_option_get(tok->file);
+    return file.data;
+}
+
+static bool
+token_file_looks_system_header(ncc_token_info_t *tok)
+{
+    const char *file = token_file(tok);
+    if (!file) {
+        return false;
+    }
+
+    return strstr(file, "/usr/include/") != nullptr
+        || strstr(file, "/usr/lib/clang/") != nullptr
+        || strstr(file, "/System/Library/Frameworks/") != nullptr
+        || strstr(file, "/opt/homebrew/") != nullptr
+        || strstr(file, "/usr/local/") != nullptr;
+}
+
+static bool
+node_starts_in_system_header(ncc_parse_tree_t *node)
+{
+    ncc_token_info_t *tok = first_leaf_token(node);
+    return tok && (tok->system_header || token_file_looks_system_header(tok));
+}
+
+static bool
+node_has_system_header_token(ncc_parse_tree_t *node)
+{
+    if (!node) {
+        return false;
+    }
+
+    if (ncc_tree_is_leaf(node)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
+        return tok && (tok->system_header || token_file_looks_system_header(tok));
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (node_has_system_header_token(ncc_tree_child(node, i))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool
+node_direct_child_leaf_text(ncc_parse_tree_t *node, const char *text)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *child = ncc_tree_child(node, i);
+        if (child && ncc_tree_is_leaf(child)
+            && ncc_xform_leaf_text_eq(child, text)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool
+node_first_child_leaf_text(ncc_parse_tree_t *node, const char *text)
+{
+    if (!node || ncc_tree_is_leaf(node) || ncc_tree_num_children(node) == 0) {
+        return false;
+    }
+
+    ncc_parse_tree_t *child = ncc_tree_child(node, 0);
+    return child && ncc_tree_is_leaf(child)
+        && ncc_xform_leaf_text_eq(child, text);
+}
+
+static bool
+node_uses_computed_goto(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+
+    if (ncc_xform_nt_name_is(node, "jump_statement")
+        && node_first_child_leaf_text(node, "goto")
+        && node_direct_child_leaf_text(node, "*")) {
+        return true;
+    }
+
+    if (ncc_xform_nt_name_is(node, "unary_expression")
+        && node_first_child_leaf_text(node, "&&")) {
+        return true;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (node_uses_computed_goto(ncc_tree_child(node, i))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool
+node_mentions_manual_gc_stack_api(ncc_parse_tree_t *node)
+{
+    if (!node) {
+        return false;
+    }
+
+    if (ncc_tree_is_leaf(node)) {
+        return ncc_xform_leaf_text_eq(node, "n00b_gc_stack_push")
+            || ncc_xform_leaf_text_eq(node, "n00b_gc_stack_pop");
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (node_mentions_manual_gc_stack_api(ncc_tree_child(node, i))) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 static void
@@ -279,6 +395,201 @@ first_descendant_nt(ncc_parse_tree_t *node, const char *name)
     return nullptr;
 }
 
+static int32_t
+first_positive_token_index(ncc_parse_tree_t *node)
+{
+    if (!node) {
+        return 0;
+    }
+
+    if (ncc_tree_is_leaf(node)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
+        return tok && tok->index > 0 ? tok->index : 0;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        int32_t index = first_positive_token_index(ncc_tree_child(node, i));
+        if (index > 0) {
+            return index;
+        }
+    }
+
+    return 0;
+}
+
+static int32_t
+node_start_index(ncc_parse_tree_t *node)
+{
+    int32_t index = first_positive_token_index(node);
+    if (index > 0) {
+        return index;
+    }
+
+    ncc_token_info_t *tok = first_leaf_token(node);
+    return tok ? tok->index : 0;
+}
+
+static char *
+direct_goto_label_name(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)
+        || !ncc_xform_nt_name_is(node, "jump_statement")
+        || !node_first_child_leaf_text(node, "goto")
+        || node_direct_child_leaf_text(node, "*")) {
+        return nullptr;
+    }
+
+    ncc_parse_tree_t *id = first_descendant_nt(node, "identifier");
+    return id ? node_text(id) : nullptr;
+}
+
+static char *
+statement_label_name(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)
+        || !ncc_xform_nt_name_is(node, "label")
+        || contains_leaf_text(node, "case")
+        || contains_leaf_text(node, "default")) {
+        return nullptr;
+    }
+
+    ncc_parse_tree_t *id = first_descendant_nt(node, "identifier");
+    return id ? node_text(id) : nullptr;
+}
+
+static bool
+has_matching_label_after(ncc_parse_tree_t *node, const char *name,
+                         int32_t anchor_start)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+
+    char *label = statement_label_name(node);
+    if (label) {
+        bool match = node_start_index(node) > anchor_start
+                  && strcmp(label, name) == 0;
+        ncc_free(label);
+        if (match) {
+            return true;
+        }
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (has_matching_label_after(ncc_tree_child(node, i), name,
+                                     anchor_start)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool
+has_forward_goto_bypassing_anchor_r(ncc_parse_tree_t *root,
+                                    ncc_parse_tree_t *node,
+                                    int32_t anchor_start)
+{
+    if (!root || !node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+
+    char *name = direct_goto_label_name(node);
+    if (name) {
+        bool bypass = node_start_index(node) < anchor_start
+                   && has_matching_label_after(root, name, anchor_start);
+        ncc_free(name);
+        if (bypass) {
+            return true;
+        }
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (has_forward_goto_bypassing_anchor_r(root, ncc_tree_child(node, i),
+                                                anchor_start)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool
+has_forward_goto_bypassing_anchor(ncc_parse_tree_t *fn,
+                                  ncc_parse_tree_t *anchor)
+{
+    return fn && anchor
+        && has_forward_goto_bypassing_anchor_r(fn, fn,
+                                               node_start_index(anchor));
+}
+
+static bool
+node_first_leaf_text_eq(ncc_parse_tree_t *node, const char *text)
+{
+    ncc_token_info_t *tok = first_leaf_token(node);
+    if (!tok || !ncc_option_is_set(tok->value)) {
+        return false;
+    }
+
+    ncc_string_t value = ncc_option_get(tok->value);
+    return value.data && strcmp(value.data, text) == 0;
+}
+
+static bool
+node_starts_with_switch_case_label(ncc_parse_tree_t *node)
+{
+    return node_first_leaf_text_eq(node, "case")
+        || node_first_leaf_text_eq(node, "default");
+}
+
+static bool
+block_has_case_label_item(ncc_parse_tree_t *anchor)
+{
+    ncc_parse_tree_t *container = node_parent(anchor);
+
+    if (!container) {
+        return false;
+    }
+
+    size_t nc = ncc_tree_num_children(container);
+    for (size_t i = 0; i < nc; i++) {
+        if (node_starts_with_switch_case_label(ncc_tree_child(container, i))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static int
+pointer_depth_in_declarator(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return 0;
+    }
+
+    if (ncc_xform_nt_name_is(node, "parameter_type_list")
+        || ncc_xform_nt_name_is(node, "assignment_expression")) {
+        return 0;
+    }
+
+    int count = 0;
+    if (ncc_xform_nt_name_is(node, "pointer")) {
+        count += node_direct_child_leaf_text(node, "*") ? 1 : 0;
+        count += node_direct_child_leaf_text(node, "^") ? 1 : 0;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        count += pointer_depth_in_declarator(ncc_tree_child(node, i));
+    }
+
+    return count;
+}
+
 static char *
 declarator_name(ncc_parse_tree_t *node)
 {
@@ -286,24 +597,47 @@ declarator_name(ncc_parse_tree_t *node)
         return nullptr;
     }
 
+    if (!ncc_tree_is_leaf(node)
+        && (ncc_xform_nt_name_is(node, "parameter_type_list")
+            || ncc_xform_nt_name_is(node, "assignment_expression"))) {
+        return nullptr;
+    }
+
     if (ncc_tree_is_leaf(node)) {
         const char *text = ncc_xform_leaf_text(node);
+        if (text
+            && (strcmp(text, "const") == 0
+                || strcmp(text, "restrict") == 0
+                || strcmp(text, "volatile") == 0
+                || strcmp(text, "_Atomic") == 0
+                || strcmp(text, "_Nullable") == 0
+                || strcmp(text, "_Nonnull") == 0
+                || strcmp(text, "_Null_unspecified") == 0
+                || strcmp(text, "__const__") == 0
+                || strcmp(text, "__const") == 0
+                || strcmp(text, "__restrict__") == 0
+                || strcmp(text, "__restrict") == 0
+                || strcmp(text, "__volatile__") == 0
+                || strcmp(text, "__volatile") == 0
+                || strcmp(text, "__nullable") == 0
+                || strcmp(text, "__nonnull") == 0
+                || strcmp(text, "__null_unspecified") == 0)) {
+            return nullptr;
+        }
         if (text && (isalpha((unsigned char)text[0]) || text[0] == '_')) {
             return copy_cstr(text);
         }
         return nullptr;
     }
 
-    char  *last = nullptr;
-    size_t nc   = ncc_tree_num_children(node);
+    size_t nc = ncc_tree_num_children(node);
     for (size_t i = 0; i < nc; i++) {
         char *candidate = declarator_name(ncc_tree_child(node, i));
         if (candidate) {
-            ncc_free(last);
-            last = candidate;
+            return candidate;
         }
     }
-    return last;
+    return nullptr;
 }
 
 static bool
@@ -439,8 +773,34 @@ parse_positive_integer_literal(const char *text, uint64_t *out)
 }
 
 static bool
+array_bound_allows_static_sizeof(const char *text)
+{
+    char *trimmed = trim_copy(text);
+    bool  saw_upper = false;
+    bool  ok        = trimmed[0] != '\0';
+
+    for (char *p = trimmed; ok && *p; p++) {
+        unsigned char c = (unsigned char)*p;
+        if (isupper(c) || *p == '_') {
+            saw_upper = true;
+            continue;
+        }
+        if (isdigit(c) || isspace(c) || *p == '(' || *p == ')' || *p == '+'
+            || *p == '-' || *p == '*' || *p == '/' || *p == '%'
+            || *p == '<' || *p == '>' || *p == '|' || *p == '&'
+            || *p == '~') {
+            continue;
+        }
+        ok = false;
+    }
+
+    ncc_free(trimmed);
+    return ok && saw_upper;
+}
+
+static bool
 array_bound_product(ncc_parse_tree_t *node, uint64_t *product,
-                    ncc_parse_tree_t **bad_array)
+                    bool *use_sizeof, ncc_parse_tree_t **bad_array)
 {
     if (!node || ncc_tree_is_leaf(node)) {
         return true;
@@ -452,26 +812,30 @@ array_bound_product(ncc_parse_tree_t *node, uint64_t *product,
         uint64_t count = 0;
 
         if (!bound) {
-            *bad_array = node;
-            return false;
+            *use_sizeof = true;
         }
-
-        char *text = node_text(bound);
-        bool  ok   = parse_positive_integer_literal(text, &count);
-        ncc_free(text);
-
-        if (!ok) {
-            *bad_array = node;
-            return false;
+        else {
+            char *text = node_text(bound);
+            bool  ok   = parse_positive_integer_literal(text, &count);
+            if (ok) {
+                *product *= count;
+            }
+            else if (array_bound_allows_static_sizeof(text)) {
+                *use_sizeof = true;
+            }
+            else {
+                ncc_free(text);
+                *bad_array = node;
+                return false;
+            }
+            ncc_free(text);
         }
-
-        *product *= count;
     }
 
     size_t nc = ncc_tree_num_children(node);
     for (size_t i = 0; i < nc; i++) {
         if (!array_bound_product(ncc_tree_child(node, i), product,
-                                 bad_array)) {
+                                 use_sizeof, bad_array)) {
             return false;
         }
     }
@@ -532,8 +896,13 @@ classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
         return;
     }
 
-    int  ptr_depth = count_leaf_text(declarator, "*")
-                   + count_leaf_text(declarator, "^");
+    ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+
+    if (function && strncmp(function, "ncplane_", 8) == 0) {
+        return;
+    }
+
+    int  ptr_depth = pointer_depth_in_declarator(declarator);
     bool is_array  = first_descendant_nt(declarator, "array_declarator")
                   != nullptr;
     bool aggregate = decl_specs_are_aggregate(decl_specs);
@@ -564,6 +933,10 @@ classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
 
     if (is_array) {
         if (ptr_depth > 0 && has_parenthesized_pointer_array(declarator)) {
+            if (data && data->gc_stack_maps_relaxed) {
+                ncc_free(name);
+                return;
+            }
             gc_stack_errorf(declarator,
                             "GC stack-map root '%s' in function '%s' uses a "
                             "parenthesized pointer/array declarator; spell the "
@@ -574,7 +947,13 @@ classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
 
         ncc_parse_tree_t *bad_array = nullptr;
         uint64_t          product   = 1;
-        if (!array_bound_product(declarator, &product, &bad_array)) {
+        bool              use_sizeof = false;
+        if (!array_bound_product(declarator, &product, &use_sizeof,
+                                 &bad_array)) {
+            if (data && data->gc_stack_maps_relaxed) {
+                ncc_free(name);
+                return;
+            }
             gc_stack_errorf(bad_array ? bad_array : declarator,
                             "GC stack-map root '%s' in function '%s' uses a "
                             "variable-length or incomplete array; only "
@@ -582,7 +961,7 @@ classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
                             name, function);
         }
 
-        num_words = product;
+        num_words = use_sizeof ? 0 : product;
         shape     = ptr_depth > 0 ? NCC_GC_STACK_ROOT_POINTER_ARRAY
                                   : NCC_GC_STACK_ROOT_AGGREGATE;
     }
@@ -591,13 +970,27 @@ classify_declarator(ncc_xform_ctx_t *ctx, const char *function,
         num_words = 0;
     }
 
-    if (kind == NCC_GC_STACK_ROOT_LOCAL
-        && !declaration_block_item(declarator)) {
-        gc_stack_errorf(declarator,
-                        "GC stack-map root '%s' in function '%s' is declared "
-                        "in an unsupported statement context; declare the root "
-                        "as a block item before the statement",
-                        name, function);
+    if (kind == NCC_GC_STACK_ROOT_LOCAL) {
+        ncc_parse_tree_t *anchor = declaration_block_item(declarator);
+        if (!anchor) {
+            if (data && data->gc_stack_maps_relaxed) {
+                ncc_free(name);
+                return;
+            }
+            gc_stack_errorf(declarator,
+                            "GC stack-map root '%s' in function '%s' is declared "
+                            "in an unsupported statement context; declare the root "
+                            "as a block item before the statement",
+                            name, function);
+        }
+
+        ncc_parse_tree_t *fn = ncc_xform_find_ancestor(decl_node,
+                                                       "function_definition");
+        if (block_has_case_label_item(anchor)
+            || has_forward_goto_bypassing_anchor(fn, declarator)) {
+            ncc_free(name);
+            return;
+        }
     }
 
     record_root(ctx, function, name, decl_specs, kind, shape, num_words,
@@ -711,9 +1104,24 @@ xform_gc_stack_function(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *fn)
         return nullptr;
     }
 
+    if (node_starts_in_system_header(fn) || node_has_system_header_token(fn)
+        || node_uses_computed_goto(fn)
+        || node_mentions_manual_gc_stack_api(compound)) {
+        return nullptr;
+    }
+
     char *fname = function_name(declarator);
     if (strncmp(fname, "n00b_gc_stack_", 14) == 0
-        || strncmp(fname, "__ncc_gc_stack_", 16) == 0) {
+        || strncmp(fname, "n00b_thread_", 12) == 0
+        || strncmp(fname, "_n00b_thread_", 13) == 0
+        || strncmp(fname, "n00b_capture_stack_", 18) == 0
+        || strncmp(fname, "n00b_futex_", 11) == 0
+        || strcmp(fname, "_n00b_stop_the_world") == 0
+        || strcmp(fname, "_n00b_restart_the_world") == 0
+        || strcmp(fname, "n00b_wait_for_stw_release") == 0
+        || strncmp(fname, "__ncc_gc_stack_", 16) == 0
+        || strncmp(fname, "__", 2) == 0
+        || strncmp(fname, "ncplane_", 8) == 0) {
         ncc_free(fname);
         return nullptr;
     }
@@ -868,6 +1276,12 @@ append_slot_num_words(ncc_buffer_t *buf, ncc_gc_stack_root_t *root)
         ncc_buffer_printf(buf,
                           "((sizeof(%s)+sizeof(void *)-1)/sizeof(void *))",
                           root->name);
+        return;
+    }
+
+    if (root->shape == NCC_GC_STACK_ROOT_POINTER_ARRAY
+        && root->num_words == 0) {
+        ncc_buffer_printf(buf, "(sizeof(%s)/sizeof(void *))", root->name);
         return;
     }
 

--- a/test/err_gc_stack_maps_for_init.c
+++ b/test/err_gc_stack_maps_for_init.c
@@ -1,0 +1,6 @@
+void
+bad_gc_stack_maps_for_init(void *input)
+{
+    for (void *cursor = input; cursor; cursor = 0) {
+    }
+}

--- a/test/err_gc_stack_maps_unnamed_param.c
+++ b/test/err_gc_stack_maps_unnamed_param.c
@@ -1,0 +1,4 @@
+void
+bad_gc_stack_maps_unnamed_param(int *)
+{
+}

--- a/test/err_gc_stack_maps_vla.c
+++ b/test/err_gc_stack_maps_vla.c
@@ -1,0 +1,6 @@
+void
+bad_gc_stack_maps_vla(int n, void *input)
+{
+    void *items[n];
+    items[0] = input;
+}

--- a/test/force_include_once.h
+++ b/test/force_include_once.h
@@ -1,0 +1,4 @@
+typedef struct {
+    int value;
+} ncc_force_include_once_t;
+

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -6,6 +6,8 @@
 # Modes:
 #   compile_run  — compile source, run the binary, expect exit 0
 #   preprocess   — run with -E, expect exit 0 and non-empty output
+#   preprocess_contains — run with -E, expect output to contain substring
+#   preprocess_not_contains — run with -E, expect output to omit substring
 #   no_ncc       — compile with --no-ncc, run the binary, expect exit 0
 #   expect_error — compile, expect non-zero exit
 #   expect_error_contains — compile, expect non-zero exit and stderr substring
@@ -65,6 +67,38 @@ case "$MODE" in
         OUTPUT=$("$NCC" "$@" -E "$SRC")
         if [ -z "$OUTPUT" ]; then
             echo "FAIL: -E produced empty output" >&2
+            exit 1
+        fi
+        ;;
+
+    preprocess_contains)
+        EXPECTED="$1"
+        shift || true
+        if [ -z "$EXPECTED" ]; then
+            echo "FAIL: expected output substring is required" >&2
+            exit 1
+        fi
+        "$NCC" "$@" -E "$SRC" > "$OUTBIN.c"
+        if ! grep -F -q "$EXPECTED" "$OUTBIN.c"; then
+            echo "FAIL: transformed output did not contain expected text:" \
+                 "$EXPECTED" >&2
+            cat "$OUTBIN.c" >&2
+            exit 1
+        fi
+        ;;
+
+    preprocess_not_contains)
+        UNEXPECTED="$1"
+        shift || true
+        if [ -z "$UNEXPECTED" ]; then
+            echo "FAIL: unexpected output substring is required" >&2
+            exit 1
+        fi
+        "$NCC" "$@" -E "$SRC" > "$OUTBIN.c"
+        if grep -F -q "$UNEXPECTED" "$OUTBIN.c"; then
+            echo "FAIL: transformed output contained unexpected text:" \
+                 "$UNEXPECTED" >&2
+            cat "$OUTBIN.c" >&2
             exit 1
         fi
         ;;

--- a/test/test_force_include_once.c
+++ b/test/test_force_include_once.c
@@ -1,0 +1,6 @@
+int
+main(void)
+{
+    return 0;
+}
+

--- a/test/test_gc_stack_maps_array_sizeof.c
+++ b/test/test_gc_stack_maps_array_sizeof.c
@@ -1,0 +1,21 @@
+enum {
+    GC_STACK_MAPS_COUNT = 3,
+};
+
+struct gc_stack_maps_array_sizeof_pair {
+    void *ptr;
+    int   tag;
+};
+
+void
+gc_stack_maps_array_sizeof_fixture(void *input)
+{
+    void *vecs[GC_STACK_MAPS_COUNT] = {input, input, input};
+    struct gc_stack_maps_array_sizeof_pair combos[] = {
+        {input, 1},
+        {input, 2},
+    };
+
+    (void)vecs;
+    (void)combos;
+}

--- a/test/test_gc_stack_maps_computed_goto.c
+++ b/test/test_gc_stack_maps_computed_goto.c
@@ -1,0 +1,19 @@
+int
+gc_stack_maps_computed_goto_fixture(void *input, int selector)
+{
+    void *local = input;
+    void *targets[] = {&&done, &&other};
+
+    if (selector < 0 || selector > 1) {
+        return 0;
+    }
+
+    goto *targets[selector];
+
+done:
+    return local != 0;
+
+other:
+    return local == 0;
+}
+

--- a/test/test_gc_stack_maps_control_flow.c
+++ b/test/test_gc_stack_maps_control_flow.c
@@ -47,6 +47,18 @@ struct macro_option {
 
 #define macro_wrapped_option_t(T) struct macro_option
 
+struct gc_stack_maps_exact_inner {
+    void *ptr;
+    int   scalar;
+};
+
+struct gc_stack_maps_exact_outer {
+    unsigned long                    disguised;
+    struct gc_stack_maps_exact_inner inner;
+    void                            *ptrs[2];
+    int                              tag;
+};
+
 void
 n00b_gc_stack_push(n00b_gc_stack_frame_t *frame,
                    const n00b_gc_stack_map_t *map,
@@ -268,6 +280,29 @@ gc_stack_maps_manual_api_fixture(void *input)
 }
 
 static int
+gc_stack_maps_aggregate_precision_fixture(void *live, unsigned long dead_bits)
+{
+    struct gc_stack_maps_exact_outer agg = {
+        .disguised = dead_bits,
+        .inner = {.ptr = live, .scalar = 1},
+        .ptrs = {live, 0},
+        .tag = 7,
+    };
+
+    expected = live;
+    if (!n00b_gc_stack_test_contains_expected()) {
+        return 100;
+    }
+
+    expected = (void *)dead_bits;
+    if (n00b_gc_stack_test_contains_expected()) {
+        return 101;
+    }
+
+    return agg.inner.ptr == live ? 0 : 102;
+}
+
+static int
 check_result(int rc)
 {
     if (rc != 0) {
@@ -324,6 +359,11 @@ main(void)
         return rc;
     }
     rc = check_result(gc_stack_maps_manual_api_fixture(&a));
+    if (rc) {
+        return rc;
+    }
+    rc = check_result(gc_stack_maps_aggregate_precision_fixture(&a,
+                                                               (unsigned long)&b));
     if (rc) {
         return rc;
     }

--- a/test/test_gc_stack_maps_control_flow.c
+++ b/test/test_gc_stack_maps_control_flow.c
@@ -1,0 +1,256 @@
+typedef struct {
+    unsigned long root_index;
+    unsigned long num_words;
+} n00b_gc_stack_slot_t;
+
+typedef struct {
+    unsigned long               num_roots;
+    unsigned long               num_slots;
+    const n00b_gc_stack_slot_t *slots;
+    const char                 *function_name;
+    const char                 *file_name;
+    unsigned int                line;
+} n00b_gc_stack_map_t;
+
+typedef struct n00b_gc_stack_frame_t {
+    const n00b_gc_stack_map_t  *map;
+    void                      **roots;
+    struct n00b_gc_stack_frame_t *prev;
+    int                         active;
+} n00b_gc_stack_frame_t;
+
+static n00b_gc_stack_frame_t *top_frame;
+static int pushed;
+static int popped;
+static int current_depth;
+static int bad_stack_map;
+static void *expected;
+static void *global_a;
+static void *global_b;
+
+void
+n00b_gc_stack_push(n00b_gc_stack_frame_t *frame,
+                   const n00b_gc_stack_map_t *map,
+                   void **roots)
+{
+    pushed++;
+    frame->map = map;
+    frame->roots = roots;
+    frame->prev = top_frame;
+    frame->active = 1;
+    top_frame = frame;
+    current_depth++;
+
+    if (!map || !roots || map->num_roots == 0
+        || map->num_roots != map->num_slots || !map->slots) {
+        bad_stack_map = 1;
+    }
+}
+
+void
+n00b_gc_stack_pop(n00b_gc_stack_frame_t *frame)
+{
+    popped++;
+    if (!frame || !frame->active || top_frame != frame) {
+        bad_stack_map = 1;
+        return;
+    }
+
+    top_frame = frame->prev;
+    frame->active = 0;
+    current_depth--;
+}
+
+int
+n00b_gc_stack_test_depth(void)
+{
+    return current_depth;
+}
+
+int
+n00b_gc_stack_test_contains_expected(void)
+{
+    for (n00b_gc_stack_frame_t *frame = top_frame; frame; frame = frame->prev) {
+        for (unsigned long i = 0; i < frame->map->num_slots; i++) {
+            const n00b_gc_stack_slot_t *slot = &frame->map->slots[i];
+            void **words = (void **)frame->roots[slot->root_index];
+            for (unsigned long w = 0; w < slot->num_words; w++) {
+                if (words[w] == expected) {
+                    return 1;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int
+gc_stack_maps_mutation_fixture(void)
+{
+    void *local = global_a;
+
+    expected = global_a;
+    if (!n00b_gc_stack_test_contains_expected()) {
+        return 10;
+    }
+
+    local = global_b;
+    expected = global_b;
+    if (!n00b_gc_stack_test_contains_expected()) {
+        return 11;
+    }
+
+    expected = global_a;
+    if (n00b_gc_stack_test_contains_expected()) {
+        return 12;
+    }
+
+    return local == global_b ? 0 : 13;
+}
+
+static int
+gc_stack_maps_early_return_fixture(void *input)
+{
+    void *outer = input;
+
+    {
+        void *inner = outer;
+        expected = input;
+        if (!n00b_gc_stack_test_contains_expected()) {
+            return 20;
+        }
+        return inner == input ? 0 : 21;
+    }
+}
+
+static int
+gc_stack_maps_break_fixture(void *input)
+{
+    int base = n00b_gc_stack_test_depth();
+
+    while (1) {
+        void *inner = input;
+        expected = input;
+        if (!inner || !n00b_gc_stack_test_contains_expected()) {
+            return 30;
+        }
+        break;
+    }
+
+    return n00b_gc_stack_test_depth() == base ? 0 : 31;
+}
+
+static int
+gc_stack_maps_continue_fixture(void *input)
+{
+    int base = n00b_gc_stack_test_depth();
+
+    for (int i = 0; i < 2; i++) {
+        void *inner = input;
+        expected = input;
+        if (!inner || !n00b_gc_stack_test_contains_expected()) {
+            return 40;
+        }
+        continue;
+    }
+
+    return n00b_gc_stack_test_depth() == base ? 0 : 41;
+}
+
+static int
+gc_stack_maps_switch_fixture(void *input)
+{
+    int base = n00b_gc_stack_test_depth();
+
+    switch (1) {
+    case 1: {
+        void *inner = input;
+        expected = input;
+        if (!inner || !n00b_gc_stack_test_contains_expected()) {
+            return 50;
+        }
+        break;
+    }
+    default:
+        return 51;
+    }
+
+    return n00b_gc_stack_test_depth() == base ? 0 : 52;
+}
+
+static int
+gc_stack_maps_goto_fixture(void *input)
+{
+    int base = n00b_gc_stack_test_depth();
+
+    {
+        void *inner = input;
+        expected = input;
+        if (!inner || !n00b_gc_stack_test_contains_expected()) {
+            return 60;
+        }
+        goto out;
+    }
+
+    return 61;
+
+out:
+    return n00b_gc_stack_test_depth() == base ? 0 : 62;
+}
+
+static int
+check_result(int rc)
+{
+    if (rc != 0) {
+        return rc;
+    }
+    if (bad_stack_map) {
+        return 90;
+    }
+    if (n00b_gc_stack_test_depth() != 0) {
+        return 91;
+    }
+    if (pushed != popped) {
+        return 92;
+    }
+    return 0;
+}
+
+int
+main(void)
+{
+    int a = 1;
+    int b = 2;
+    int rc = 0;
+
+    global_a = &a;
+    global_b = &b;
+
+    rc = check_result(gc_stack_maps_mutation_fixture());
+    if (rc) {
+        return rc;
+    }
+    rc = check_result(gc_stack_maps_early_return_fixture(&a));
+    if (rc) {
+        return rc;
+    }
+    rc = check_result(gc_stack_maps_break_fixture(&a));
+    if (rc) {
+        return rc;
+    }
+    rc = check_result(gc_stack_maps_continue_fixture(&a));
+    if (rc) {
+        return rc;
+    }
+    rc = check_result(gc_stack_maps_switch_fixture(&a));
+    if (rc) {
+        return rc;
+    }
+    rc = check_result(gc_stack_maps_goto_fixture(&a));
+    if (rc) {
+        return rc;
+    }
+
+    return 0;
+}

--- a/test/test_gc_stack_maps_control_flow.c
+++ b/test/test_gc_stack_maps_control_flow.c
@@ -28,6 +28,25 @@ static void *expected;
 static void *global_a;
 static void *global_b;
 
+static const n00b_gc_stack_slot_t manual_slots[] = {
+    {.root_index = 0, .num_words = 1},
+};
+
+static const n00b_gc_stack_map_t manual_map = {
+    .num_roots     = 1,
+    .num_slots     = 1,
+    .slots         = manual_slots,
+    .function_name = "manual",
+    .file_name     = __FILE__,
+};
+
+struct macro_option {
+    void *value;
+    int   has_value;
+};
+
+#define macro_wrapped_option_t(T) struct macro_option
+
 void
 n00b_gc_stack_push(n00b_gc_stack_frame_t *frame,
                    const n00b_gc_stack_map_t *map,
@@ -200,6 +219,55 @@ out:
 }
 
 static int
+gc_stack_maps_forward_goto_fixture(void *input)
+{
+    int base = n00b_gc_stack_test_depth();
+
+    goto add_arg;
+
+    void *skipped = input;
+    if (skipped) {
+        return 70;
+    }
+
+    macro_wrapped_option_t(unsigned long) macro_skipped =
+        (struct macro_option){.value = input, .has_value = input != 0};
+    if (macro_skipped.has_value) {
+        return 73;
+    }
+
+add_arg:;
+    {
+        void *after = input;
+        expected = input;
+        if (!after || !n00b_gc_stack_test_contains_expected()) {
+            return 71;
+        }
+    }
+
+    return n00b_gc_stack_test_depth() == base ? 0 : 72;
+}
+
+static int
+gc_stack_maps_manual_api_fixture(void *input)
+{
+    int base = n00b_gc_stack_test_depth();
+
+    void                 *local = input;
+    void                 *roots[] = {&local};
+    n00b_gc_stack_frame_t frame;
+
+    n00b_gc_stack_push(&frame, &manual_map, roots);
+    expected = input;
+    if (!local || !n00b_gc_stack_test_contains_expected()) {
+        return 80;
+    }
+    n00b_gc_stack_pop(&frame);
+
+    return n00b_gc_stack_test_depth() == base ? 0 : 81;
+}
+
+static int
 check_result(int rc)
 {
     if (rc != 0) {
@@ -248,6 +316,14 @@ main(void)
         return rc;
     }
     rc = check_result(gc_stack_maps_goto_fixture(&a));
+    if (rc) {
+        return rc;
+    }
+    rc = check_result(gc_stack_maps_forward_goto_fixture(&a));
+    if (rc) {
+        return rc;
+    }
+    rc = check_result(gc_stack_maps_manual_api_fixture(&a));
     if (rc) {
         return rc;
     }

--- a/test/test_gc_stack_maps_empty_body.c
+++ b/test/test_gc_stack_maps_empty_body.c
@@ -1,0 +1,4 @@
+void
+gc_stack_maps_empty_body_fixture(void *input)
+{
+}

--- a/test/test_gc_stack_maps_flag.c
+++ b/test/test_gc_stack_maps_flag.c
@@ -1,0 +1,6 @@
+int
+gc_stack_maps_flag_fixture(int *input)
+{
+    int *local = input;
+    return local ? *local : 0;
+}

--- a/test/test_gc_stack_maps_function_pointer.c
+++ b/test/test_gc_stack_maps_function_pointer.c
@@ -1,0 +1,7 @@
+void
+gc_stack_maps_function_pointer_fixture(void *(*fn)(void *), void *arg)
+{
+    (void)fn;
+    (void)arg;
+}
+

--- a/test/test_gc_stack_maps_qualified_pointer.c
+++ b/test/test_gc_stack_maps_qualified_pointer.c
@@ -1,0 +1,6 @@
+void
+gc_stack_maps_qualified_pointer_fixture(int *const state)
+{
+    (void)state;
+}
+

--- a/test/test_gc_stack_maps_roots.c
+++ b/test/test_gc_stack_maps_roots.c
@@ -1,0 +1,23 @@
+struct gc_stack_maps_box {
+    void *ptr;
+    int   tag;
+};
+
+void
+gc_stack_maps_roots_fixture(void *param,
+                            int *items,
+                            struct gc_stack_maps_box box_param)
+{
+    void *local = param;
+    void *slots[3] = {param, items, local};
+    struct gc_stack_maps_box box = {.ptr = local, .tag = 1};
+
+    {
+        int *nested = items;
+        (void)nested;
+    }
+
+    (void)slots;
+    (void)box;
+    (void)box_param;
+}

--- a/test/test_gc_stack_maps_roots.c
+++ b/test/test_gc_stack_maps_roots.c
@@ -1,7 +1,38 @@
+typedef struct gc_stack_maps_inner {
+    void *inner;
+    int   count;
+} gc_stack_maps_inner_t;
+
+typedef struct gc_stack_maps_atomic_store {
+    void *next;
+    int   generation;
+} gc_stack_maps_atomic_store_t;
+
+typedef _Atomic(gc_stack_maps_atomic_store_t) gc_stack_maps_atomic_cell_t;
+
+typedef void (*gc_stack_maps_predicate_t)(void);
+
 struct gc_stack_maps_box {
-    void *ptr;
-    int   tag;
+    void                  *ptr;
+    int                    tag;
+    gc_stack_maps_inner_t  nested;
+    void                  *ptrs[2];
 };
+
+typedef struct gc_stack_maps_filter {
+    gc_stack_maps_predicate_t predicate;
+    void                     *ctx;
+} gc_stack_maps_filter_t;
+
+typedef struct gc_stack_maps_flexible_tail {
+    void *known;
+    void *opaque[];
+} gc_stack_maps_flexible_tail_t;
+
+typedef struct gc_stack_maps_atomic_holder {
+    _Atomic(gc_stack_maps_atomic_store_t *) store;
+    void                                   *scan_user;
+} gc_stack_maps_atomic_holder_t;
 
 void
 gc_stack_maps_roots_fixture(void *param,
@@ -10,7 +41,23 @@ gc_stack_maps_roots_fixture(void *param,
 {
     void *local = param;
     void *slots[3] = {param, items, local};
-    struct gc_stack_maps_box box = {.ptr = local, .tag = 1};
+    struct gc_stack_maps_box box = {
+        .ptr = local,
+        .tag = 1,
+        .nested = {.inner = items, .count = 2},
+        .ptrs = {param, items},
+    };
+    gc_stack_maps_atomic_holder_t holder = {
+        .store     = (gc_stack_maps_atomic_store_t *)0,
+        .scan_user = local,
+    };
+    gc_stack_maps_filter_t filters[] = {
+        {0, param},
+    };
+    gc_stack_maps_flexible_tail_t flex = {
+        .known = param,
+    };
+    gc_stack_maps_atomic_cell_t atomic_store;
 
     {
         int *nested = items;
@@ -20,4 +67,8 @@ gc_stack_maps_roots_fixture(void *param,
     (void)slots;
     (void)box;
     (void)box_param;
+    (void)holder;
+    (void)filters;
+    (void)flex;
+    (void)atomic_store;
 }

--- a/test/test_gc_stack_maps_runtime.c
+++ b/test/test_gc_stack_maps_runtime.c
@@ -1,0 +1,105 @@
+#pragma ncc off
+typedef struct {
+    unsigned long root_index;
+    unsigned long num_words;
+} n00b_gc_stack_slot_t;
+
+typedef struct {
+    unsigned long                 num_roots;
+    unsigned long                 num_slots;
+    const n00b_gc_stack_slot_t   *slots;
+    const char                   *function_name;
+    const char                   *file_name;
+    unsigned int                  line;
+} n00b_gc_stack_map_t;
+
+typedef struct {
+    const n00b_gc_stack_map_t *map;
+    void                    **roots;
+    int                       active;
+} n00b_gc_stack_frame_t;
+
+static int pushed;
+static int popped;
+static int bad_stack_map;
+
+void
+n00b_gc_stack_push(n00b_gc_stack_frame_t *frame,
+                   const n00b_gc_stack_map_t *map,
+                   void **roots)
+{
+    pushed++;
+    frame->map = map;
+    frame->roots = roots;
+    frame->active = 1;
+
+    if (!map || !roots || map->num_roots == 0
+        || map->num_roots != map->num_slots || !map->slots
+        || !map->function_name || !map->file_name || map->line == 0) {
+        bad_stack_map = 1;
+        return;
+    }
+
+    for (unsigned long i = 0; i < map->num_roots; i++) {
+        if (!roots[i] || map->slots[i].root_index != i
+            || map->slots[i].num_words == 0) {
+            bad_stack_map = 1;
+        }
+    }
+}
+
+void
+n00b_gc_stack_pop(n00b_gc_stack_frame_t *frame)
+{
+    popped++;
+    if (!frame || !frame->active) {
+        bad_stack_map = 1;
+        return;
+    }
+    frame->active = 0;
+}
+#pragma ncc on
+
+struct gc_stack_runtime_box {
+    void *ptr;
+    int   tag;
+};
+
+static int
+gc_stack_maps_runtime_fixture(void *input)
+{
+    void *local = input;
+    void *slots[2] = {local, input};
+    struct gc_stack_runtime_box box = {.ptr = local, .tag = 7};
+
+    {
+        void *nested = box.ptr;
+        if (nested != input) {
+            return 10;
+        }
+    }
+
+    return slots[0] == input ? 0 : 11;
+}
+
+int
+main(void)
+{
+    int marker = 0;
+    int rc = gc_stack_maps_runtime_fixture(&marker);
+
+    if (rc != 0) {
+        return rc;
+    }
+    if (bad_stack_map) {
+        return 20;
+    }
+    if (pushed != popped) {
+        return 21;
+    }
+    if (pushed < 5) {
+        return 22;
+    }
+
+    return 0;
+}

--- a/test/test_gc_stack_maps_scalar_array.c
+++ b/test/test_gc_stack_maps_scalar_array.c
@@ -1,0 +1,6 @@
+void
+gc_stack_maps_scalar_array_fixture(void)
+{
+    int values[3] = {1, 2, 3};
+    (void)values;
+}

--- a/test/test_gc_stack_maps_system_header.c
+++ b/test/test_gc_stack_maps_system_header.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int
+gc_stack_maps_system_header_fixture(FILE *file)
+{
+    return file != NULL;
+}
+

--- a/test/test_gc_stack_maps_thread_runtime_skip.c
+++ b/test/test_gc_stack_maps_thread_runtime_skip.c
@@ -1,0 +1,50 @@
+void *sink;
+
+void
+n00b_thread_init(void *arg)
+{
+    void *local = arg;
+    sink = local;
+}
+
+void
+n00b_thread_destroy(void *arg)
+{
+    void *local = arg;
+    sink = local;
+}
+
+void
+n00b_capture_stack_top(void *arg)
+{
+    void *local = arg;
+    sink = local;
+}
+
+void
+_n00b_thread_suspend(void *arg)
+{
+    void *local = arg;
+    sink = local;
+}
+
+void
+_n00b_stop_the_world(void *arg)
+{
+    void *local = arg;
+    sink = local;
+}
+
+void
+n00b_wait_for_stw_release(void *arg)
+{
+    void *local = arg;
+    sink = local;
+}
+
+void
+n00b_futex_wait_timespec(void *arg)
+{
+    void *local = arg;
+    sink = local;
+}


### PR DESCRIPTION
## Summary

- add precise n00b GC stack-map emission for pointer, pointer-array, and pointer-bearing aggregate stack roots
- expand aggregate roots to pointer-bearing field slots, including nested aggregates and fixed aggregate arrays
- handle n00b compatibility cases for atomic aggregate typedefs, flexible array members, system-header functions, and direct cleanup-backed frame pops
- document the stack-map contract and supported/unsupported shapes in README

## Validation

- `SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk meson test -C build --print-errorlogs --suite ncc` passed 92/92
- `scan-build --status-bugs -o /private/tmp/ncc-scan-build meson compile -C build` found no bugs
- `clang-tidy src/xform/xform_gc_stack_maps.c ...` found no remaining stack-map path correctness/security warnings after audit fixes; remaining output is existing project-wide style/CERT noise
- downstream n00b clean rebuild with `NCC_PATH=/Users/viega/ncc/.workspaces/gc-stack-maps/build/ncc` completed
- downstream focused n00b GC/runtime tests passed 9/9: `gc_stack`, `gc_scan_map`, `gc_selective_scan`, `gc`, `stw`, `finalizer`, `arena_alloc`, `pool_alloc`, `alloc_metadata`

## Audit Disposition

- fixed analyzer-found prefix bug by replacing hand-counted `strncmp` skip checks with `cstr_has_prefix()`
- marked `gc_stack_errorf()` as `[[noreturn]]` so static analysis can reason about diagnostic exits
- accepted remaining deferrals for future WPs: last-use liveness, non-local exits, static-object migration, arbitrary uninstrumented C boundaries, and union active-member precision