### PR TITLE
xform: emit auto GC roots via linker section

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -442,8 +442,8 @@ foreach name, params : ncc_compile_tests
   # provides n00b_gc_stack_push / _pop, so the transform would emit
   # references that fail to compile. Opt out per-test.
   # WP-003 Phase 1 (D-031): auto-roots default flipped to on. Same
-  # reason — these fixtures don't link libn00b and therefore have
-  # no n00b_gc_register_roots / n00b_gc_root_t. Opt out per-test.
+  # reason — these fixtures don't link libn00b and therefore do not
+  # provide the n00b GC root section types. Opt out per-test.
   test('ncc_' + name, test_runner,
     args : [ncc_exe, params[0], params[1]] + ncc_test_flags + extra_args
            + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
@@ -957,11 +957,11 @@ test('ncc_auto_gc_roots_default_on', test_runner,
 )
 
 # WP-001 Phase 2: pointer-scalar TU-scope decls register. The
-# emit shape per spec § 4.1 / D-005 is one table-and-ctor trio per
-# TU. Three assertions pin the per-symbol entries (`& x` and
-# `& y` in declaration order) and the forward declaration of the
-# batch runtime API (`n00b_gc_register_roots`, per D-012). All
-# four use the same source so a missing emit fails every check.
+# emit shape per spec § 4.1 / D-005 is one root table and one
+# linker-section entry per TU. Three assertions pin the per-symbol
+# entries (`& x` and `& y` in declaration order) and the section
+# descriptor. All use the same source so a missing emit fails every
+# check.
 test('ncc_auto_gc_roots_pointer_scalar_x', test_runner,
   args : [ncc_exe, 'preprocess_contains',
           test_dir / 'test_auto_gc_roots_pointer_scalar.c',
@@ -980,10 +980,10 @@ test('ncc_auto_gc_roots_pointer_scalar_y', test_runner,
   depends : ncc_exe,
 )
 
-test('ncc_auto_gc_roots_pointer_scalar_fwd_decl', test_runner,
+test('ncc_auto_gc_roots_pointer_scalar_section_entry', test_runner,
   args : [ncc_exe, 'preprocess_contains',
           test_dir / 'test_auto_gc_roots_pointer_scalar.c',
-          'extern void n00b_gc_register_roots']
+          '__ncc_gc_root_section_entry_']
          + ncc_test_flags + ['--ncc-auto-gc-roots'],
   suite : 'ncc',
   depends : ncc_exe,

--- a/src/xform/xform_gc_globals.c
+++ b/src/xform/xform_gc_globals.c
@@ -42,8 +42,8 @@
 // — the cheapest possible no-op (no allocation, no walk, no emit, no
 // diagnostic). When the flag is on, the pass walks the TU's
 // external_declarations, classifies definitions per the rules above,
-// and emits the per-TU table + `[[gnu::constructor]]` registrar
-// trio from spec § 4.1.
+// and emits the per-TU table + linker-section descriptor from spec
+// § 4.1.
 //
 // The `gc_globals_warnf` helper is the warn-and-skip diagnostic-
 // emission idiom (DF-001 / D-013). The shape mirrors
@@ -56,10 +56,9 @@
 //     primitives, ncc_alloc_*, etc.
 //   * The C source we *emit* via `ncc_buffer_printf` into the
 //     post-transform TU is libn00b-flavored: uses `((void *)0)` not
-//     `NULL` per D-016 (clangd test-file noise), `[[gnu::constructor]]`
-//     not `__attribute__((constructor))`, and references
-//     `n00b_gc_root_t` + `n00b_gc_register_roots` as defined in
-//     libn00b's `core/gc.h` (D-005, D-012).
+//     `NULL` per D-016 (clangd test-file noise), and references
+//     `n00b_gc_root_t` + `n00b_gc_root_section_entry_t` as defined in
+//     libn00b's `n00b.h`.
 
 #include "lib/alloc.h"
 #include "lib/buffer.h"
@@ -1412,22 +1411,53 @@ classify_declaration(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *decl,
 }
 
 // ============================================================================
-// Emit: build the forward-decl + table + ctor source string
+// Emit: build the table + linker-section descriptor source string
 // ============================================================================
 
 static char *
-build_emit_source(const char *tu_uniq, candvec_t *cands)
+derive_gc_root_section_attr(const char *stobj_attr)
+{
+    if (stobj_attr) {
+        const char *p = strstr(stobj_attr, "n00b_stobj");
+        if (p) {
+            const char *end = p + strlen("n00b_stobj");
+            while (*end && *end != '"') {
+                end++;
+            }
+            return ncc_layout_format_cstr(
+                "%.*sn00b_gcroots%s",
+                (int)(p - stobj_attr), stobj_attr,
+                end);
+        }
+
+        p = strstr(stobj_attr, ".n00bs");
+        if (p) {
+            return ncc_layout_format_cstr(
+                "%.*s.n00br%s",
+                (int)(p - stobj_attr), stobj_attr,
+                p + strlen(".n00bs"));
+        }
+    }
+
+#if defined(__APPLE__)
+    return ncc_layout_copy_cstr("[[gnu::section(\"__DATA,n00b_gcroots\"), gnu::used]]");
+#elif defined(_WIN32)
+    return ncc_layout_copy_cstr("[[gnu::section(\".n00br$m\"), gnu::used]]");
+#else
+    return ncc_layout_copy_cstr("[[gnu::section(\"n00b_gcroots\"), gnu::used]]");
+#endif
+}
+
+static char *
+build_emit_source(ncc_xform_ctx_t *ctx, const char *tu_uniq, candvec_t *cands)
 {
     ncc_buffer_t *buf = ncc_buffer_empty();
-
-    // Forward declaration of the libn00b runtime symbol (D-012).
-    ncc_buffer_puts(buf,
-        "extern void n00b_gc_register_roots(const n00b_gc_root_t *roots,"
-        " size_t count);\n");
+    const char   *stobj_attr = ncc_xform_get_data(ctx)->static_object_entry_attr;
+    char         *root_attr  = derive_gc_root_section_attr(stobj_attr);
 
     // Table.
     ncc_buffer_printf(buf,
-        "static n00b_gc_root_t __ncc_gc_root_table_%s[] = {\n",
+        "static const n00b_gc_root_t __ncc_gc_root_table_%s[] = {\n",
         tu_uniq);
     for (size_t i = 0; i < cands->len; i++) {
         cand_t *c = &cands->items[i];
@@ -1461,18 +1491,15 @@ build_emit_source(const char *tu_uniq, candvec_t *cands)
     }
     ncc_buffer_puts(buf, "};\n");
 
-    // Constructor. Uses libn00b-flavored C — `[[gnu::constructor]]`
-    // (C23 attribute spelling) and the single batch register call
-    // (D-005).
     ncc_buffer_printf(buf,
-        "[[gnu::constructor]]\n"
-        "static void __ncc_gc_root_register_%s(void) {\n"
-        "    n00b_gc_register_roots(__ncc_gc_root_table_%s,\n"
-        "                           sizeof __ncc_gc_root_table_%s\n"
-        "                               / sizeof __ncc_gc_root_table_%s[0]);\n"
-        "}\n",
-        tu_uniq, tu_uniq, tu_uniq, tu_uniq);
+        "%s static const n00b_gc_root_section_entry_t "
+        "__ncc_gc_root_section_entry_%s = {"
+        ".roots = __ncc_gc_root_table_%s,"
+        ".count = sizeof __ncc_gc_root_table_%s"
+        " / sizeof __ncc_gc_root_table_%s[0]};\n",
+        root_attr, tu_uniq, tu_uniq, tu_uniq, tu_uniq);
 
+    ncc_free(root_attr);
     return ncc_buffer_take(buf);
 }
 
@@ -1550,7 +1577,7 @@ xform_gc_globals_tu(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu)
     }
 
     char *tu_uniq = tu_uniq_suffix(data->input_file);
-    char *source  = build_emit_source(tu_uniq, &cands);
+    char *source  = build_emit_source(ctx, tu_uniq, &cands);
     ncc_free(tu_uniq);
     candvec_free(&cands);
 

--- a/test/test_auto_gc_roots_pointer_scalar.c
+++ b/test/test_auto_gc_roots_pointer_scalar.c
@@ -8,14 +8,12 @@
 //   2. `static n00b_buffer_t *y = ((void *)0);`
 //
 // The ncc-emitted post-transform stream must contain:
-//   - a single `extern void n00b_gc_register_roots(...)` forward
-//     declaration,
 //   - a single `__ncc_gc_root_table_<TU-uniq>[]` array with one
 //     entry per qualifying decl in declaration order,
-//   - a `[[gnu::constructor]]` registrar that calls the runtime
-//     function with the table and its computed length.
+//   - a single `__ncc_gc_root_section_entry_<TU-uniq>` descriptor
+//     in the `n00b_gcroots` linker section.
 //
-// The meson wiring asserts the presence of the registrar entries
+// The meson wiring asserts the presence of the root entries
 // for both `x` and `y` via `preprocess_contains`. The runner only
 // exercises `ncc -E`, so this source is never compiled to an
 // executable; the local typedefs are stubs that let ncc's


### PR DESCRIPTION
Moves auto-GC-root emission from constructor calls to linker-section descriptors so n00b can register static root tables during runtime init without pre-init allocation. The default section spelling now uses __DATA,n00b_gcroots on Darwin, .n00br on Windows, and n00b_gcroots on ELF. Tests: NCC_COMPILE_ARGS='-j8' NCC_TEST_ARGS='ncc_auto_gc_roots_pointer_scalar_x ncc_auto_gc_roots_pointer_scalar_y ncc_auto_gc_roots_pointer_scalar_section_entry ncc_auto_gc_roots_default_on ncc_auto_gc_roots_nested_generic_struct ncc_gc_stack_maps_nogc_attribute_skips_function ncc_gc_stack_maps_nogc_attribute_stripped' scripts/build.sh.