### PR TITLE
xform: fix nogc stack maps and generic auto-roots

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -908,6 +908,22 @@ test('ncc_gc_stack_maps_default_on', test_runner,
   depends : ncc_exe,
 )
 
+test('ncc_gc_stack_maps_nogc_attribute_skips_function', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_nogc_attribute.c', 'n00b_gc_stack_']
+         + ncc_test_flags,
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_stack_maps_nogc_attribute_stripped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_stack_maps_nogc_attribute.c', 'n00b::nogc']
+         + ncc_test_flags,
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
 # WP-001 Phase 1: pins the no-op-when-off contract for the
 # xform_gc_globals transform (spec § 6.1, D-006). Even when the
 # source contains a TU-scope pointer-bearing static that would
@@ -1136,6 +1152,19 @@ test('ncc_auto_gc_roots_nested_struct_offset', test_runner,
   args : [ncc_exe, 'preprocess_contains',
           test_dir / 'test_auto_gc_roots_nested_struct.c',
           '(void *) & (outer).in.p']
+         + ncc_test_flags + ['--ncc-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# Regression: static aggregate fields whose type comes from
+# `_generic_struct` lowering must be walked after the concrete struct
+# definition has been emitted. This is the shape used by embedded
+# `n00b_list_t(...)` fields in Wax globals.
+test('ncc_auto_gc_roots_nested_generic_struct', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_auto_gc_roots_nested_generic_struct.c',
+          '(void *) & (g_endpoint).events.data']
          + ncc_test_flags + ['--ncc-auto-gc-roots'],
   suite : 'ncc',
   depends : ncc_exe,

--- a/src/xform/xform_gc_globals.c
+++ b/src/xform/xform_gc_globals.c
@@ -6,12 +6,15 @@
 // Walk-order placement: registered LAST in the xform sequence (after
 // rpc / generic_struct / typeid / option / typestr / typehash /
 // kargs_vargs / once / bang / rstr / static_image / gc_stack_maps /
-// constexpr / constexpr_paste — see src/ncc.c). The auto-roots pass
-// must see the final flattened translation_unit, including any
-// TU-scope synthetic decls earlier passes have produced
-// (spec § 8.3). The placement is enforced at the registration site
-// (ncc.c) rather than here; this comment documents the contract for
-// future readers.
+// constexpr / constexpr_paste — see src/ncc.c) and registered as a
+// post-order translation_unit transform. The auto-roots pass must see
+// the final flattened translation_unit, including any TU-scope
+// synthetic decls earlier passes have produced (spec § 8.3). Last
+// registration alone is not enough: a pre-order translation_unit
+// transform runs before child transforms such as `_generic_struct`
+// lowering. The placement is enforced at the registration site (ncc.c)
+// rather than here; this comment documents the contract for future
+// readers.
 //
 // Phase 2 scope was pointer scalars only. Phases 3+4+5 combined (per
 // D-017) extend to:
@@ -1474,12 +1477,11 @@ build_emit_source(const char *tu_uniq, candvec_t *cands)
 }
 
 // ============================================================================
-// Pass entry point (pre-order on translation_unit)
+// Pass entry point (post-order on translation_unit)
 // ============================================================================
 
 static ncc_parse_tree_t *
-xform_gc_globals_tu(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu,
-                    [[maybe_unused]] ncc_xform_control_t *control)
+xform_gc_globals_tu(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu)
 {
     ncc_xform_data_t *data = ncc_xform_get_data(ctx);
 
@@ -1614,6 +1616,6 @@ xform_gc_globals_tu(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu,
 void
 ncc_register_gc_globals_xform(ncc_xform_registry_t *reg)
 {
-    ncc_xform_register_pre(reg, "translation_unit", xform_gc_globals_tu,
-                           "gc_globals");
+    ncc_xform_register(reg, "translation_unit", xform_gc_globals_tu,
+                       "gc_globals");
 }

--- a/src/xform/xform_gc_stack_maps.c
+++ b/src/xform/xform_gc_stack_maps.c
@@ -349,6 +349,121 @@ first_leaf_node(ncc_parse_tree_t *node)
     return nullptr;
 }
 
+static bool
+attribute_is_n00b_named(ncc_parse_tree_t *attr_node, const char *name)
+{
+    if (!attr_node || !name || ncc_tree_is_leaf(attr_node)) {
+        return false;
+    }
+
+    ncc_parse_tree_t *prefixed = ncc_layout_first_descendant_nt(
+        attr_node, "attribute_prefixed_token");
+    if (!prefixed) {
+        return false;
+    }
+
+    bool   saw_n00b = false;
+    bool   saw_name = false;
+    size_t nc       = ncc_tree_num_children(prefixed);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *c = ncc_tree_child(prefixed, i);
+        if (!c) {
+            continue;
+        }
+
+        ncc_parse_tree_t *cur = c;
+        while (cur && !ncc_tree_is_leaf(cur)
+               && ncc_tree_num_children(cur) > 0) {
+            ncc_parse_tree_t *next = ncc_tree_child(cur, 0);
+            if (!next) {
+                break;
+            }
+            cur = next;
+        }
+        if (!cur || !ncc_tree_is_leaf(cur)) {
+            continue;
+        }
+
+        const char *text = ncc_xform_leaf_text(cur);
+        if (!text) {
+            continue;
+        }
+        if (!saw_n00b && strcmp(text, "n00b") == 0) {
+            saw_n00b = true;
+            continue;
+        }
+        if (saw_n00b && !saw_name && strcmp(text, name) == 0) {
+            saw_name = true;
+        }
+    }
+
+    return saw_n00b && saw_name;
+}
+
+static bool
+attribute_seq_contains_n00b_named(ncc_parse_tree_t *attr_seq,
+                                  const char *name)
+{
+    if (!attr_seq || !name || ncc_tree_is_leaf(attr_seq)) {
+        return false;
+    }
+
+    ncc_layout_parse_tree_list_t attrs = {0};
+    ncc_layout_collect_nt_children(attr_seq, "attribute", &attrs);
+    bool found = false;
+    for (size_t i = 0; i < attrs.len; i++) {
+        if (attribute_is_n00b_named(attrs.data[i], name)) {
+            found = true;
+            break;
+        }
+    }
+    ncc_free(attrs.data);
+    return found;
+}
+
+static bool
+subtree_carries_n00b_named_attr(ncc_parse_tree_t *node, const char *name)
+{
+    if (!node || !name || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+
+    if (ncc_xform_nt_name_is(node, "attribute_specifier_sequence")) {
+        return attribute_seq_contains_n00b_named(node, name);
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (subtree_carries_n00b_named_attr(ncc_tree_child(node, i), name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void
+strip_n00b_named_attribute_specifiers(ncc_parse_tree_t *parent,
+                                      const char *name)
+{
+    if (!parent || !name || ncc_tree_is_leaf(parent)) {
+        return;
+    }
+
+    size_t i = 0;
+    while (i < ncc_tree_num_children(parent)) {
+        ncc_parse_tree_t *child = ncc_tree_child(parent, i);
+        if (child && !ncc_tree_is_leaf(child)
+            && ncc_xform_nt_name_is(child, "attribute_specifier")
+            && attribute_seq_contains_n00b_named(child, name)) {
+            ncc_xform_remove_child(parent, i);
+            continue;
+        }
+
+        strip_n00b_named_attribute_specifiers(child, name);
+        i++;
+    }
+}
+
 static void
 add_token_trivia(ncc_token_info_t *tok, const char *text, bool leading)
 {
@@ -2596,6 +2711,10 @@ scan_function_definition(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *fn)
         return;
     }
 
+    if (subtree_carries_n00b_named_attr(fn, "nogc")) {
+        return;
+    }
+
     if (node_starts_in_system_header(fn) || node_uses_computed_goto(fn)
         || node_mentions_manual_gc_stack_api(compound)) {
         return;
@@ -2999,11 +3118,13 @@ xform_gc_stack_translation_unit(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu)
 {
     ncc_xform_data_t *data = ncc_xform_get_data(ctx);
     if (!data || !data->gc_stack_maps) {
+        strip_n00b_named_attribute_specifiers(tu, "nogc");
         return nullptr;
     }
 
     collect_gc_type_info(ctx, tu);
     scan_function_definitions(ctx, tu);
+    strip_n00b_named_attribute_specifiers(tu, "nogc");
 
     if (!data->gc_stack_roots) {
         return nullptr;

--- a/test/test_auto_gc_roots_nested_generic_struct.c
+++ b/test/test_auto_gc_roots_nested_generic_struct.c
@@ -1,0 +1,51 @@
+// test_auto_gc_roots_nested_generic_struct.c
+//
+// Regression test for static aggregates that embed a generic-struct
+// field. The auto-root pass must run after `_generic_struct` lowering
+// has emitted the concrete struct definition and rewritten this member
+// to `struct <generated-tag>`, otherwise the nested pointer-bearing
+// fields are invisible and no root table entry is emitted.
+//
+// Expected emit includes at least:
+//     { .addr = (void *) & (g_endpoint).events.data, .num_words = 1 },
+
+typedef unsigned long size_t;
+
+typedef struct n00b_rwlock_t n00b_rwlock_t;
+typedef struct n00b_allocator_t n00b_allocator_t;
+typedef struct n00b_gc_map_t n00b_gc_map_t;
+
+typedef enum n00b_gc_scan_kind_t {
+    N00B_GC_SCAN_NONE = 0,
+} n00b_gc_scan_kind_t;
+
+typedef void (*n00b_gc_scan_cb_t)(n00b_gc_map_t *, void *);
+
+#define n00b_list_tid(T) typeid("n00b_list", T)
+#define n00b_list_t(T)                                                      \
+    _generic_struct n00b_list_tid(T) {                                      \
+        T                  *data;                                           \
+        size_t              len;                                            \
+        size_t              cap;                                            \
+        n00b_rwlock_t      *lock;                                           \
+        n00b_allocator_t   *allocator;                                      \
+        n00b_gc_scan_kind_t scan_kind;                                      \
+        n00b_gc_scan_cb_t   scan_cb;                                        \
+        void               *scan_user;                                      \
+    }
+
+typedef struct n00b_string_t n00b_string_t;
+
+static struct endpoint_like_t {
+    int marker;
+    n00b_list_t(n00b_string_t *) events;
+} g_endpoint;
+
+int
+main(void)
+{
+    return (g_endpoint.marker == 0
+            && g_endpoint.events.data == ((void *)0))
+               ? 0
+               : 1;
+}

--- a/test/test_gc_stack_maps_nogc_attribute.c
+++ b/test/test_gc_stack_maps_nogc_attribute.c
@@ -1,0 +1,6 @@
+[[n00b::nogc]] int
+gc_stack_maps_nogc_fixture(int *input)
+{
+    int *local = input;
+    return local ? *local : 0;
+}


### PR DESCRIPTION
Summary: move gc_globals to post-order translation_unit so auto-roots see generic-struct lowering; honor and strip [[n00b::nogc]] in gc stack-map emission. Tests: NCC_COMPILE_ARGS='-j8' NCC_TEST_ARGS='ncc_gc_stack_maps_nogc_attribute_skips_function ncc_gc_stack_maps_nogc_attribute_stripped ncc_auto_gc_roots_nested_generic_struct' scripts/build.sh