### PR TITLE
xform(kargs): don't treat a struct/union/enum tag as a callee name

### DIFF
--- a/src/xform/xform_kargs_vargs.c
+++ b/src/xform/xform_kargs_vargs.c
@@ -311,6 +311,16 @@ static const char *extract_func_name(ncc_parse_tree_t *node) {
     }
     return nullptr;
   }
+  // A struct/union/enum tag is a TYPE name, not a callee. Don't descend
+  // into these specifiers: otherwise a struct/union/enum *definition* whose
+  // tag matches a known function (e.g. a constructor named after the result
+  // struct, as in net/quic/metrics) gets misread as a misparsed function
+  // call by the heuristic that calls this on a declaration's
+  // declaration_specifiers.
+  if (ncc_xform_nt_name_is(node, "struct_or_union_specifier") ||
+      ncc_xform_nt_name_is(node, "enum_specifier")) {
+    return nullptr;
+  }
   size_t nc = ncc_tree_num_children(node);
   for (size_t i = 0; i < nc; i++) {
     const char *name = extract_func_name(ncc_tree_child(node, i));


### PR DESCRIPTION
extract_func_name() recursively returned the first IDENTIFIER leaf, so for a declaration whose declaration_specifiers is a tagged-type definition (struct/union/enum) it returned the TAG. The misparsed-function-call heuristic in xform_decl then looked the tag up in the function metadata table; when a constructor is named after its result struct (e.g. n00b net/quic/metrics: `struct n00b_quic_metric_counter` and the `n00b_quic_metric_counter()` ctor), the struct DEFINITION was misread as a misparsed call and fed to parse_template("postfix_expression", ...), which fails and prints `template parse failed for postfix_expression` (4x per metrics TU). Harmless (parse fails → node left as-is) but noisy.

Fix: extract_func_name() returns nullptr for struct_or_union_specifier / enum_specifier nodes (a type tag is not a callee). A genuine misparsed call has a bare-identifier declaration_specifiers, so this only suppresses the false positive.

Verified: net/quic/{metrics,metrics_encode,chan}.c compile with zero 'template parse failed' warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)