### PR TITLE
xform: store kargs metadata in dynamic dict

### DIFF
--- a/include/xform/xform_data.h
+++ b/include/xform/xform_data.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// Canonical definition of ncc_xform_data_t and ncc_meta_table_t.
+// Canonical definition of ncc_xform_data_t.
 //
 // All transform files include this header instead of re-declaring
 // layout-compatible struct copies.  The struct is allocated in ncc.c
@@ -8,17 +8,6 @@
 
 #include "xform/xform_template.h"
 #include "lib/dict.h"  // ncc_dict_t used in ncc_xform_data_t
-
-#define NCC_META_TABLE_SIZE 256
-
-typedef struct {
-    char *key;
-    void *value;
-} ncc_meta_entry_t;
-
-typedef struct {
-    ncc_meta_entry_t entries[NCC_META_TABLE_SIZE];
-} ncc_meta_table_t;
 
 typedef enum {
     NCC_GC_STACK_ROOT_PARAM,
@@ -57,7 +46,7 @@ typedef struct {
     const char                *compiler;
     const char                *input_file;
     const char                *constexpr_headers;
-    ncc_meta_table_t           func_meta;
+    ncc_dict_t                 func_meta;
     ncc_dict_t                 option_meta;
     ncc_dict_t                 option_decls;
     ncc_dict_t                 generic_struct_decls;

--- a/meson.build
+++ b/meson.build
@@ -404,6 +404,8 @@ ncc_compile_tests = {
                                   test_dir / 'test_kargs_vargs_default_omitted.c'],
   'kargs_void_params': ['compile_run',
                         test_dir / 'test_kargs_void_params.c'],
+  'kargs_many_metadata': ['compile_run',
+                          test_dir / 'test_kargs_many_metadata.c'],
   'function_contracts': ['compile_run',
                          test_dir / 'test_function_contracts.c'],
   'function_contracts_parse': ['preprocess',

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -2195,7 +2195,6 @@ compile_file(ncc_opts_t *opts)
         .compiler          = opts->compiler,
         .input_file        = opts->input_file,
         .constexpr_headers = opts->constexpr_headers,
-        .func_meta         = {0},
         .template_reg      = &tmpl_reg,
         .vargs_type        = vargs_type,
         .once_prefix       = once_prefix,
@@ -2216,6 +2215,8 @@ compile_file(ncc_opts_t *opts)
         .gc_stack_maps_relaxed       = opts->gc_stack_maps_relaxed,
         .auto_gc_roots               = opts->auto_gc_roots,
     };
+    ncc_dict_init(&xdata.func_meta,
+                            ncc_hash_cstring, ncc_dict_cstr_eq);
     ncc_dict_init(&xdata.option_meta,
                             ncc_hash_cstring, ncc_dict_cstr_eq);
     ncc_dict_init(&xdata.option_decls,
@@ -2252,6 +2253,7 @@ compile_file(ncc_opts_t *opts)
     ncc_mem_report("after transform");
 #endif
 
+    ncc_dict_free(&xdata.func_meta);
     ncc_dict_free(&xdata.option_meta);
     ncc_dict_free(&xdata.option_decls);
     ncc_dict_free(&xdata.generic_struct_decls);

--- a/src/xform/xform_kargs_vargs.c
+++ b/src/xform/xform_kargs_vargs.c
@@ -66,66 +66,33 @@ typedef struct {
   ncc_vargs_info_t *va;
 } ncc_func_meta_t;
 
-// Simple hash table for function metadata.
-#define META_TABLE_SIZE 256
-
-typedef struct {
-  char *key;
-  ncc_func_meta_t *value;
-} meta_entry_t;
-
-typedef struct {
-  meta_entry_t entries[META_TABLE_SIZE];
-} meta_table_t;
+typedef ncc_dict_t meta_table_t;
 
 // Access the meta_table from ctx->user_data.
 static meta_table_t *get_meta_table(ncc_xform_ctx_t *ctx) {
   ncc_xform_data_t *d = ncc_xform_get_data(ctx);
-  // meta_table_t and ncc_meta_table_t have identical layout.
-  return (meta_table_t *)&d->func_meta;
+  return &d->func_meta;
 }
 
 // ============================================================================
 // Hash table operations
 // ============================================================================
 
-static uint32_t hash_str(const char *s) {
-  uint32_t h = 5381;
-  for (; *s; s++) {
-    h = ((h << 5) + h) + (unsigned char)*s;
-  }
-  return h;
-}
-
 static ncc_func_meta_t *meta_lookup(meta_table_t *table, const char *name) {
-  uint32_t idx = hash_str(name) % META_TABLE_SIZE;
-  for (uint32_t i = 0; i < META_TABLE_SIZE; i++) {
-    uint32_t slot = (idx + i) % META_TABLE_SIZE;
-    if (!table->entries[slot].key) {
-      return nullptr;
-    }
-    if (strcmp(table->entries[slot].key, name) == 0) {
-      return table->entries[slot].value;
-    }
-  }
-  return nullptr;
+  bool found = false;
+  ncc_func_meta_t *meta = ncc_dict_get(table, (void *)name, &found);
+  return found ? meta : nullptr;
 }
 
 static ncc_func_meta_t *meta_insert(meta_table_t *table, const char *name) {
-  uint32_t idx = hash_str(name) % META_TABLE_SIZE;
-  for (uint32_t i = 0; i < META_TABLE_SIZE; i++) {
-    uint32_t slot = (idx + i) % META_TABLE_SIZE;
-    if (!table->entries[slot].key) {
-      table->entries[slot].key = strdup(name);
-      table->entries[slot].value = ncc_alloc(ncc_func_meta_t);
-      return table->entries[slot].value;
-    }
-    if (strcmp(table->entries[slot].key, name) == 0) {
-      return table->entries[slot].value;
-    }
+  ncc_func_meta_t *meta = meta_lookup(table, name);
+  if (meta != nullptr) {
+    return meta;
   }
-  fprintf(stderr, "ncc: error: function metadata table full\n");
-  exit(1);
+
+  meta = ncc_alloc(ncc_func_meta_t);
+  ncc_dict_put(table, strdup(name), meta);
+  return meta;
 }
 
 // ============================================================================

--- a/test/test_kargs_many_metadata.c
+++ b/test/test_kargs_many_metadata.c
@@ -1,0 +1,42 @@
+// Regression: _kargs metadata must not be capped by a small fixed table.
+//
+// The transform tracks per-function keyword metadata so later call-site
+// rewrites know whether to synthesize a kargs object. A translation unit with
+// enough _kargs functions used to fail with "function metadata table full".
+
+#include <stdio.h>
+
+#define DEF_ONE(name)                                                        \
+    int name(int x) _kargs { int bias = 1; };                                \
+    int name(int x) _kargs { int bias = 1; } { return x + kargs->bias; }
+
+#define CHECK_ONE(name)                                                      \
+    do {                                                                     \
+        if (name(1) != 2) {                                                  \
+            printf("FAIL " #name " default\n");                            \
+            return 1;                                                        \
+        }                                                                    \
+        if (name(1, .bias = 3) != 4) {                                       \
+            printf("FAIL " #name " override\n");                           \
+            return 1;                                                        \
+        }                                                                    \
+    } while (0);
+
+#define EACH_10(M, p)                                                        \
+    M(p##0) M(p##1) M(p##2) M(p##3) M(p##4)                                 \
+    M(p##5) M(p##6) M(p##7) M(p##8) M(p##9)
+
+#define EACH_100(M, p)                                                       \
+    EACH_10(M, p##0) EACH_10(M, p##1) EACH_10(M, p##2) EACH_10(M, p##3)      \
+    EACH_10(M, p##4) EACH_10(M, p##5) EACH_10(M, p##6) EACH_10(M, p##7)      \
+    EACH_10(M, p##8) EACH_10(M, p##9)
+
+#define EACH_300(M) EACH_100(M, f0) EACH_100(M, f1) EACH_100(M, f2)
+
+EACH_300(DEF_ONE)
+
+int main(void) {
+    EACH_300(CHECK_ONE)
+    printf("ok\n");
+    return 0;
+}


### PR DESCRIPTION
Summary:
- replace the fixed-size _kargs function metadata table with ncc_dict_t
- initialize/free the metadata dict with transform state
- add a 300-function _kargs regression test for the old table-full failure

Tests:
- NCC_TEST_ARGS='--no-rebuild ncc_kargs ncc_kargs_vargs ncc_kargs_vargs_default_omitted ncc_kargs_void_params ncc_kargs_many_metadata' scripts/build.sh