### PR TITLE
WP-020: emit GC typemap and index sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,24 @@ macro shape and selected GC/STW runtime primitives as reserved runtime
 mechanics; ordinary parser/error unwinds through raw libc calls are not
 accepted.
 
+### n00b GC Typemaps
+
+ncc also emits link-time GC layout metadata for n00b typed heap allocations.
+When ncc sees `typehash(T *)` and can prove the layout of `T`, it appends a
+`n00b_gcmap` entry keyed by that type hash plus a `n00b_gcidx` placeholder.
+n00b's post-link `n00b-gcmap-index` command fills the index in the final
+executable. At runtime, n00b uses the indexed map to upgrade default-scanned
+`n00b_alloc(T)` and `n00b_alloc_array(T, N)` objects to precise callback scans.
+
+There is no separate ncc flag for normal n00b builds; the allocation macros
+already contain the necessary `typehash(T *)` sites. The type must be visible
+enough for ncc to enumerate every data-pointer word. Ambiguous shapes, such as
+mixed pointer/scalar unions or pointer arrays, are skipped so the runtime keeps
+the conservative fallback.
+
+For the detailed ncc contract, see `docs/gc_typemaps.md`. For the n00b
+post-link command, see `docs/gc_type_maps.md` in the n00b repository.
+
 
 ## Customization
 

--- a/docs/gc_typemaps.md
+++ b/docs/gc_typemaps.md
@@ -1,0 +1,134 @@
+# GC Typemaps for n00b Allocations
+
+This page documents the ncc side of n00b heap allocation type maps. It is for
+people compiling n00b-integrated C code with ncc, and for embedding runtimes
+that provide the same GC metadata ABI.
+
+## What ncc Emits
+
+When ncc transforms a translation unit, every `typehash(T *)` expression is
+also treated as a possible request for a GC layout record for `T`. If ncc can
+prove the layout of `T` precisely enough, it appends file-scope C declarations
+for:
+
+- a `n00b_gc_struct_layout_t` describing the pointer-word offsets in one `T`;
+- a `n00b_gc_type_map_entry_t` in the `n00b_gcmap` linker section, keyed by
+  the exact `typehash(T *)` value;
+- a matching `n00b_gc_type_map_index_entry_t` placeholder in the `n00b_gcidx`
+  linker section.
+
+The `n00b_gcmap` entry contains a relocated pointer to the layout descriptor.
+The `n00b_gcidx` entry intentionally contains no pointers. n00b's post-link
+indexing tool fills and sorts only `n00b_gcidx`, so it does not disturb linker
+fixups in the pointer-bearing `n00b_gcmap` section.
+
+For normal n00b code there is no separate source annotation or ncc flag. The
+allocation macros already pass `typehash(T *)` to the runtime:
+
+```c
+typedef struct widget_t {
+    n00b_string_t *name;
+    uint64_t       count;
+} widget_t;
+
+widget_t *one = n00b_alloc(widget_t);
+widget_t *many = n00b_alloc_array(widget_t, 16);
+```
+
+Those macro expansions create the `typehash(widget_t *)` sites that let ncc
+emit the matching type map entry.
+
+## Runtime Effect
+
+The linked binary must be indexed with `n00b-gcmap-index` before execution.
+At runtime, `_n00b_alloc_raw()` uses the allocation's `typehash(T *)` to look
+up a layout. If a valid indexed entry exists and the caller did not specify a
+custom scan policy, the allocation is upgraded from conservative `DEFAULT`
+scanning to `CALLBACK` scanning with `n00b_gc_scan_cb_type_layout`.
+
+This has two visible effects:
+
+- The GC scans only the pointer fields ncc proved are real heap edges.
+- Marshal can round-trip these heap objects using an explicit callback-scan
+  record instead of rejecting or over-scanning the allocation shape.
+
+If no entry exists, or if the final executable was not indexed, n00b falls back
+to the old conservative `DEFAULT` behavior. That fallback is GC-safe, but it is
+less precise and may be insufficient for marshal workflows that require exact
+pointer layout.
+
+## Eligible Types
+
+ncc is intentionally conservative. It emits a type map only when it can describe
+every GC pointer word without guessing.
+
+Eligible `typehash()` shapes:
+
+- `typehash(T *)` for one pointer level to `T`;
+- file-scope-visible aggregate definitions;
+- scalar or no-pointer types, which produce a zero-pointer layout;
+- structs with direct data-pointer fields;
+- structs with nested by-value structs whose layouts are fully visible;
+- structs with function-pointer fields, which are skipped because code
+  pointers are not GC heap edges;
+- unions whose active storage is always pointer-shaped or always scalar.
+
+Skipped shapes:
+
+- `void *`, `T **`, pointer arrays, and top-level atomic pointer hashes;
+- block-local typedefs or tags that would be out of scope for appended
+  file-scope declarations;
+- unresolved or incomplete aggregate types;
+- data-pointer arrays and aggregate arrays;
+- unions that mix pointer and non-pointer alternatives;
+- aggregate layouts requiring more than the internal safety cap for emitted
+  pointer offsets.
+
+ncc also recognizes a n00b runtime-scan struct shape containing
+`n00b_gc_scan_kind_t scan_kind`, `n00b_gc_scan_cb_t scan_cb`, and pointer
+`scan_user`. For that exact shape, runtime infrastructure fields such as
+`scan_cb`, `scan_user`, `lock`, and `allocator` are skipped while ordinary
+payload pointers are still mapped.
+
+## Build Requirements
+
+The generated declarations reference the n00b GC metadata ABI:
+
+- `n00b_gc_struct_layout_t`
+- `n00b_gc_type_map_entry_t`
+- `n00b_gc_type_map_index_entry_t`
+- the platform section attributes for `n00b_gcmap` and `n00b_gcidx`
+
+n00b builds provide these through the normal n00b headers. If another runtime
+embeds ncc and wants this feature, it must provide compatible declarations and
+must run an equivalent post-link index pass.
+
+The n00b build script wires this up for n00b targets. For manual builds, invoke
+the built `n00b-gcmap-index` tool after the final link:
+
+```sh
+ncc -c module.c
+cc module.o -o app
+path/to/n00b-gcmap-index app
+./app
+```
+
+For test runners or one-shot execution,
+`path/to/n00b-gcmap-index --exec app [args...]` indexes in place and then
+`execv()`s the program.
+
+## Inspecting Output
+
+Use ncc's transformed-source output when debugging an emitted map:
+
+```sh
+ncc -E module.c
+```
+
+Look near the end of the emitted C for declarations named
+`__ncc_gcmap_lay_*`, `__ncc_gcmap_ent_*`, and `__ncc_gcidx_ent_*`.
+Missing declarations mean ncc skipped the type because the shape was not a
+safe candidate.
+
+For the n00b-side post-link tool and runtime lookup behavior, see the n00b
+repository's `docs/gc_type_maps.md`.

--- a/docs/static_objects_pipeline.md
+++ b/docs/static_objects_pipeline.md
@@ -210,6 +210,45 @@ error: dict literal initializer for 'n00b_dict_t(int, int)' requires
        --ncc-static-init-helper=PATH
 ```
 
+## GC typemaps for typed allocations
+
+In n00b-integrated builds, ncc automatically turns eligible
+`typehash(T *)` sites into link-time GC layout metadata. This is what lets
+ordinary runtime allocations such as `n00b_alloc(T)` and
+`n00b_alloc_array(T, N)` be scanned with the same field precision as
+descriptor-backed static objects.
+
+No extra source annotation is needed. The n00b allocation macros already
+contain the necessary `typehash(T *)` expression. If `T` is visible at file
+scope and ncc can prove every pointer word in the type, ncc emits:
+
+- a `n00b_gc_struct_layout_t` for one element of `T`;
+- a pointer-bearing `n00b_gcmap` section entry keyed by `typehash(T *)`;
+- a no-pointer `n00b_gcidx` placeholder that the final binary indexes after
+  link.
+
+The final executable must be processed by n00b's `n00b-gcmap-index` command.
+The n00b build does this for the affected helper binaries and test wrappers.
+Manual builds should run:
+
+```sh
+path/to/n00b-gcmap-index path/to/executable
+```
+
+or execute through:
+
+```sh
+path/to/n00b-gcmap-index --exec path/to/executable [args...]
+```
+
+If no map entry is available, or if the executable was not indexed, n00b falls
+back to conservative default scanning. That fallback is GC-safe but less
+precise and may not be enough for marshal workflows that need exact pointer
+layout.
+
+For the full ncc-side eligibility rules, see `docs/gc_typemaps.md`. For the
+n00b post-link tool, see `docs/gc_type_maps.md` in the n00b repository.
+
 ---
 
 # Part 2 — Contributor Notes

--- a/include/xform/xform_data.h
+++ b/include/xform/xform_data.h
@@ -66,6 +66,9 @@ typedef struct {
     ncc_dict_t                 dict_types;
     ncc_dict_t                 gc_aggregate_types;
     ncc_dict_t                 gc_pointer_typedefs;
+    // Subset of gc_pointer_typedefs that are FUNCTION pointers (code, not
+    // heap). The gc-typemap walker excludes these from GC pointer maps.
+    ncc_dict_t                 gc_function_pointer_typedefs;
     ncc_template_registry_t   *template_reg;
     const char                *vargs_type;
     const char                *once_prefix;

--- a/include/xform/xform_gc_typemap.h
+++ b/include/xform/xform_gc_typemap.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// WP-020 / D-049: emit per-type GC pointer-map descriptors for the link-time
+// type->GC-map dictionary (libn00b's pointer-bearing `n00b_gcmap` section plus
+// the post-link-filled no-pointer `n00b_gcidx` search index). The hash key is
+// recorded from `typehash(AGG *)` sites so it matches the alloc-site
+// `typehash(T*)` byte-for-byte (same computation), and the pointer-offset
+// layout is emitted with `__builtin_offsetof` (the C compiler does the
+// arithmetic; we only emit field paths for pointer members).
+
+#include "xform/transform.h"
+
+#include <stdint.h>
+
+// Record a typehash occurrence (called from xform_typehash). `type_str` is the
+// normalized full type string the hash was computed from (e.g.
+// "n00b_nonterm_t*"); `hash` is that typehash. A no-op unless `type_str` names
+// a single pointer to an aggregate type whose full definition is known in this
+// TU. Idempotent per hash.
+void ncc_gc_typemap_note(ncc_xform_ctx_t *ctx,
+                         const char     *type_str,
+                         uint64_t        hash);
+
+// Emit the C text (descriptors + n00b_gcmap section entries) for everything
+// recorded this TU. Returns a heap string (caller frees) — empty if nothing
+// qualifies. Drains the accumulator. Call after ncc_xform_apply, before the
+// transform dicts are freed.
+char *ncc_gc_typemap_emit(ncc_xform_ctx_t *ctx);

--- a/include/xform/xform_type_layout.h
+++ b/include/xform/xform_type_layout.h
@@ -65,6 +65,7 @@ int ncc_layout_pointer_depth_for_specs(ncc_xform_ctx_t *ctx,
 int ncc_layout_pointer_depth_for_declarator(ncc_xform_ctx_t *ctx,
                                             ncc_parse_tree_t *specs,
                                             ncc_parse_tree_t *declarator);
+bool ncc_layout_declarator_is_function_pointer(ncc_parse_tree_t *declarator);
 
 bool ncc_layout_struct_or_union_is_union(ncc_parse_tree_t *su);
 bool ncc_layout_aggregate_specifier_has_members(ncc_parse_tree_t *su);
@@ -88,5 +89,9 @@ char *ncc_layout_implicit_member_field_name(ncc_parse_tree_t *member,
 
 bool ncc_layout_typedef_name_is_pointer(ncc_xform_ctx_t *ctx,
                                         const char *name);
+// True if `name` is a typedef for a FUNCTION pointer (code pointer). Used to
+// exclude such fields from GC pointer maps.
+bool ncc_layout_typedef_name_is_function_pointer(ncc_xform_ctx_t *ctx,
+                                                 const char *name);
 void ncc_layout_collect_type_info(ncc_xform_ctx_t *ctx,
                                   ncc_parse_tree_t *tu);

--- a/meson.build
+++ b/meson.build
@@ -203,6 +203,7 @@ src_xform = files(
   'src/xform/xform_typestr.c',
   'src/xform/xform_typehash.c',
   'src/xform/xform_template.c',
+  'src/xform/xform_gc_typemap.c',
 )
 
 src_scanner = files(
@@ -528,6 +529,174 @@ test('ncc_static_image_dependency_contract', test_runner,
          + ncc_test_flags + static_image_helper_flags,
   suite : 'ncc',
   depends : [ncc_exe, static_image_helper],
+)
+
+test('ncc_gc_typemap_direct_pointer_offset', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_direct_fn_t,payload)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_direct_function_pointer_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_direct_fn_t,callback)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_typedef_pointer_offset', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_typedef_fn_t,payload)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_typedef_function_pointer_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_typedef_fn_t,callback)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_user_scan_user_scanned', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_user_scan_field_t,scan_user)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_runtime_scan_user_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_runtime_shape_t,scan_user)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_runtime_lock_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_runtime_shape_t,lock)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_runtime_allocator_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_runtime_shape_t,allocator)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_runtime_payload_scanned', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_runtime_shape_t,payload)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_runtime_near_miss_scan_user_scanned', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_runtime_near_miss_t,scan_user)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_static_assert_c23', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          'static_assert((__builtin_offsetof(gcmap_direct_fn_t,payload)%sizeof(void*))==0']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_no_legacy_static_assert', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          '_Static_assert']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_section_attr_c23', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          '[[gnu::section("n00b_gcmap"), gnu::used]]']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_legacy_section_attr_rewritten_c23', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          '[[gnu::section("__DATA,n00b_gcmap"), gnu::used]]']
+         + ncc_test_flags
+         + ['--ncc-no-gc-stack-maps',
+            '--ncc-no-auto-gc-roots',
+            '--ncc-static-object-entry-attr=__attribute__((section("__DATA,n00b_stobj"),used))'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_legacy_section_attr_no_legacy_attribute', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__attribute__((section("__DATA,n00b_gcmap")']
+         + ncc_test_flags
+         + ['--ncc-no-gc-stack-maps',
+            '--ncc-no-auto-gc-roots',
+            '--ncc-static-object-entry-attr=__attribute__((section("__DATA,n00b_stobj"),used))'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_gcidx_entry', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__ncc_gcidx_ent_']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_pointer_array_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          'sizeof(gcmap_pointer_array_t)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_union_mixed_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          'sizeof(gcmap_union_mixed_t)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
 )
 
 if host_machine.system() != 'windows' and cc.has_header('pthread.h')

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -38,6 +38,7 @@
 #include "parse/typedef_walk.h"
 #include "parse/c_tokenizer.h"
 #include "parse/emit.h"
+#include "xform/xform_gc_typemap.h"
 #include "parse/tree_dump.h"
 #include "xform/transform.h"
 #include "xform/xform_template.h"
@@ -2229,6 +2230,8 @@ compile_file(ncc_opts_t *opts)
                             ncc_hash_cstring, ncc_dict_cstr_eq);
     ncc_dict_init(&xdata.gc_pointer_typedefs,
                             ncc_hash_cstring, ncc_dict_cstr_eq);
+    ncc_dict_init(&xdata.gc_function_pointer_typedefs,
+                            ncc_hash_cstring, ncc_dict_cstr_eq);
     xctx.user_data = &xdata;
     ncc_verbose("applying transforms");
     tree = ncc_xform_apply(&xreg, &xctx);
@@ -2236,6 +2239,12 @@ compile_file(ncc_opts_t *opts)
     if (xctx.nodes_replaced > 0) {
         ncc_verbose("transforms: %d nodes replaced", xctx.nodes_replaced);
     }
+
+    // WP-020 / D-049: emit link-time GC pointer-map descriptors for the
+    // pointer-to-aggregate types this TU typehash'd. Must run before the
+    // transform dicts (gc_aggregate_types) are freed below; appended to the
+    // pretty-printed output further down.
+    char *gc_typemap_text = ncc_gc_typemap_emit(&xctx);
 
 #ifdef NCC_MEM_DEBUG
     ncc_mem_report("after transform");
@@ -2249,6 +2258,7 @@ compile_file(ncc_opts_t *opts)
     ncc_dict_free(&xdata.dict_types);
     ncc_dict_free(&xdata.gc_aggregate_types);
     ncc_dict_free(&xdata.gc_pointer_typedefs);
+    ncc_dict_free(&xdata.gc_function_pointer_typedefs);
     free_gc_stack_roots(xdata.gc_stack_roots);
     ncc_template_registry_free(&tmpl_reg);
     ncc_xform_registry_free(&xreg);
@@ -2273,6 +2283,20 @@ compile_file(ncc_opts_t *opts)
         ncc_scanner_free(scanner);
         ncc_grammar_free(g);
         return 1;
+    }
+
+    // Append the GC pointer-map descriptors (valid C at TU end: the element
+    // types were typehash'd here and their definitions appear above).
+    if (gc_typemap_text && gc_typemap_text[0]) {
+        size_t base = emitted.u8_bytes;
+        size_t add  = strlen(gc_typemap_text);
+        char  *combined = (char *)malloc(base + add + 2);
+        memcpy(combined, emitted.data, base);
+        combined[base] = '\n';
+        memcpy(combined + base + 1, gc_typemap_text, add);
+        combined[base + 1 + add] = '\0';
+        emitted.data     = combined;
+        emitted.u8_bytes = base + 1 + add;
     }
 
     size_t emit_len = emitted.u8_bytes;

--- a/src/xform/xform_gc_typemap.c
+++ b/src/xform/xform_gc_typemap.c
@@ -657,6 +657,25 @@ walk_union(ncc_xform_ctx_t *ctx, const char *elem_type,
     }
 
     if (any_complex || (first_ptr && any_scalar)) {
+        // The union can't be statically described as all-pointer or
+        // all-scalar, so the whole type gets NO precise GC pointer-map and
+        // silently falls back to conservative scanning. That conservative
+        // scan can misread a scalar union payload (e.g. a packed {min,max}
+        // like 0x100000000) as a pointer, which makes the type
+        // unmarshalable at runtime. Warn (don't fail) so the build still
+        // completes but every offending type is surfaced; the fix is to
+        // split the union into separate pointer / non-pointer fields.
+        fprintf(stderr,
+                "ncc: warning: gc-typemap: type '%s' has a union that cannot "
+                "be statically described for GC scanning (%s); the type loses "
+                "its precise pointer map and falls back to conservative scan "
+                "(not precisely marshalable). Split the union into separate "
+                "pointer and non-pointer fields.\n",
+                elem_type ? elem_type : "(anonymous)",
+                any_complex
+                    ? "a member is a by-value aggregate, an unnamed pointer, "
+                      "or a non-function-pointer array"
+                    : "it mixes pointer and non-pointer members");
         *ok = false; // can't statically describe this union
     }
     else if (first_ptr && !any_scalar) {

--- a/src/xform/xform_gc_typemap.c
+++ b/src/xform/xform_gc_typemap.c
@@ -1,0 +1,950 @@
+// xform_gc_typemap.c — WP-020 / D-049 link-time type->GC-map emission.
+//
+// For every `typehash(AGG *)` of a (single) pointer to a fully-defined
+// aggregate, emit a precise per-element pointer-map descriptor, a pointer-
+// bearing `n00b_gcmap` section entry keyed by that exact typehash, and a
+// no-pointer `n00b_gcidx` placeholder. A post-link pass fills/sorts only
+// `n00b_gcidx`; libn00b's `_n00b_alloc_raw` binary-searches that index to
+// upgrade DEFAULT-scanned typed allocations to a precise CALLBACK scan, which
+// makes them marshalable.
+//
+// Correctness: the walker is CONSERVATIVE. It emits a map only when it is
+// certain it has found EVERY pointer word in the element type; on any
+// uncertainty it marks the type unhandled (no entry → the allocation keeps its
+// conservative DEFAULT scan, which is always GC-safe — never an UNDER-scan).
+// A by-value (non-pointer) aggregate member must be a complete type in this TU
+// (C rule), so ncc can always resolve it; a non-pointer member that does not
+// resolve to a known aggregate is therefore a scalar with no pointer words.
+//
+// Offsets are emitted as `__builtin_offsetof` expressions: the C compiler does
+// the arithmetic, so this never hand-computes a struct offset.
+
+#include "lib/alloc.h"
+#include "lib/buffer.h"
+#include "util/type_normalize.h"
+#include "xform/xform_data.h"
+#include "xform/xform_gc_typemap.h"
+#include "xform/xform_helpers.h"
+#include "xform/xform_type_layout.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+// ---------------------------------------------------------------------------
+// Per-TU accumulator (ncc runs one translation unit per process invocation).
+// ---------------------------------------------------------------------------
+
+typedef struct {
+    uint64_t hash;
+    char    *elem_type; // typedef/tag spelling used at the typehash site
+} gc_typemap_record_t;
+
+static gc_typemap_record_t *records   = nullptr;
+static size_t               record_len = 0;
+static size_t               record_cap = 0;
+
+static bool
+record_seen(uint64_t hash)
+{
+    for (size_t i = 0; i < record_len; i++) {
+        if (records[i].hash == hash) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool
+elem_type_is_scalar_no_ptr(const char *elem_type)
+{
+    static const char *const scalar_types[] = {
+        "_Bool",
+        "bool",
+        "char",
+        "signed char",
+        "unsigned char",
+        "short",
+        "short int",
+        "signed short",
+        "signed short int",
+        "unsigned short",
+        "unsigned short int",
+        "int",
+        "signed int",
+        "unsigned int",
+        "long",
+        "long int",
+        "signed long",
+        "signed long int",
+        "unsigned long",
+        "unsigned long int",
+        "long long",
+        "long long int",
+        "signed long long",
+        "signed long long int",
+        "unsigned long long",
+        "unsigned long long int",
+        "float",
+        "double",
+        "long double",
+        "int8_t",
+        "uint8_t",
+        "int16_t",
+        "uint16_t",
+        "int32_t",
+        "uint32_t",
+        "int64_t",
+        "uint64_t",
+        "intptr_t",
+        "uintptr_t",
+        "ptrdiff_t",
+        "size_t",
+        "ssize_t",
+        "n00b_size_t",
+        "n00b_isize_t",
+        "n00b_futex_t",
+        "n00b_utf8_t",
+        "n00b_codepoint_t",
+    };
+
+    if (!elem_type || strchr(elem_type, '*') != nullptr) {
+        return false;
+    }
+
+    for (size_t i = 0; i < sizeof(scalar_types) / sizeof(scalar_types[0]); i++) {
+        if (strcmp(elem_type, scalar_types[i]) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool
+aggregate_type_is_file_visible(ncc_layout_aggregate_type_info_t *info)
+{
+    if (!info || !info->specifier) {
+        return false;
+    }
+
+    // The gcmap descriptors are appended at file scope after the transformed
+    // translation unit. Block-local typedefs/tags are out of scope there, so
+    // any descriptor that names them would make the generated C invalid.
+    return ncc_xform_find_ancestor(info->specifier, "compound_statement") == nullptr
+        && ncc_xform_find_ancestor(info->specifier, "function_definition") == nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Field-path + offset-expression helpers.
+// ---------------------------------------------------------------------------
+
+static char *
+path_join(const char *base, const char *name)
+{
+    if (base && *base) {
+        return ncc_layout_format_cstr("%s.%s", base, name);
+    }
+    return ncc_layout_copy_cstr(name);
+}
+
+typedef struct {
+    bool scan_kind;
+    bool scan_cb;
+    bool scan_user;
+} runtime_scan_shape_t;
+
+static bool
+member_specs_typedef_is(ncc_parse_tree_t *member_specs, const char *expected)
+{
+    char *tdname = ncc_layout_first_typedef_name_text(member_specs);
+    bool  result = tdname && strcmp(tdname, expected) == 0;
+    if (tdname) {
+        ncc_free(tdname);
+    }
+    return result;
+}
+
+static void
+runtime_shape_note_member(ncc_xform_ctx_t      *ctx,
+                          runtime_scan_shape_t *shape,
+                          const char           *name,
+                          ncc_parse_tree_t     *member_specs,
+                          ncc_parse_tree_t     *declarator)
+{
+    if (!name) {
+        return;
+    }
+
+    if (strcmp(name, "scan_kind") == 0) {
+        shape->scan_kind = member_specs_typedef_is(member_specs,
+                                                   "n00b_gc_scan_kind_t");
+        return;
+    }
+
+    if (strcmp(name, "scan_cb") == 0) {
+        shape->scan_cb = member_specs_typedef_is(member_specs,
+                                                 "n00b_gc_scan_cb_t");
+        return;
+    }
+
+    if (strcmp(name, "scan_user") == 0) {
+        int ptr = declarator
+                    ? ncc_layout_pointer_depth_for_declarator(ctx,
+                                                              member_specs,
+                                                              declarator)
+                    : ncc_layout_pointer_depth_for_specs(ctx, member_specs);
+        shape->scan_user = ptr > 0;
+    }
+}
+
+static bool
+aggregate_has_runtime_scan_shape(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *spec)
+{
+    runtime_scan_shape_t shape = {0};
+    ncc_parse_tree_t    *members = ncc_xform_find_child_nt(
+        spec, "member_declaration_list");
+    if (!members) {
+        return false;
+    }
+
+    ncc_layout_parse_tree_list_t mlist = {0};
+    ncc_layout_collect_nt_children(members, "member_declaration", &mlist);
+
+    for (size_t i = 0; i < mlist.len; i++) {
+        ncc_parse_tree_t *member_specs = ncc_xform_find_child_nt(
+            mlist.data[i], "specifier_qualifier_list");
+        ncc_parse_tree_t *member_list = ncc_xform_find_child_nt(
+            mlist.data[i], "member_declarator_list");
+        if (!member_specs) {
+            continue;
+        }
+
+        if (!member_list) {
+            if (ncc_layout_aggregate_spec_from_specs(ctx, member_specs)) {
+                continue;
+            }
+            ncc_parse_tree_t *declarator = ncc_layout_first_descendant_nt(
+                mlist.data[i], "declarator");
+            char *name = ncc_layout_implicit_member_field_name(mlist.data[i],
+                                                               member_specs);
+            if (!name && declarator) {
+                name = ncc_layout_declarator_name(declarator);
+            }
+            if (name) {
+                runtime_shape_note_member(ctx, &shape, name, member_specs,
+                                          declarator);
+                ncc_free(name);
+            }
+            continue;
+        }
+
+        ncc_layout_parse_tree_list_t decls = {0};
+        ncc_layout_collect_nt_children(member_list, "member_declarator",
+                                       &decls);
+        for (size_t j = 0; j < decls.len; j++) {
+            ncc_parse_tree_t *declarator = ncc_xform_find_child_nt(
+                decls.data[j], "declarator");
+            if (!declarator) {
+                continue;
+            }
+            char *name = ncc_layout_declarator_name(declarator);
+            runtime_shape_note_member(ctx, &shape, name, member_specs,
+                                      declarator);
+            if (name) {
+                ncc_free(name);
+            }
+        }
+        if (decls.data) {
+            ncc_free(decls.data);
+        }
+    }
+
+    if (mlist.data) {
+        ncc_free(mlist.data);
+    }
+
+    return shape.scan_kind && shape.scan_cb && shape.scan_user;
+}
+
+static bool
+member_is_runtime_infra(bool runtime_scan_shape, const char *name,
+                        ncc_parse_tree_t *member_specs)
+{
+    if (!name) {
+        return false;
+    }
+
+    if (!runtime_scan_shape) {
+        return false;
+    }
+
+    // These fields are runtime scan policy, not managed payload edges. Gate
+    // this on the exact n00b scan triple so ordinary user fields named
+    // `scan_user`, `allocator`, etc. are still walked normally.
+    if (strcmp(name, "scan_user") == 0
+        || (strcmp(name, "scan_cb") == 0
+            && member_specs_typedef_is(member_specs, "n00b_gc_scan_cb_t"))) {
+        return true;
+    }
+
+    char *tdname = ncc_layout_first_typedef_name_text(member_specs);
+    bool  result = false;
+    if (tdname) {
+        result = (strcmp(name, "lock") == 0
+                  && strcmp(tdname, "n00b_rwlock_t") == 0)
+              || (strcmp(name, "allocator") == 0
+                  && strcmp(tdname, "n00b_allocator_t") == 0);
+        ncc_free(tdname);
+    }
+
+    return result;
+}
+
+static char *
+offset_expr(const char *elem_type, const char *path)
+{
+    return ncc_layout_format_cstr("(__builtin_offsetof(%s,%s)/sizeof(void*))",
+                                  elem_type, path);
+}
+
+static char *
+offset_assert(const char *elem_type, const char *path)
+{
+    return ncc_layout_format_cstr(
+        "static_assert((__builtin_offsetof(%s,%s)%%sizeof(void*))==0,"
+        "\"n00b gc-map: pointer field must be word-aligned\");",
+        elem_type, path);
+}
+
+// ---------------------------------------------------------------------------
+// Tolerant, conservative pointer-offset walker.
+// ---------------------------------------------------------------------------
+
+static void
+gc_walk(ncc_xform_ctx_t *ctx,
+        const char      *elem_type,
+        ncc_parse_tree_t *spec,
+        const char      *base,
+        ncc_buffer_t    *offs,
+        ncc_buffer_t    *asserts,
+        int             *count,
+        bool            *ok,
+        int              depth);
+
+static void
+emit_pointer(const char *elem_type, const char *path,
+             ncc_buffer_t *offs, ncc_buffer_t *asserts, int *count)
+{
+    char *oe = offset_expr(elem_type, path);
+    char *as = offset_assert(elem_type, path);
+    if (*count > 0) {
+        ncc_buffer_puts(offs, ",");
+    }
+    ncc_buffer_puts(offs, oe);
+    ncc_buffer_puts(asserts, as);
+    (*count)++;
+    ncc_free(oe);
+    ncc_free(as);
+}
+
+// Walk one member_declaration of a STRUCT.
+static void
+walk_struct_member(ncc_xform_ctx_t *ctx, const char *elem_type,
+                   ncc_parse_tree_t *member, const char *base,
+                   bool runtime_scan_shape, ncc_buffer_t *offs,
+                   ncc_buffer_t *asserts, int *count, bool *ok, int depth)
+{
+    ncc_parse_tree_t *member_specs = ncc_xform_find_child_nt(
+        member, "specifier_qualifier_list");
+    if (!member_specs) {
+        return; // nothing typed here (e.g. a stray ';')
+    }
+
+    ncc_parse_tree_t *member_list = ncc_xform_find_child_nt(
+        member, "member_declarator_list");
+
+    if (!member_list) {
+        // Anonymous member: usually an anonymous aggregate (struct/union).
+        // Resolve the aggregate FIRST and recurse — note that
+        // pointer_depth_for_specs would return >0 for an anon aggregate whose
+        // body contains pointer members (it sees the inner '*'), so the
+        // aggregate check must come before any pointer test.
+        ncc_parse_tree_t *nspec = ncc_layout_aggregate_spec_from_specs(
+            ctx, member_specs);
+        if (nspec) {
+            char *field = ncc_layout_implicit_member_field_name(member,
+                                                                member_specs);
+            char *nbase = field ? path_join(base, field)
+                                : ncc_layout_copy_cstr(base);
+            gc_walk(ctx, elem_type, nspec, nbase, offs, asserts, count, ok,
+                    depth + 1);
+            ncc_free(nbase);
+            if (field) {
+                ncc_free(field);
+            }
+            return;
+        }
+        // Not an aggregate. In practice this is a typedef-to-pointer member
+        // whose declarator the parser surfaced without a
+        // member_declarator_list. If the typedef is a FUNCTION pointer
+        // (n00b_gc_scan_cb_t / n00b_walk_action_t / n00b_hash_fn), EXCLUDE it:
+        // it points to code, never the heap, so the GC must not scan it and
+        // marshal must not relocate it. A DATA-pointer typedef must still be
+        // MARKED (excluding it would under-scan and corrupt the heap).
+        if (ncc_layout_pointer_depth_for_specs(ctx, member_specs) > 0) {
+            char *tdname = ncc_layout_first_typedef_name_text(member_specs);
+            bool  is_fnptr = tdname
+                          && ncc_layout_typedef_name_is_function_pointer(ctx,
+                                                                         tdname);
+            if (tdname) {
+                ncc_free(tdname);
+            }
+            if (is_fnptr) {
+                return; // code pointer -> not a GC heap pointer
+            }
+            char *field = ncc_layout_implicit_member_field_name(member,
+                                                                member_specs);
+            if (field) {
+                if (!member_is_runtime_infra(runtime_scan_shape, field,
+                                             member_specs)) {
+                    char *path = path_join(base, field);
+                    emit_pointer(elem_type, path, offs, asserts, count);
+                    ncc_free(path);
+                }
+                ncc_free(field);
+            }
+            else {
+                *ok = false; // pointer member we cannot name
+            }
+        }
+        return;
+    }
+
+    ncc_layout_parse_tree_list_t decls = {0};
+    ncc_layout_collect_nt_children(member_list, "member_declarator", &decls);
+
+    for (size_t i = 0; i < decls.len && *ok; i++) {
+        ncc_parse_tree_t *declarator = ncc_xform_find_child_nt(decls.data[i],
+                                                              "declarator");
+        if (!declarator) {
+            continue;
+        }
+        char *name = ncc_layout_declarator_name(declarator);
+        if (!name) {
+            *ok = false; // can't address it -> can't reason about it
+            break;
+        }
+        if (member_is_runtime_infra(runtime_scan_shape, name, member_specs)) {
+            ncc_free(name);
+            continue;
+        }
+        char *path     = path_join(base, name);
+        bool  is_array = ncc_layout_first_descendant_nt(declarator,
+                                                       "array_declarator")
+                      != nullptr;
+        int ptr = ncc_layout_pointer_depth_for_declarator(ctx, member_specs,
+                                                          declarator);
+        bool is_fnptr = ncc_layout_declarator_is_function_pointer(declarator);
+
+        if (is_array) {
+            // Data-pointer arrays / aggregate arrays are not handled in this
+            // pass; scalar arrays and function-pointer arrays carry no GC heap
+            // words and are safe to ignore.
+            ncc_parse_tree_t *agg = ncc_layout_aggregate_spec_from_specs(
+                ctx, member_specs);
+            if ((ptr > 0 && !is_fnptr) || agg) {
+                *ok = false;
+            }
+        }
+        else if (ptr > 0) {
+            if (!is_fnptr) {
+                emit_pointer(elem_type, path, offs, asserts, count);
+            }
+        }
+        else {
+            // No '*' in the declarator, but the SPECS may still make this a
+            // pointer: a pointer typedef, or an _Atomic(T *) wrapper. Detect
+            // that before treating it as a nested by-value aggregate —
+            // otherwise we would emit an offsetof THROUGH a pointer.
+            int ptr_specs = ncc_layout_pointer_depth_for_specs(ctx,
+                                                               member_specs);
+            if (ptr_specs > 0) {
+                char *tdname = ncc_layout_first_typedef_name_text(member_specs);
+                bool  is_fnptr = tdname
+                              && ncc_layout_typedef_name_is_function_pointer(
+                                     ctx, tdname);
+                if (tdname) {
+                    ncc_free(tdname);
+                }
+                if (!is_fnptr) {
+                    emit_pointer(elem_type, path, offs, asserts, count);
+                }
+                // function pointer -> excluded (code, not a heap pointer)
+            }
+            else {
+                ncc_parse_tree_t *nspec = ncc_layout_aggregate_spec_from_specs(
+                    ctx, member_specs);
+                if (nspec) {
+                    gc_walk(ctx, elem_type, nspec, path, offs, asserts, count,
+                            ok, depth + 1);
+                }
+                // else: scalar by-value member -> no pointer words.
+            }
+        }
+
+        ncc_free(path);
+        ncc_free(name);
+    }
+
+    if (decls.data) {
+        ncc_free(decls.data);
+    }
+}
+
+// Classify + handle the members of a UNION. An all-pointer union occupies one
+// word that is always a pointer (emit one offset); a union mixing pointer and
+// non-pointer members can't be statically resolved (skip the type); an
+// all-scalar union has no pointer words.
+static void
+walk_union(ncc_xform_ctx_t *ctx, const char *elem_type,
+           ncc_parse_tree_t *spec, const char *base, bool runtime_scan_shape,
+           ncc_buffer_t *offs, ncc_buffer_t *asserts, int *count, bool *ok)
+{
+    ncc_parse_tree_t *members = ncc_xform_find_child_nt(
+        spec, "member_declaration_list");
+    if (!members) {
+        *ok = false;
+        return;
+    }
+
+    ncc_layout_parse_tree_list_t mlist = {0};
+    ncc_layout_collect_nt_children(members, "member_declaration", &mlist);
+
+    bool  any_scalar  = false;
+    bool  any_complex = false;
+    char *first_ptr   = nullptr;
+
+    for (size_t i = 0; i < mlist.len; i++) {
+        ncc_parse_tree_t *member       = mlist.data[i];
+        ncc_parse_tree_t *member_specs = ncc_xform_find_child_nt(
+            member, "specifier_qualifier_list");
+        ncc_parse_tree_t *member_list = ncc_xform_find_child_nt(
+            member, "member_declarator_list");
+        if (!member_specs) {
+            continue;
+        }
+
+        if (!member_list) {
+            // A union member with a single declarator may carry no
+            // member_declarator_list wrapper (ncc puts the declarator directly
+            // under the member_declaration). Classify it instead of treating
+            // every such member as complex.
+            //
+            // Do not search through a by-value aggregate member's body for a
+            // declarator: that would mistake fields inside `struct { ... } x`
+            // for direct union alternatives and emit invalid paths like
+            // `offsetof(outer, inner_field)`.
+            if (ncc_layout_aggregate_spec_from_specs(ctx, member_specs)) {
+                any_complex = true;
+                continue;
+            }
+            ncc_parse_tree_t *d = ncc_layout_first_descendant_nt(member,
+                                                                 "declarator");
+            if (!d) {
+                // No declarator: either a scalar member whose name isn't
+                // wrapped in a declarator (e.g. `long x;`) or a truly
+                // anonymous nested aggregate. Aggregate -> complex; otherwise
+                // it's a scalar (no pointer words).
+                any_scalar = true;
+                continue;
+            }
+            bool is_array = ncc_layout_first_descendant_nt(d, "array_declarator")
+                         != nullptr;
+            int  p = ncc_layout_pointer_depth_in_declarator(d)
+                   + ncc_layout_pointer_depth_for_specs(ctx, member_specs);
+            bool is_fnptr = ncc_layout_declarator_is_function_pointer(d);
+            if (is_array) {
+                if (is_fnptr) {
+                    any_scalar = true;
+                }
+                else {
+                    any_complex = true;
+                }
+            }
+            else if (p > 0) {
+                if (is_fnptr) {
+                    any_scalar = true;
+                }
+                else if (!first_ptr) {
+                    char *nm = ncc_layout_declarator_name(d);
+                    if (nm) {
+                        first_ptr = path_join(base, nm);
+                        ncc_free(nm);
+                    }
+                    else {
+                        any_complex = true; // pointer we can't name
+                    }
+                }
+            }
+            else {
+                any_scalar = true;
+            }
+            continue;
+        }
+
+        ncc_layout_parse_tree_list_t decls = {0};
+        ncc_layout_collect_nt_children(member_list, "member_declarator",
+                                       &decls);
+        for (size_t j = 0; j < decls.len; j++) {
+            ncc_parse_tree_t *declarator = ncc_xform_find_child_nt(
+                decls.data[j], "declarator");
+            if (!declarator) {
+                continue;
+            }
+            char *name = ncc_layout_declarator_name(declarator);
+            if (!name) {
+                any_complex = true;
+                continue;
+            }
+            if (member_is_runtime_infra(runtime_scan_shape, name,
+                                        member_specs)) {
+                ncc_free(name);
+                continue;
+            }
+            bool is_array = ncc_layout_first_descendant_nt(declarator,
+                                                          "array_declarator")
+                         != nullptr;
+            int ptr = ncc_layout_pointer_depth_for_declarator(
+                ctx, member_specs, declarator);
+            bool is_fnptr =
+                ncc_layout_declarator_is_function_pointer(declarator);
+            if (is_array) {
+                if (is_fnptr) {
+                    any_scalar = true;
+                }
+                else {
+                    any_complex = true;
+                }
+            }
+            else if (ptr > 0) {
+                if (is_fnptr) {
+                    any_scalar = true;
+                }
+                else if (!first_ptr) {
+                    first_ptr = path_join(base, name);
+                }
+            }
+            else {
+                ncc_parse_tree_t *agg = ncc_layout_aggregate_spec_from_specs(
+                    ctx, member_specs);
+                if (agg) {
+                    any_complex = true;
+                }
+                else {
+                    any_scalar = true;
+                }
+            }
+            ncc_free(name);
+        }
+        if (decls.data) {
+            ncc_free(decls.data);
+        }
+    }
+
+    if (mlist.data) {
+        ncc_free(mlist.data);
+    }
+
+    if (any_complex || (first_ptr && any_scalar)) {
+        *ok = false; // can't statically describe this union
+    }
+    else if (first_ptr && !any_scalar) {
+        emit_pointer(elem_type, first_ptr, offs, asserts, count); // all-pointer
+    }
+    // else: all-scalar union -> nothing.
+
+    if (first_ptr) {
+        ncc_free(first_ptr);
+    }
+}
+
+// Safety cap on a single type's pointer-offset count. Real n00b types have a
+// few dozen pointer words; a blow-up past this means the walk recursed into
+// something pathological (a huge/wide nested expansion) — bail the type rather
+// than emit a giant generated file that overwhelms the C compiler.
+#define NCC_GCMAP_MAX_OFFSETS 256
+
+static void
+gc_walk(ncc_xform_ctx_t *ctx, const char *elem_type, ncc_parse_tree_t *spec,
+        const char *base, ncc_buffer_t *offs, ncc_buffer_t *asserts,
+        int *count, bool *ok, int depth)
+{
+    if (depth > 64 || *count > NCC_GCMAP_MAX_OFFSETS) {
+        *ok = false;
+        return;
+    }
+
+    spec = ncc_layout_resolve_aggregate_specifier(ctx, spec);
+    if (!spec) {
+        *ok = false;
+        return;
+    }
+
+    bool runtime_scan_shape = aggregate_has_runtime_scan_shape(ctx, spec);
+
+    if (ncc_layout_struct_or_union_is_union(spec)) {
+        walk_union(ctx, elem_type, spec, base, runtime_scan_shape, offs, asserts,
+                   count, ok);
+        return;
+    }
+
+    ncc_parse_tree_t *members = ncc_xform_find_child_nt(
+        spec, "member_declaration_list");
+    if (!members) {
+        *ok = false; // unresolved/incomplete aggregate
+        return;
+    }
+
+    ncc_layout_parse_tree_list_t mlist = {0};
+    ncc_layout_collect_nt_children(members, "member_declaration", &mlist);
+    for (size_t i = 0; i < mlist.len && *ok; i++) {
+        walk_struct_member(ctx, elem_type, mlist.data[i], base,
+                           runtime_scan_shape, offs, asserts, count, ok,
+                           depth);
+    }
+    if (mlist.data) {
+        ncc_free(mlist.data);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Recording (called from xform_typehash).
+// ---------------------------------------------------------------------------
+
+void
+ncc_gc_typemap_note(ncc_xform_ctx_t *ctx, const char *type_str, uint64_t hash)
+{
+    if (!ctx || !type_str || !hash) {
+        return;
+    }
+
+    // _Atomic(T *) may carry a trailing '*' in its normalized spelling, but it
+    // is not an aggregate object type we can allocate and describe with
+    // offsetof(). Atomic pointer FIELDS are handled by gc_walk; top-level
+    // atomic-pointer typehash records are not GC-map descriptor candidates.
+    if (strstr(type_str, "_Atomic") != nullptr) {
+        return;
+    }
+
+    // Must be a single pointer: exactly one trailing '*', no '*'/'[' before it.
+    size_t len = strlen(type_str);
+    while (len > 0 && (type_str[len - 1] == ' ' || type_str[len - 1] == '\t')) {
+        len--;
+    }
+    if (len < 2 || type_str[len - 1] != '*') {
+        return;
+    }
+    size_t base_len = len - 1;
+    for (size_t i = 0; i < base_len; i++) {
+        if (type_str[i] == '*' || type_str[i] == '[') {
+            return; // multi-level pointer / array of pointers
+        }
+    }
+    // Trim the element-type spelling.
+    while (base_len > 0
+           && (type_str[base_len - 1] == ' ' || type_str[base_len - 1] == '\t')) {
+        base_len--;
+    }
+    if (base_len == 0) {
+        return;
+    }
+
+    char *elem = ncc_alloc_array(char, base_len + 1);
+    memcpy(elem, type_str, base_len);
+    elem[base_len] = '\0';
+
+    // Aggregate resolution is deferred to emit() (which runs after all
+    // xforms, when the aggregate table is fully populated). Here we only
+    // record candidate single-pointer element types; non-aggregates and
+    // unresolved types are filtered out at emit time. Skip obvious
+    // non-aggregates to keep the record set small.
+    if (strcmp(elem, "void") == 0) {
+        ncc_free(elem);
+        return;
+    }
+
+    if (record_seen(hash)) {
+        ncc_free(elem);
+        return;
+    }
+
+    if (record_len == record_cap) {
+        size_t ncap = record_cap ? record_cap * 2 : 16;
+        records = (gc_typemap_record_t *)ncc_realloc(
+            records, ncap * sizeof(gc_typemap_record_t));
+        record_cap = ncap;
+    }
+    records[record_len].hash      = hash;
+    records[record_len].elem_type = elem;
+    record_len++;
+}
+
+// ---------------------------------------------------------------------------
+// Emission (called from ncc.c after ncc_xform_apply).
+// ---------------------------------------------------------------------------
+
+// ncc emits POST-preprocessed C, so the `N00B_GC_TYPE_MAP_*_SECTION` macros
+// would not expand in the appended code. Derive the platform-correct section
+// name from n00b's already-expanded static-object attribute, but always spell
+// the generated GC-map attribute in C23 form.
+static char *
+derive_gc_section_attr(const char *stobj_attr, const char *section_name)
+{
+    if (stobj_attr) {
+        const char *p = strstr(stobj_attr, "n00b_stobj");
+        if (p) {
+            const char *start = p;
+            while (start > stobj_attr && start[-1] != '"') {
+                start--;
+            }
+            const char *end = p + strlen("n00b_stobj");
+            while (*end && *end != '"') {
+                end++;
+            }
+            return ncc_layout_format_cstr(
+                "[[gnu::section(\"%.*s%s%.*s\"), gnu::used]]",
+                (int)(p - start), start, section_name,
+                (int)(end - (p + strlen("n00b_stobj"))),
+                p + strlen("n00b_stobj"));
+        }
+    }
+    return ncc_layout_format_cstr("[[gnu::section(\"%s\"), gnu::used]]",
+                                  section_name);
+}
+
+static char *
+derive_gcmap_attr(const char *stobj_attr)
+{
+    return derive_gc_section_attr(stobj_attr, "n00b_gcmap");
+}
+
+static char *
+derive_gcidx_attr(const char *stobj_attr)
+{
+    return derive_gc_section_attr(stobj_attr, "n00b_gcidx");
+}
+
+char *
+ncc_gc_typemap_emit(ncc_xform_ctx_t *ctx)
+{
+    ncc_buffer_t *out      = ncc_buffer_empty();
+    size_t        n_emitted = 0;
+    const char   *stobj_attr = ncc_xform_get_data(ctx)->static_object_entry_attr;
+    char         *gcmap_attr = derive_gcmap_attr(stobj_attr);
+    char         *gcidx_attr = derive_gcidx_attr(stobj_attr);
+
+    for (size_t i = 0; i < record_len; i++) {
+        // Skip only source-level generic macro spellings such as
+        // `n00b_dict_t(...)`: ncc appends this C after preprocessing, so those
+        // macros no longer exist. Resolved generated tags (`struct __...`) are
+        // real aggregate names in the post-preprocessed TU and are exactly what
+        // typehash sites for generic containers often use; they must be
+        // eligible so dict/list wrapper objects get precise maps instead of
+        // DEFAULT-scanning function pointers and scan infrastructure fields.
+        if (strchr(records[i].elem_type, '(') != nullptr) {
+            continue;
+        }
+
+        bool scalar_no_ptr = elem_type_is_scalar_no_ptr(records[i].elem_type);
+        ncc_layout_aggregate_type_info_t *info = nullptr;
+        if (!scalar_no_ptr) {
+            info = ncc_layout_aggregate_info_from_type_name(ctx,
+                                                            records[i].elem_type);
+            if (!info || !info->specifier) {
+                continue;
+            }
+            if (!aggregate_type_is_file_visible(info)) {
+                continue;
+            }
+            if (info->is_atomic) {
+                continue;
+            }
+        }
+
+        ncc_buffer_t *offs    = ncc_buffer_empty();
+        ncc_buffer_t *asserts = ncc_buffer_empty();
+        int           count   = 0;
+        bool          ok      = true;
+
+        if (!scalar_no_ptr) {
+            gc_walk(ctx, records[i].elem_type, info->specifier, "", offs, asserts,
+                    &count, &ok, 0);
+        }
+
+        if (ok) {
+            char *asserts_str = ncc_buffer_take(asserts);
+
+            // Asserts first (file scope), then the descriptor + section entry.
+            ncc_buffer_printf(out, "%s", asserts_str);
+            if (count > 0) {
+                char *offs_csv = ncc_buffer_take(offs);
+                ncc_buffer_printf(
+                    out,
+                    "static const uint64_t __ncc_gcmap_off_%zu[]={%s};",
+                    i, offs_csv);
+                ncc_free(offs_csv);
+            }
+            else {
+                ncc_free(ncc_buffer_take(offs));
+            }
+            char *offsets_expr = count > 0
+                               ? ncc_layout_format_cstr("__ncc_gcmap_off_%zu", i)
+                               : ncc_layout_copy_cstr("nullptr");
+            ncc_buffer_printf(
+                out,
+                "static const n00b_gc_struct_layout_t __ncc_gcmap_lay_%zu="
+                "{.stride=(sizeof(%s)/sizeof(void*)),.count=1,.offset_count=%d,"
+                ".offsets=%s};",
+                i, records[i].elem_type, count, offsets_expr);
+            ncc_buffer_printf(
+                out,
+                "%s static const n00b_gc_type_map_entry_t "
+                "__ncc_gcmap_ent_%zu={.type_hash=%lluULL,.layout="
+                "&__ncc_gcmap_lay_%zu};",
+                gcmap_attr, i, (unsigned long long)records[i].hash, i);
+            ncc_buffer_printf(
+                out,
+                "%s static const n00b_gc_type_map_index_entry_t "
+                "__ncc_gcidx_ent_%zu={.type_hash=0ULL,.entry_index=%zuULL};",
+                gcidx_attr, i, i);
+            n_emitted++;
+
+            ncc_free(offsets_expr);
+            ncc_free(asserts_str);
+        }
+        else {
+            ncc_free(ncc_buffer_take(offs));
+            ncc_free(ncc_buffer_take(asserts));
+        }
+    }
+
+    ncc_free(gcmap_attr);
+    ncc_free(gcidx_attr);
+
+    // Drain the accumulator (per-TU state).
+    for (size_t i = 0; i < record_len; i++) {
+        ncc_free(records[i].elem_type);
+    }
+    ncc_free(records);
+    records    = nullptr;
+    record_len = 0;
+    record_cap = 0;
+
+    if (n_emitted == 0) {
+        ncc_free(ncc_buffer_take(out));
+        return ncc_layout_copy_cstr("");
+    }
+
+    return ncc_buffer_take(out);
+}

--- a/src/xform/xform_type_layout.c
+++ b/src/xform/xform_type_layout.c
@@ -12,7 +12,6 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 char *
@@ -278,6 +277,21 @@ int
 ncc_layout_pointer_depth_in_declarator(ncc_parse_tree_t *node)
 {
     return pointer_depth_in_type_node(node);
+}
+
+bool
+ncc_layout_declarator_is_function_pointer(ncc_parse_tree_t *declarator)
+{
+    if (!declarator) {
+        return false;
+    }
+
+    return ncc_layout_first_descendant_nt(declarator, "parameter_type_list")
+        != nullptr
+        || ncc_layout_first_descendant_nt(declarator, "parameter_list")
+               != nullptr
+        || ncc_layout_first_descendant_nt(declarator, "identifier_list")
+               != nullptr;
 }
 
 static int
@@ -642,12 +656,59 @@ layout_pointer_typedefs(ncc_xform_ctx_t *ctx)
     return data ? &data->gc_pointer_typedefs : nullptr;
 }
 
+static ncc_dict_t *
+layout_function_pointer_typedefs(ncc_xform_ctx_t *ctx)
+{
+    ncc_xform_data_t *data = ncc_xform_get_data(ctx);
+    return data ? &data->gc_function_pointer_typedefs : nullptr;
+}
+
+static void
+record_function_pointer_typedef(ncc_xform_ctx_t *ctx, const char *name)
+{
+    ncc_dict_t *fns = layout_function_pointer_typedefs(ctx);
+    if (!fns || !name || !*name) {
+        return;
+    }
+    bool found = false;
+    ncc_dict_get(fns, (void *)name, &found);
+    if (!found) {
+        ncc_dict_put(fns, ncc_layout_copy_cstr(name), (void *)(uintptr_t)1);
+    }
+}
+
+bool
+ncc_layout_typedef_name_is_function_pointer(ncc_xform_ctx_t *ctx,
+                                            const char *name)
+{
+    ncc_dict_t *fns = layout_function_pointer_typedefs(ctx);
+    if (!fns || !name) {
+        return false;
+    }
+    bool found = false;
+    (void)ncc_dict_get(fns, (void *)name, &found);
+    return found;
+}
+
 static char *
 struct_or_union_kind_text(ncc_parse_tree_t *su)
 {
-    ncc_parse_tree_t *kind = ncc_layout_first_descendant_nt(
-        su, "_kw_kw_struct_or_union");
-    return kind ? ncc_layout_node_text(kind) : nullptr;
+    // A specifier's text begins with its own keyword ("struct"/"union"). A
+    // descendant keyword search would, for a struct whose first member is an
+    // anonymous union, wrongly return that nested "union" and misclassify the
+    // outer struct as a union. Use the leading keyword of the specifier text.
+    // The specifier's first leaf token is its own keyword ("struct"/"union").
+    ncc_token_info_t *tok = ncc_layout_first_leaf_token(su);
+    if (tok && ncc_option_is_set(tok->value)) {
+        ncc_string_t v = ncc_option_get(tok->value);
+        if (v.data && strcmp(v.data, "union") == 0) {
+            return ncc_layout_copy_cstr("union");
+        }
+        if (v.data && strcmp(v.data, "struct") == 0) {
+            return ncc_layout_copy_cstr("struct");
+        }
+    }
+    return ncc_layout_copy_cstr("struct");
 }
 
 bool
@@ -829,10 +890,49 @@ first_known_type_alias_text(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node,
     return nullptr;
 }
 
+static bool
+atomic_type_specifier_is_pointer(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+
+    if (ncc_xform_nt_name_is(node, "member_declaration_list")) {
+        return false;
+    }
+
+    if (ncc_xform_nt_name_is(node, "atomic_type_specifier")) {
+        if (ncc_layout_first_descendant_nt(node, "pointer") != nullptr) {
+            return true;
+        }
+
+        char *text = ncc_layout_node_text(node);
+        bool  result = text && strstr(text, "_Atomic") != nullptr
+                    && strchr(text, '*') != nullptr;
+        if (text) {
+            ncc_free(text);
+        }
+        return result;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (atomic_type_specifier_is_pointer(ncc_tree_child(node, i))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 ncc_parse_tree_t *
 ncc_layout_aggregate_spec_from_specs(ncc_xform_ctx_t *ctx,
                                      ncc_parse_tree_t *specs)
 {
+    if (ncc_layout_pointer_depth_for_specs(ctx, specs) > 0) {
+        return nullptr;
+    }
+
     ncc_parse_tree_t *su = ncc_layout_first_descendant_nt(
         specs, "struct_or_union_specifier");
     if (su) {
@@ -854,6 +954,10 @@ ncc_layout_aggregate_type_info_t *
 ncc_layout_aggregate_info_from_specs(ncc_xform_ctx_t *ctx,
                                      ncc_parse_tree_t *specs)
 {
+    if (ncc_layout_pointer_depth_for_specs(ctx, specs) > 0) {
+        return nullptr;
+    }
+
     ncc_parse_tree_t *su = ncc_layout_first_descendant_nt(
         specs, "struct_or_union_specifier");
     if (su) {
@@ -1033,6 +1137,13 @@ ncc_layout_pointer_depth_for_specs(ncc_xform_ctx_t *ctx,
     if (decl_specs_use_pointer_typedef(ctx, specs)) {
         ptr_depth++;
     }
+    // A pointer can hide inside an _Atomic(T *) wrapper, where the '*' is an
+    // abstract declarator (a `pointer` NT) within the atomic_type_specifier
+    // that the scans above don't reach. Count it so every consumer classifies
+    // _Atomic(T *) members/typedefs as pointers (not by-value aggregates).
+    if (ptr_depth == 0 && atomic_type_specifier_is_pointer(specs)) {
+        ptr_depth++;
+    }
     return ptr_depth;
 }
 
@@ -1127,9 +1238,26 @@ collect_typedef_aliases_from_decl(ncc_xform_ctx_t *ctx,
             continue;
         }
 
+        // An _Atomic(T *) typedef ( typedef _Atomic(struct X *) name; ) hides
+        // its '*' in an abstract declarator inside the atomic_type_specifier,
+        // so the declarator/specs pointer checks miss it. Detect it here so
+        // the typedef is classified as a POINTER (not an aggregate alias) —
+        // otherwise downstream code treats fields of this type as by-value
+        // structs.
+        bool atomic_ptr = atomic_type_specifier_is_pointer(decl_specs);
+
         if (ncc_layout_pointer_depth_in_declarator(declarator) > 0
-            || decl_specs_use_pointer_typedef(ctx, decl_specs)) {
+            || decl_specs_use_pointer_typedef(ctx, decl_specs)
+            || atomic_ptr) {
             record_pointer_typedef(ctx, name);
+            // A function-pointer typedef ( typedef RET (*name)(params) ) has a
+            // parameter list inside its declarator. Record it separately so
+            // the GC-map walker can exclude it (code pointers are not heap
+            // pointers and must not be scanned/marshaled as data).
+            if (ncc_layout_first_descendant_nt(declarator, "parameter_type_list")
+                || ncc_layout_first_descendant_nt(declarator, "parameter_list")) {
+                record_function_pointer_typedef(ctx, name);
+            }
             ncc_free(name);
             continue;
         }

--- a/src/xform/xform_typehash.c
+++ b/src/xform/xform_typehash.c
@@ -4,6 +4,7 @@
 // typehash(int *) becomes 12345678901234ULL.
 
 #include "xform/xform_helpers.h"
+#include "xform/xform_gc_typemap.h"
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -41,6 +42,10 @@ xform_typehash(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
 
     ncc_string_t type_str = ncc_xform_extract_type_string(ctx, atom, cont);
     uint64_t     hash     = ncc_type_hash_u64(type_str.data);
+
+    // WP-020 / D-049: record pointer-to-aggregate typehashes so we can emit a
+    // matching link-time GC pointer-map entry (same hash -> guaranteed match).
+    ncc_gc_typemap_note(ctx, type_str.data, hash);
 
     char buf[32];
     snprintf(buf, sizeof(buf), "%" PRIu64 "ULL", hash);

--- a/test/test_gc_typemap.c
+++ b/test/test_gc_typemap.c
@@ -1,0 +1,77 @@
+// test_gc_typemap.c -- WP-020 link-time type->GC-map emission fixture.
+//
+// Meson runs this source through `ncc -E` and asserts on the transformed output:
+// direct data pointers are emitted as offsetof entries, direct function
+// pointers are omitted, conservative skip cases emit no descriptor, and fallback
+// generated spellings use C23 attributes/assertions.
+
+#include <stdint.h>
+
+typedef struct gcmap_payload_t {
+    uint64_t value;
+} gcmap_payload_t;
+
+typedef struct gcmap_direct_fn_t {
+    void             (*callback)(void);
+    gcmap_payload_t  *payload;
+} gcmap_direct_fn_t;
+
+typedef void (*gcmap_callback_t)(void);
+
+typedef struct gcmap_typedef_fn_t {
+    gcmap_callback_t  callback;
+    gcmap_payload_t  *payload;
+} gcmap_typedef_fn_t;
+
+typedef struct gcmap_user_scan_field_t {
+    void             *scan_user;
+    gcmap_payload_t  *payload;
+} gcmap_user_scan_field_t;
+
+typedef unsigned char n00b_gc_scan_kind_t;
+typedef void (*n00b_gc_scan_cb_t)(void *, void *);
+typedef struct n00b_rwlock_t n00b_rwlock_t;
+typedef struct n00b_allocator_t n00b_allocator_t;
+
+typedef struct gcmap_runtime_shape_t {
+    n00b_gc_scan_kind_t  scan_kind;
+    n00b_gc_scan_cb_t    scan_cb;
+    void                *scan_user;
+    n00b_rwlock_t       *lock;
+    n00b_allocator_t    *allocator;
+    gcmap_payload_t     *payload;
+} gcmap_runtime_shape_t;
+
+typedef unsigned char gcmap_scan_kind_t;
+
+typedef struct gcmap_runtime_near_miss_t {
+    gcmap_scan_kind_t  scan_kind;
+    void              *scan_cb;
+    void              *scan_user;
+    gcmap_payload_t   *payload;
+} gcmap_runtime_near_miss_t;
+
+typedef struct gcmap_pointer_array_t {
+    gcmap_payload_t *items[2];
+} gcmap_pointer_array_t;
+
+typedef union gcmap_union_mixed_t {
+    void            (*callback)(void);
+    gcmap_payload_t *payload;
+} gcmap_union_mixed_t;
+
+static uint64_t h_direct = typehash(gcmap_direct_fn_t *);
+static uint64_t h_typedef = typehash(gcmap_typedef_fn_t *);
+static uint64_t h_user    = typehash(gcmap_user_scan_field_t *);
+static uint64_t h_runtime = typehash(gcmap_runtime_shape_t *);
+static uint64_t h_near    = typehash(gcmap_runtime_near_miss_t *);
+static uint64_t h_array   = typehash(gcmap_pointer_array_t *);
+static uint64_t h_union   = typehash(gcmap_union_mixed_t *);
+
+int
+main(void)
+{
+    return (int)((h_direct ^ h_typedef ^ h_user ^ h_runtime ^ h_near
+                  ^ h_array ^ h_union)
+                 == 0);
+}


### PR DESCRIPTION
## Summary
- Add GC typemap transform support and build wiring for generated type metadata.
- Emit typed `gcidx` placeholders plus C23-compatible static assertions and section attributes.
- Detect runtime object shapes precisely enough to skip lock, allocator, and function-pointer fields while preserving scan-user payloads.

## Testing
Focused ncc tests passed: direct pointer offsets, function-pointer skips, typedef pointer handling, scan-user/runtime shape cases, C23 static assert and section attribute rewriting, `gcidx` entry emission, pointer-array skip, and mixed-union skip.

Result: `Ok: 18`, `Fail: 0`.

Pairs with n00b PR https://github.com/n00b-lang/n00b/pull/98.