### PR TITLE
xform: pack varargs when kargs are omitted

### DIFF
--- a/src/xform/xform_kargs_vargs.c
+++ b/src/xform/xform_kargs_vargs.c
@@ -1714,6 +1714,53 @@ static bool is_kw_func_kargs_literal(ncc_parse_tree_t *expr) {
   return match;
 }
 
+// Check whether a positional arg's text is a synthesized ncc vargs compound
+// literal: & ( <vargs_type> ) { . nargs = ..., . cur_ix = ..., . args = ... }.
+//
+// This is intentionally shape-based rather than count-based. A user call to a
+// vargs+kargs function may have the same number of positional arguments as a
+// transformed call; only the synthesized trailing slots should suppress another
+// call-site rewrite.
+static bool is_ncc_vargs_literal(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *expr) {
+  if (!expr) {
+    return false;
+  }
+
+  ncc_string_t text = ncc_xform_node_to_text(expr);
+  if (!text.data) {
+    return false;
+  }
+
+  const char *p = text.data;
+  while (*p == ' ' || *p == '\t') {
+    p++;
+  }
+
+  const char *vargs_type = get_vargs_type(ctx);
+  bool match = strncmp(p, "&", 1) == 0 && strstr(p, vargs_type) != nullptr &&
+               strstr(p, ". nargs") != nullptr &&
+               strstr(p, ". cur_ix") != nullptr &&
+               strstr(p, ". args") != nullptr;
+
+  ncc_free(text.data);
+  return match;
+}
+
+static ncc_parse_tree_t *nth_positional_arg(collected_arg_t *args,
+                                            int arg_count,
+                                            int ordinal) {
+  int pos_count = 0;
+  for (int i = 0; i < arg_count; i++) {
+    if (!args[i].name) {
+      pos_count++;
+      if (pos_count == ordinal) {
+        return args[i].expr;
+      }
+    }
+  }
+  return nullptr;
+}
+
 // Extract the first positional argument from an argument_expression_list.
 // Returns the assignment_expression or conditional_expression node.
 static ncc_parse_tree_t *find_first_positional_arg(ncc_parse_tree_t *arg_list) {
@@ -1928,31 +1975,27 @@ static ncc_parse_tree_t *xform_call(ncc_xform_ctx_t *ctx,
       // Function has no special params — nothing to do.
       already_done = true;
     } else if (meta->kw && !meta->va) {
-      // kargs-only: expected = positional + 1 kargs struct.
+      // kargs-only: expected = positional + 1 synthesized kargs struct.
       int expected = meta->kw->num_positional + 1;
-      if (n_positional == expected) {
+      ncc_parse_tree_t *kargs_arg =
+          nth_positional_arg(args, arg_count, expected);
+      if (n_positional == expected && meta->kw && !meta->kw->is_opaque &&
+          is_kw_func_kargs_literal(kargs_arg)) {
         already_done = true;
       }
     } else if (meta->va && meta->kw) {
-      // vargs+kargs: expected = positional + 1 vargs + 1 kargs.
-      // But if the last positional arg is a kw_func-generated kargs
-      // compound literal, it looks like a positional arg but is really
-      // the kargs — the call still needs transformation.
+      // vargs+kargs: expected = positional + 1 synthesized vargs literal
+      // + 1 synthesized kargs struct.  Count alone is not enough: a normal
+      // call such as log(fmt, a, b) has the same count when fmt is the only
+      // fixed positional parameter.
       int expected = meta->va->num_positional + 2;
       if (n_positional == expected) {
-        // Find the last positional arg and check if it's a kw_func
-        // kargs literal.  If so, the call is NOT already done.
-        ncc_parse_tree_t *last_pos = nullptr;
-        int pos_count = 0;
-        for (int i = 0; i < arg_count; i++) {
-          if (!args[i].name) {
-            pos_count++;
-            if (pos_count == n_positional) {
-              last_pos = args[i].expr;
-            }
-          }
-        }
-        if (!last_pos || !is_kw_func_kargs_literal(last_pos)) {
+        ncc_parse_tree_t *vargs_arg =
+            nth_positional_arg(args, arg_count, meta->va->num_positional + 1);
+        ncc_parse_tree_t *kargs_arg =
+            nth_positional_arg(args, arg_count, expected);
+        if (is_ncc_vargs_literal(ctx, vargs_arg) && meta->kw &&
+            !meta->kw->is_opaque && is_kw_func_kargs_literal(kargs_arg)) {
           already_done = true;
         }
       }

--- a/test/test_kargs_vargs.c
+++ b/test/test_kargs_vargs.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 typedef struct ncc_vargs_t {
     unsigned int  nargs;
@@ -6,13 +7,38 @@ typedef struct ncc_vargs_t {
     void        **args;
 } ncc_vargs_t;
 
+static unsigned    seen_args[4];
+static const char *seen_prefix[4];
+static int         seen_count;
+
 // Function with both vargs and kargs
 void log_msg(int level, +) _kargs { const char *prefix = "LOG"; } {
+    seen_prefix[seen_count] = prefix;
+    seen_args[seen_count]   = vargs->nargs;
+    seen_count++;
     printf("[%s] level=%d args=%u\n", prefix, level, vargs->nargs);
 }
 
 int main(void) {
     log_msg(1);                                // no vargs, default prefix
     log_msg(2, "a", "b", .prefix = "DBG");     // vargs + karg override
+    log_msg(3, "a", "b");                      // vargs + omitted kargs
+
+    if (seen_count != 3) {
+        printf("FAIL seen_count=%d\n", seen_count);
+        return 1;
+    }
+    if (seen_args[0] != 0 || strcmp(seen_prefix[0], "LOG") != 0) {
+        printf("FAIL default no-vargs case\n");
+        return 2;
+    }
+    if (seen_args[1] != 2 || strcmp(seen_prefix[1], "DBG") != 0) {
+        printf("FAIL keyword override case\n");
+        return 3;
+    }
+    if (seen_args[2] != 2 || strcmp(seen_prefix[2], "LOG") != 0) {
+        printf("FAIL omitted kargs with two vargs\n");
+        return 4;
+    }
     return 0;
 }


### PR DESCRIPTION
## Summary
- fix the kargs/vargs call-site already-transformed guard to require synthesized vargs and kargs argument shapes instead of relying on positional argument count
- add regression coverage for a `+ _kargs` function called with multiple ordinary varargs and no keyword overrides

## Tests
- `SDKROOT=$(/usr/bin/xcrun --show-sdk-path) meson test -C build --no-rebuild ncc_kargs_vargs ncc_kargs_vargs_default_omitted ncc_kargs ncc_vargs`