### PR TITLE
xform: add typed inference support for gc typemap variants

### DIFF
--- a/include/parse/symbol_populate.h
+++ b/include/parse/symbol_populate.h
@@ -1,0 +1,34 @@
+#pragma once
+
+/**
+ * @file symbol_populate.h
+ * @brief Build a scoped symbol table from a parsed translation unit.
+ *
+ * A post-parse, scope-aware DFS that records every named entity — typedefs,
+ * variables, functions, parameters, struct/union/enum tags, and enum
+ * constants — into an `ncc_symtab_t`, along with the parse subtree describing
+ * its type. This is the foundation the type model queries: expression typing
+ * (`typeof`, `typehash`/`typeid` of expressions) and the transforms that today
+ * pattern-match parse-tree shapes resolve names through this table instead.
+ *
+ * Each symbol carries:
+ *   - `decl_node`: the declarator (or specifier) parse node it was declared by.
+ *   - `type_node`: the `declaration_specifiers` / `specifier_qualifier_list`
+ *     subtree giving the base type; combined with the declarator's pointer/
+ *     array suffix to derive the full type.
+ *
+ * Ordinary names live in the "" namespace; struct/union/enum tags live in the
+ * "tag" namespace. Scopes are pushed at `function_definition` and
+ * `compound_statement` boundaries.
+ */
+
+#include "parse/types.h"
+#include "parse/parse_tree.h"
+#include "parse/symtab.h"
+
+/**
+ * @brief Walk @p tree and return a populated symbol table (caller frees with
+ *        `ncc_symtab_free`). @p g supplies the IDENTIFIER terminal id used to
+ *        locate declared names.
+ */
+ncc_symtab_t *ncc_populate_symbols(ncc_grammar_t *g, ncc_parse_tree_t *tree);

--- a/include/parse/type_infer.h
+++ b/include/parse/type_infer.h
@@ -1,0 +1,26 @@
+#pragma once
+
+/**
+ * @file type_infer.h
+ * @brief Expression type inference over the scoped symbol table.
+ *
+ * Computes the C type of an expression parse subtree, returned as a canonical
+ * type spelling (e.g. "int", "n00b_string_t*", "struct foo*"). The spelling is
+ * normalized the same way `ncc_normalize_type_tree` normalizes written types,
+ * so it is directly usable as a `typeof` replacement AND hashes identically to
+ * the same type written explicitly (`typehash`/`typeid`/`typestr`).
+ *
+ * Coverage is incremental. Supported forms return a heap string (caller frees);
+ * anything not yet handled returns nullptr, so callers fall back to existing
+ * behavior rather than emitting a wrong type.
+ */
+
+#include "parse/types.h"
+#include "parse/parse_tree.h"
+#include "parse/symtab.h"
+
+/**
+ * @brief Canonical type spelling of expression @p expr under symbol table
+ *        @p st, or nullptr if the form is not yet typeable. Caller frees.
+ */
+char *ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr);

--- a/include/xform/xform_data.h
+++ b/include/xform/xform_data.h
@@ -8,6 +8,7 @@
 
 #include "xform/xform_template.h"
 #include "lib/dict.h"  // ncc_dict_t used in ncc_xform_data_t
+#include "parse/symtab.h"  // ncc_symtab_t used in ncc_xform_data_t
 
 typedef enum {
     NCC_GC_STACK_ROOT_PARAM,
@@ -78,6 +79,9 @@ typedef struct {
     bool                       auto_gc_roots;
     ncc_gc_stack_root_t       *gc_stack_roots;
     size_t                     gc_stack_root_count;
+    // Scoped symbol table for the TU (built post-parse by symbol_populate).
+    // The type model queries this; nullptr if population was skipped.
+    ncc_symtab_t              *symtab;
 } ncc_xform_data_t;
 
 static inline ncc_xform_data_t *ncc_xform_get_data(ncc_xform_ctx_t *ctx) {

--- a/meson.build
+++ b/meson.build
@@ -170,6 +170,8 @@ src_parse = files(
   'src/parse/tree_dump.c',
   'src/parse/typedef_walk.c',
   'src/parse/symtab.c',
+  'src/parse/symbol_populate.c',
+  'src/parse/type_infer.c',
   'src/parse/c_tokenizer.c',
   'src/parse/emit.c',
   'src/parse/commander.c',
@@ -393,6 +395,7 @@ ncc_static_descriptor_flags = [
 # Compiler-level tests (run through ncc executable)
 ncc_compile_tests = {
   'bang':          ['compile_run',  test_dir / 'test_bang.c'],
+  'typehash_expr': ['compile_run',  test_dir / 'test_typehash_expr.c'],
   'array_literal': ['compile_run',  test_dir / 'test_array_literal.c'],
   'list_literal':  ['compile_run',  test_dir / 'test_list_literal.c'],
   'dict_literal':  ['compile_run',  test_dir / 'test_dict_literal.c'],
@@ -866,6 +869,72 @@ test('ncc_gc_typemap_union_mixed_skipped', test_runner,
   args : [ncc_exe, 'preprocess_not_contains',
           test_dir / 'test_gc_typemap.c',
           'sizeof(gcmap_union_mixed_t)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# Discriminated-union (n00b_variant_t) GC maps: a variant's value word is
+# described precisely via its selector discriminant instead of warning + a
+# conservative scan.
+
+# A pointer-bearing variant emits a variant descriptor (not a flat offset).
+test('ncc_gc_typemap_variant_descriptor_emitted', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          'n00b_gc_variant_field_t']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# The descriptor records the selector and value word offsets.
+test('ncc_gc_typemap_variant_selector_offset', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          '__builtin_offsetof(vmap_variant_t,selector)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_variant_value_offset', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          '__builtin_offsetof(vmap_variant_t,value)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# An EMBEDDED variant field is described in-place: the selector/value offsets
+# are taken through the containing struct's field path.
+test('ncc_gc_typemap_variant_embedded', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          '__builtin_offsetof(vmap_holder_t,choice.selector)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# The containing struct still gets its ordinary (unconditional) pointer offsets
+# alongside the variant descriptor.
+test('ncc_gc_typemap_variant_embedded_flat_offset', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          '__builtin_offsetof(vmap_holder_t,head)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# An all-scalar variant stays precise without a variant descriptor (its value
+# word is never a heap pointer) and must not be skipped.
+test('ncc_gc_typemap_variant_all_scalar_no_descriptor', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          'sizeof(vmap_scalar_variant_t)']
          + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
   suite : 'ncc',
   depends : ncc_exe,

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -36,6 +36,7 @@
 #include "parse/bnf.h"
 #include "parse/pwz.h"
 #include "parse/typedef_walk.h"
+#include "parse/symbol_populate.h"
 #include "parse/c_tokenizer.h"
 #include "parse/emit.h"
 #include "xform/xform_gc_typemap.h"
@@ -2235,6 +2236,9 @@ compile_file(ncc_opts_t *opts)
                             ncc_hash_cstring, ncc_dict_cstr_eq);
     ncc_dict_init(&xdata.gc_function_pointer_typedefs,
                             ncc_hash_cstring, ncc_dict_cstr_eq);
+    // Build the scoped symbol table for the type model. Runs after the typedef
+    // reclassification walk so declarator names are settled.
+    xdata.symtab = ncc_populate_symbols(g, tree);
     xctx.user_data = &xdata;
     ncc_verbose("applying transforms");
     tree = ncc_xform_apply(&xreg, &xctx);
@@ -2263,6 +2267,10 @@ compile_file(ncc_opts_t *opts)
     ncc_dict_free(&xdata.gc_aggregate_types);
     ncc_dict_free(&xdata.gc_pointer_typedefs);
     ncc_dict_free(&xdata.gc_function_pointer_typedefs);
+    if (xdata.symtab) {
+        ncc_symtab_free(xdata.symtab);
+        xdata.symtab = nullptr;
+    }
     free_gc_stack_roots(xdata.gc_stack_roots);
     ncc_template_registry_free(&tmpl_reg);
     ncc_xform_registry_free(&xreg);

--- a/src/parse/symbol_populate.c
+++ b/src/parse/symbol_populate.c
@@ -1,0 +1,397 @@
+// symbol_populate.c — Build a scoped symbol table from a parsed TU.
+//
+// Scope-aware DFS over the parse tree. Records typedefs, variables, functions,
+// parameters, struct/union/enum tags, and enum constants into an ncc_symtab_t,
+// each with the parse subtree describing its type. Ordinary names go in the ""
+// namespace; tags go in "tag". Scopes are pushed at function_definition and
+// compound_statement boundaries so shadowing resolves correctly.
+//
+// This is deliberately a thin first layer: it records WHERE each name is
+// declared and the syntactic type that declares it. Deriving a normalized type
+// from (specifiers, declarator) and typing expressions is the job of the type
+// model built on top of this table.
+
+#include "parse/symbol_populate.h"
+#include "internal/parse/grammar_internal.h"
+#include <string.h>
+
+// ============================================================================
+// Tree helpers (parse-layer; mirror the primitives in typedef_walk.c)
+// ============================================================================
+
+static int64_t
+identifier_tid(ncc_grammar_t *g)
+{
+    ncc_string_t name  = NCC_STRING_STATIC("IDENTIFIER");
+    bool         found = false;
+    void        *val   = _ncc_dict_get(g->terminal_map, (void *)name.data,
+                                       &found);
+    return found ? (int64_t)(intptr_t)val : NCC_TOK_IDENTIFIER;
+}
+
+static bool
+nt_is(ncc_parse_tree_t *node, const char *lit)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+    ncc_string_t name = ncc_tree_node_value(node).name;
+    return name.data && strcmp(name.data, lit) == 0;
+}
+
+// Direct child by NT name, transparently descending through group wrappers
+// (the same convention typedef_walk.c uses).
+static ncc_parse_tree_t *
+child_nt(ncc_parse_tree_t *node, const char *child_name)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return nullptr;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *child = ncc_tree_child(node, i);
+        if (!child || ncc_tree_is_leaf(child)) {
+            continue;
+        }
+        ncc_nt_node_t *cpn = &ncc_tree_node_value(child);
+        if (cpn->group_top) {
+            ncc_parse_tree_t *found = child_nt(child, child_name);
+            if (found) {
+                return found;
+            }
+            continue;
+        }
+        if (cpn->name.data && strcmp(cpn->name.data, child_name) == 0) {
+            return child;
+        }
+    }
+    return nullptr;
+}
+
+static bool
+subtree_has_token(ncc_parse_tree_t *node, const char *text)
+{
+    if (!node) {
+        return false;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
+        if (tok && ncc_option_is_set(tok->value)) {
+            ncc_string_t val = ncc_option_get(tok->value);
+            return val.data && strcmp(val.data, text) == 0;
+        }
+        return false;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (subtree_has_token(ncc_tree_child(node, i), text)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// First IDENTIFIER token in a declarator that names the declared entity — i.e.
+// the first identifier NOT inside a parameter list (which would be a parameter
+// name, not the name being declared). Handles `*x`, `x[]`, `(*fp)(args)`.
+static ncc_token_info_t *
+declared_name_tok(ncc_parse_tree_t *node, int64_t id_tid)
+{
+    if (!node) {
+        return nullptr;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
+        return (tok && tok->tid == (int32_t)id_tid) ? tok : nullptr;
+    }
+    // Do not descend into parameter lists: their identifiers are parameter
+    // names, not the name being declared here.
+    if (nt_is(node, "parameter_type_list") || nt_is(node, "parameter_list")) {
+        return nullptr;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_token_info_t *t = declared_name_tok(ncc_tree_child(node, i), id_tid);
+        if (t) {
+            return t;
+        }
+    }
+    return nullptr;
+}
+
+static ncc_string_t
+tok_text(ncc_token_info_t *tok)
+{
+    if (tok && ncc_option_is_set(tok->value)) {
+        return ncc_option_get(tok->value);
+    }
+    return ncc_string_empty();
+}
+
+// ============================================================================
+// Recording
+// ============================================================================
+
+// Namespace names. Returned from helpers because NCC_STRING_STATIC is a
+// compound literal (not a valid file-scope static initializer).
+static inline ncc_string_t
+ns_ord(void)
+{
+    return NCC_STRING_STATIC("");
+}
+static inline ncc_string_t
+ns_tag(void)
+{
+    return NCC_STRING_STATIC("tag");
+}
+
+static void scan_params(ncc_symtab_t *st, ncc_parse_tree_t *node,
+                        int64_t id_tid);
+
+// True if a declarator subtree is a function declarator (has a parameter list).
+static bool
+declarator_is_function(ncc_parse_tree_t *declarator)
+{
+    if (!declarator) {
+        return false;
+    }
+    return child_nt(declarator, "parameter_type_list") != nullptr
+        || child_nt(declarator, "parameter_list") != nullptr;
+}
+
+static void
+add_named(ncc_symtab_t *st, ncc_string_t ns, ncc_token_info_t *name_tok,
+          ncc_sym_kind_t kind, ncc_parse_tree_t *decl_node,
+          ncc_parse_tree_t *type_node)
+{
+    if (!name_tok) {
+        return;
+    }
+    ncc_string_t name = tok_text(name_tok);
+    if (!name.data || name.u8_bytes == 0) {
+        return;
+    }
+    ncc_sym_entry_t *e = ncc_symtab_add(st, ns, name, kind, decl_node);
+    if (e) {
+        e->type_node = type_node;
+    }
+}
+
+// Register a struct/union/enum tag (with body) found in a specifier subtree.
+static void
+record_tag(ncc_symtab_t *st, ncc_parse_tree_t *spec, int64_t id_tid)
+{
+    ncc_parse_tree_t *tag = child_nt(spec, "tag_name");
+    if (!tag) {
+        return;
+    }
+    ncc_token_info_t *tok = declared_name_tok(tag, id_tid);
+    add_named(st, ns_tag(), tok, NCC_SYM_TAG, spec, spec);
+}
+
+// Register enumerators of an enum specifier as integer constants.
+static void
+record_enum_constants(ncc_symtab_t *st, ncc_parse_tree_t *enum_spec,
+                      int64_t id_tid)
+{
+    ncc_parse_tree_t *list = child_nt(enum_spec, "enumerator_list");
+    if (!list) {
+        return;
+    }
+    size_t nc = ncc_tree_num_children(list);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *child = ncc_tree_child(list, i);
+        if (nt_is(child, "enumerator")) {
+            ncc_token_info_t *tok = declared_name_tok(child, id_tid);
+            add_named(st, ns_ord(), tok, NCC_SYM_ENUM_CONST, child, enum_spec);
+        }
+        else {
+            // enumerator_list is left-recursive; recurse to reach nested ones.
+            record_enum_constants(st, child, id_tid);
+        }
+    }
+}
+
+// Walk specifiers for any struct/union/enum tag definitions + enum constants,
+// recording them regardless of whether the enclosing declaration declares a
+// name. (e.g. `struct foo { ... };` or a tag used inline in a variable's type.)
+static void
+record_specifier_tags(ncc_symtab_t *st, ncc_parse_tree_t *node, int64_t id_tid)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return;
+    }
+    if (nt_is(node, "struct_or_union_specifier")
+        && child_nt(node, "member_declaration_list")) {
+        record_tag(st, node, id_tid);
+    }
+    else if (nt_is(node, "enum_specifier")
+             && child_nt(node, "enumerator_list")) {
+        record_tag(st, node, id_tid);
+        record_enum_constants(st, node, id_tid);
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        record_specifier_tags(st, ncc_tree_child(node, i), id_tid);
+    }
+}
+
+// Record each init_declarator of a `declaration` as a typedef / function /
+// variable, keyed by the base specifiers.
+static void
+record_declaration(ncc_symtab_t *st, ncc_parse_tree_t *decl, int64_t id_tid)
+{
+    ncc_parse_tree_t *specs = child_nt(decl, "declaration_specifiers");
+    ncc_parse_tree_t *list  = child_nt(decl, "init_declarator_list");
+
+    // Tags / enum constants in the specifiers are visible even with no
+    // declarator (e.g. a bare `struct foo { ... };`).
+    if (specs) {
+        record_specifier_tags(st, specs, id_tid);
+    }
+    if (!specs || !list) {
+        return;
+    }
+
+    bool is_typedef = subtree_has_token(specs, "typedef");
+
+    size_t nc = ncc_tree_num_children(list);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *child = ncc_tree_child(list, i);
+        ncc_parse_tree_t *id    = nt_is(child, "init_declarator")
+                                    ? child
+                                    : (nt_is(child, "declarator") ? child
+                                                                  : nullptr);
+        if (!id) {
+            // group / left-recursive list node — recurse one level.
+            if (!ncc_tree_is_leaf(child)) {
+                size_t gc = ncc_tree_num_children(child);
+                for (size_t j = 0; j < gc; j++) {
+                    ncc_parse_tree_t *gch = ncc_tree_child(child, j);
+                    if (nt_is(gch, "init_declarator")
+                        || nt_is(gch, "declarator")) {
+                        id = gch;
+                        break;
+                    }
+                }
+            }
+            if (!id) {
+                continue;
+            }
+        }
+        ncc_parse_tree_t *declarator = nt_is(id, "declarator")
+                                         ? id
+                                         : child_nt(id, "declarator");
+        if (!declarator) {
+            continue;
+        }
+        ncc_token_info_t *name = declared_name_tok(declarator, id_tid);
+
+        ncc_sym_kind_t kind = is_typedef          ? NCC_SYM_TYPEDEF
+                            : declarator_is_function(declarator)
+                                ? NCC_SYM_FUNCTION
+                                : NCC_SYM_VARIABLE;
+        add_named(st, ns_ord(), name, kind, declarator, specs);
+    }
+}
+
+// Record every parameter_declaration anywhere under a (left-recursive)
+// parameter list into the current scope.
+static void
+scan_params(ncc_symtab_t *st, ncc_parse_tree_t *node, int64_t id_tid)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return;
+    }
+    if (nt_is(node, "parameter_declaration")) {
+        ncc_parse_tree_t *specs = child_nt(node, "declaration_specifiers");
+        ncc_parse_tree_t *declr = child_nt(node, "declarator");
+        ncc_token_info_t *name  = declr ? declared_name_tok(declr, id_tid)
+                                        : nullptr;
+        add_named(st, ns_ord(), name, NCC_SYM_PARAM, declr ? declr : node, specs);
+        return; // do not descend (nested declarators are this param's own)
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        scan_params(st, ncc_tree_child(node, i), id_tid);
+    }
+}
+
+// Record the parameters of a function declarator into the current scope.
+static void
+record_parameters(ncc_symtab_t *st, ncc_parse_tree_t *declarator, int64_t id_tid)
+{
+    ncc_parse_tree_t *ptl = child_nt(declarator, "parameter_type_list");
+    if (ptl) {
+        scan_params(st, ptl, id_tid);
+    }
+}
+
+// ============================================================================
+// Scope-aware DFS
+// ============================================================================
+
+static void
+walk(ncc_symtab_t *st, ncc_parse_tree_t *node, int64_t id_tid)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return;
+    }
+
+    bool pushed = false;
+    if (nt_is(node, "function_definition") || nt_is(node, "compound_statement")) {
+        ncc_symtab_push_scope(st, ns_ord(), ncc_string_empty());
+        ncc_symtab_push_scope(st, ns_tag(), ncc_string_empty());
+        pushed = true;
+    }
+
+    if (nt_is(node, "declaration")) {
+        record_declaration(st, node, id_tid);
+    }
+    else if (nt_is(node, "function_definition")) {
+        // Return type + name, then parameters into the just-pushed scope.
+        ncc_parse_tree_t *specs = child_nt(node, "declaration_specifiers");
+        ncc_parse_tree_t *declr = child_nt(node, "declarator");
+        if (specs) {
+            record_specifier_tags(st, specs, id_tid);
+        }
+        if (declr) {
+            // The function name binds in the ENCLOSING scope, but recording it
+            // in the body scope still makes it resolvable while typing the
+            // body; the enclosing file-scope prototype (if any) also recorded
+            // it. Good enough for the type model's needs.
+            ncc_token_info_t *name = declared_name_tok(declr, id_tid);
+            add_named(st, ns_ord(), name, NCC_SYM_FUNCTION, declr, specs);
+            record_parameters(st, declr, id_tid);
+        }
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        walk(st, ncc_tree_child(node, i), id_tid);
+    }
+
+    if (pushed) {
+        ncc_symtab_pop_scope(st, ns_ord());
+        ncc_symtab_pop_scope(st, ns_tag());
+    }
+}
+
+ncc_symtab_t *
+ncc_populate_symbols(ncc_grammar_t *g, ncc_parse_tree_t *tree)
+{
+    ncc_symtab_t *st = ncc_symtab_new();
+    if (!st || !tree) {
+        return st;
+    }
+    int64_t id_tid = identifier_tid(g);
+
+    // Global scope so file-scope names live in a scope chain (consistent
+    // shadowing with nested scopes).
+    ncc_symtab_push_scope(st, ns_ord(), ncc_string_empty());
+    ncc_symtab_push_scope(st, ns_tag(), ncc_string_empty());
+
+    walk(st, tree, id_tid);
+
+    return st;
+}

--- a/src/parse/type_infer.c
+++ b/src/parse/type_infer.c
@@ -1,0 +1,366 @@
+// type_infer.c — Expression type inference over the scoped symbol table.
+//
+// Returns the canonical type spelling of an expression (e.g. "n00b_string_t*").
+// Coverage is incremental: identifier, parenthesization, cast, address-of, and
+// dereference are handled today; member access, calls, subscripts, and
+// arithmetic return nullptr (callers fall back rather than emit a wrong type).
+//
+// The spelling is built so it matches ncc_normalize_type_tree's output for the
+// same type written explicitly: a normalized base (from the declaration
+// specifiers) followed by pointer stars with no intervening space. That makes
+// the result usable both as a typeof replacement and as a typehash/typeid key.
+
+#include "parse/type_infer.h"
+#include "util/type_normalize.h"
+#include "lib/alloc.h"
+#include "lib/buffer.h"
+#include <string.h>
+
+// ============================================================================
+// Tree helpers (parse-layer)
+// ============================================================================
+
+static bool
+nt_is(ncc_parse_tree_t *node, const char *lit)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+    ncc_string_t name = ncc_tree_node_value(node).name;
+    return name.data && strcmp(name.data, lit) == 0;
+}
+
+static bool
+is_group(ncc_parse_tree_t *node)
+{
+    return node && !ncc_tree_is_leaf(node) && ncc_tree_node_value(node).group_top;
+}
+
+static ncc_parse_tree_t *
+child_nt(ncc_parse_tree_t *node, const char *child_name)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return nullptr;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *c = ncc_tree_child(node, i);
+        if (!c || ncc_tree_is_leaf(c)) {
+            continue;
+        }
+        if (is_group(c)) {
+            ncc_parse_tree_t *f = child_nt(c, child_name);
+            if (f) {
+                return f;
+            }
+            continue;
+        }
+        ncc_string_t nm = ncc_tree_node_value(c).name;
+        if (nm.data && strcmp(nm.data, child_name) == 0) {
+            return c;
+        }
+    }
+    return nullptr;
+}
+
+// Leaf token text of a leaf node (empty if not a value leaf).
+static ncc_string_t
+leaf_text(ncc_parse_tree_t *node)
+{
+    if (node && ncc_tree_is_leaf(node)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
+        if (tok && ncc_option_is_set(tok->value)) {
+            return ncc_option_get(tok->value);
+        }
+    }
+    return ncc_string_empty();
+}
+
+// Count the non-trivial (nonterminal or value-leaf) children of a node,
+// returning the single such child via *only when there is exactly one.
+static size_t
+meaningful_children(ncc_parse_tree_t *node, ncc_parse_tree_t **only)
+{
+    size_t            count = 0;
+    ncc_parse_tree_t *last  = nullptr;
+    size_t            nc    = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *c = ncc_tree_child(node, i);
+        if (!c) {
+            continue;
+        }
+        count++;
+        last = c;
+    }
+    if (only) {
+        *only = (count == 1) ? last : nullptr;
+    }
+    return count;
+}
+
+// Pointer depth contributed by a declarator's explicit stars, not descending
+// into parameter lists. Returns -1 for forms we cannot type simply (arrays,
+// function declarators) so the caller bails.
+static int
+declarator_ptr_depth(ncc_parse_tree_t *node)
+{
+    if (!node) {
+        return 0;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        ncc_string_t t = leaf_text(node);
+        return (t.data && strcmp(t.data, "*") == 0) ? 1 : 0;
+    }
+    if (nt_is(node, "parameter_type_list") || nt_is(node, "parameter_list")) {
+        return 0;
+    }
+    if (nt_is(node, "array_declarator")) {
+        return -1; // arrays not handled by the simple spelling yet
+    }
+    // A nested function declarator (function pointer) — bail.
+    if (child_nt(node, "parameter_type_list") || child_nt(node, "parameter_list")) {
+        // Only bail if this isn't the top call form; conservatively bail.
+        return -1;
+    }
+    int total = 0;
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        int d = declarator_ptr_depth(ncc_tree_child(node, i));
+        if (d < 0) {
+            return -1;
+        }
+        total += d;
+    }
+    return total;
+}
+
+// Storage-class and function specifiers are not part of a value's type; drop
+// them from a normalized specifier spelling (keep const/volatile, which are).
+static bool
+is_storage_word(const char *w, size_t len)
+{
+    static const char *const kw[] = {
+        "static",    "extern",       "register",  "auto",
+        "typedef",   "thread_local", "constexpr", "inline",
+        "_Noreturn", "__inline",     "__inline__",
+    };
+    for (size_t i = 0; i < sizeof(kw) / sizeof(kw[0]); i++) {
+        if (strlen(kw[i]) == len && strncmp(w, kw[i], len) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Remove storage-class words from a space-joined normalized type spelling.
+// Returns a fresh string (frees the input).
+static char *
+strip_storage_classes(char *base)
+{
+    if (!base) {
+        return nullptr;
+    }
+    ncc_buffer_t *b   = ncc_buffer_empty();
+    const char   *p   = base;
+    bool          any = false;
+    while (*p) {
+        const char *start = p;
+        while (*p && *p != ' ') {
+            p++;
+        }
+        size_t wlen = (size_t)(p - start);
+        if (wlen > 0 && !is_storage_word(start, wlen)) {
+            ncc_buffer_printf(b, "%s%.*s", any ? " " : "", (int)wlen, start);
+            any = true;
+        }
+        while (*p == ' ') {
+            p++;
+        }
+    }
+    ncc_free(base);
+    return ncc_buffer_take(b);
+}
+
+// Canonical base spelling from a specifier subtree, with any trailing declared
+// name stripped (the same pwz ambiguity that folds `x` into `int x` specifiers
+// can apply here; the canonicalizer space-joins alnum tokens, so a trailing
+// " <name>" is removable). Caller frees.
+static char *
+canonical_base(ncc_parse_tree_t *specs, ncc_string_t strip_name)
+{
+    ncc_string_t norm = ncc_normalize_type_tree(specs);
+    if (!norm.data) {
+        return nullptr;
+    }
+    if (strip_name.data && strip_name.u8_bytes > 0) {
+        size_t blen = strlen(norm.data);
+        size_t flen = strip_name.u8_bytes;
+        if (blen > flen + 1 && norm.data[blen - flen - 1] == ' '
+            && strncmp(norm.data + blen - flen, strip_name.data, flen) == 0
+            && norm.data[blen] == '\0') {
+            norm.data[blen - flen - 1] = '\0';
+        }
+    }
+    return strip_storage_classes(norm.data);
+}
+
+static char *
+append_stars(char *base, int n)
+{
+    if (!base || n <= 0) {
+        return base;
+    }
+    ncc_buffer_t *b = ncc_buffer_empty();
+    ncc_buffer_puts(b, base);
+    for (int i = 0; i < n; i++) {
+        ncc_buffer_puts(b, "*");
+    }
+    ncc_free(base);
+    return ncc_buffer_take(b);
+}
+
+// Drop one trailing '*' from a pointer type spelling; nullptr if not a pointer.
+static char *
+strip_one_star(char *type)
+{
+    if (!type) {
+        return nullptr;
+    }
+    size_t len = strlen(type);
+    while (len > 0 && (type[len - 1] == ' ' || type[len - 1] == '\t')) {
+        len--;
+    }
+    if (len == 0 || type[len - 1] != '*') {
+        ncc_free(type);
+        return nullptr;
+    }
+    type[len - 1] = '\0';
+    // Trim a trailing space left before the removed star.
+    size_t n = strlen(type);
+    while (n > 0 && (type[n - 1] == ' ' || type[n - 1] == '\t')) {
+        type[--n] = '\0';
+    }
+    return type;
+}
+
+// ============================================================================
+// Symbol -> type spelling
+// ============================================================================
+
+static char *
+type_of_symbol(ncc_sym_entry_t *sym)
+{
+    if (!sym || !sym->type_node) {
+        return nullptr;
+    }
+    int depth = declarator_ptr_depth(sym->decl_node);
+    if (depth < 0) {
+        return nullptr; // array / function declarator — not yet typed
+    }
+    char *base = canonical_base(sym->type_node, sym->name);
+    if (!base) {
+        return nullptr;
+    }
+    return append_stars(base, depth);
+}
+
+// ============================================================================
+// Expression typing
+// ============================================================================
+
+char *
+ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
+{
+    if (!st || !expr) {
+        return nullptr;
+    }
+
+    // Identifier leaf -> variable/param/function lookup.
+    if (ncc_tree_is_leaf(expr)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(expr);
+        if (tok && tok->tid == NCC_TOK_IDENTIFIER) {
+            ncc_string_t     name = leaf_text(expr);
+            ncc_sym_entry_t *sym  = ncc_symtab_lookup(st, ncc_string_empty(),
+                                                      name);
+            if (sym) {
+                return type_of_symbol(sym);
+            }
+        }
+        return nullptr;
+    }
+
+    // Transparent group wrappers.
+    if (is_group(expr)) {
+        ncc_parse_tree_t *only = nullptr;
+        meaningful_children(expr, &only);
+        return only ? ncc_type_of_expr(st, only) : nullptr;
+    }
+
+    // cast: ( type_name ) cast_expression  ->  the cast type.
+    if (nt_is(expr, "cast_expression")) {
+        ncc_parse_tree_t *tn = child_nt(expr, "type_name");
+        if (tn) {
+            ncc_string_t norm = ncc_normalize_type_tree(tn);
+            return norm.data;
+        }
+    }
+
+    // primary_expression: ( expression ) -> inner expression.
+    if (nt_is(expr, "primary_expression")) {
+        ncc_parse_tree_t *inner = child_nt(expr, "expression");
+        if (inner) {
+            return ncc_type_of_expr(st, inner);
+        }
+        // identifier directly under primary_expression.
+        ncc_parse_tree_t *id = child_nt(expr, "identifier");
+        if (id) {
+            return ncc_type_of_expr(st, id);
+        }
+    }
+
+    // identifier nonterminal wrapping the IDENTIFIER leaf.
+    if (nt_is(expr, "identifier")) {
+        ncc_parse_tree_t *only = nullptr;
+        meaningful_children(expr, &only);
+        if (only) {
+            return ncc_type_of_expr(st, only);
+        }
+    }
+
+    // unary_operator cast_expression: handle & (address-of) and * (deref).
+    if (nt_is(expr, "unary_expression")) {
+        ncc_parse_tree_t *op  = child_nt(expr, "unary_operator");
+        ncc_parse_tree_t *rhs = child_nt(expr, "cast_expression");
+        if (op && rhs) {
+            // The operator token lives under unary_operator -> _ops_op_unary.
+            ncc_string_t opc = ncc_string_empty();
+            // Find the single operator leaf.
+            ncc_parse_tree_t *opnode = op;
+            while (opnode && !ncc_tree_is_leaf(opnode)) {
+                ncc_parse_tree_t *only = nullptr;
+                meaningful_children(opnode, &only);
+                opnode = only;
+            }
+            opc = leaf_text(opnode);
+            if (opc.data && strcmp(opc.data, "&") == 0) {
+                char *inner = ncc_type_of_expr(st, rhs);
+                return append_stars(inner, 1);
+            }
+            if (opc.data && strcmp(opc.data, "*") == 0) {
+                char *inner = ncc_type_of_expr(st, rhs);
+                return strip_one_star(inner);
+            }
+            return nullptr; // other unary operators not typed yet
+        }
+    }
+
+    // Pass-through precedence cascade: a single meaningful child.
+    {
+        ncc_parse_tree_t *only = nullptr;
+        if (meaningful_children(expr, &only) == 1 && only) {
+            return ncc_type_of_expr(st, only);
+        }
+    }
+
+    return nullptr; // member access, calls, subscripts, arithmetic: TODO
+}

--- a/src/xform/xform_gc_typemap.c
+++ b/src/xform/xform_gc_typemap.c
@@ -29,6 +29,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 // ---------------------------------------------------------------------------
@@ -318,6 +319,374 @@ offset_assert(const char *elem_type, const char *path)
 }
 
 // ---------------------------------------------------------------------------
+// Discriminated unions (n00b_variant_t).
+//
+// `n00b_variant_t(T1, T2, ...)` expands to a struct shaped exactly:
+//     struct { uint64_t selector; union { T1 field_<h1>; ... } value; }
+// where `selector` holds typehash(T) of the active alternative (0 = unset).
+// The conservative union walker cannot describe this, but the discriminant
+// makes it precisely scannable: the `value` word is a heap pointer iff the
+// selector equals the typehash of one of the POINTER alternatives. ncc records
+// those typehashes (recomputed exactly as `typehash(T)` does, so they match the
+// runtime selector byte-for-byte) and emits a variant descriptor the collector
+// resolves per element at scan time.
+// ---------------------------------------------------------------------------
+
+// Accumulates the emitted variant descriptors for one element type.
+typedef struct {
+    ncc_buffer_t *arrays; // file-scope ptr-hash arrays + offset asserts
+    ncc_buffer_t *inits;  // CSV of n00b_gc_variant_field_t initializers
+    int           count;  // number of variant fields recorded
+    size_t        rec;    // owning record index (for unique array names)
+} variant_acc_t;
+
+typedef enum {
+    ALT_PTR,        // a heap pointer; its typehash joins the discriminant set
+    ALT_NONPTR,     // carries no heap pointer (primitive scalar or code pointer)
+    ALT_UNSUPPORTED // cannot be described safely -> fall back to conservative
+} alt_class_t;
+
+// Normalized type spelling of a struct member, with the trailing field name
+// removed. A member without a pointer/array declarator (e.g. `uint64_t x;`) is
+// parsed ambiguously: the field name folds into the specifier-qualifier-list,
+// so `normalize(specs)` yields "uint64_t x". Because the canonicalizer
+// space-joins adjacent alnum tokens, the field name is exactly a trailing
+// " <name>" we can strip — leaving normalize(T), which equals what
+// `typehash(T)` hashes at the n00b_variant_set site. Caller frees.
+static char *
+member_type_spelling(ncc_parse_tree_t *specs, const char *field_name)
+{
+    ncc_string_t norm = ncc_normalize_type_tree(specs);
+    if (!norm.data) {
+        return nullptr;
+    }
+    if (field_name) {
+        size_t blen = strlen(norm.data);
+        size_t flen = strlen(field_name);
+        if (blen > flen + 1 && norm.data[blen - flen - 1] == ' '
+            && strcmp(norm.data + blen - flen, field_name) == 0) {
+            norm.data[blen - flen - 1] = '\0';
+        }
+    }
+    return norm.data;
+}
+
+// True if any leaf under `node` is a const/volatile qualifier. A variant
+// alternative carrying such a qualifier on its pointer (e.g. `T * const`) would
+// change typehash normalization, so we cannot reconstruct a matching selector
+// value and must fall back to a conservative scan.
+static bool
+subtree_has_cv_qualifier(ncc_parse_tree_t *node)
+{
+    if (!node) {
+        return false;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        const char *t = ncc_xform_leaf_text(node);
+        return t && (strcmp(t, "const") == 0 || strcmp(t, "volatile") == 0);
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (subtree_has_cv_qualifier(ncc_tree_child(node, i))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Classify one alternative (a member_declaration of the value union) and, for a
+// pointer alternative, compute its typehash into *out_hash. The hash MUST equal
+// `typehash(T)` at the n00b_variant_set site: the runtime selector is that
+// value, and a mismatch would leave a live pointer unmarked (heap corruption).
+// We reproduce it exactly — normalize(specifier_qualifier_list) yields the
+// canonical base, and the canonicalizer appends pointer stars with no spacing,
+// so base + "*"*depth == normalize(T).
+static alt_class_t
+classify_variant_alt(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *member,
+                     uint64_t *out_hash)
+{
+    ncc_parse_tree_t *specs = ncc_xform_find_child_nt(
+        member, "specifier_qualifier_list");
+    if (!specs) {
+        return ALT_UNSUPPORTED;
+    }
+    // _Atomic is dropped by normalization, but treat atomic alternatives as
+    // unsupported rather than reason about the wrapper here.
+    if (ncc_layout_specs_have_atomic_type_wrapper(specs)) {
+        return ALT_UNSUPPORTED;
+    }
+
+    // A non-pointer scalar member (e.g. `uint64_t field_1;`) carries no
+    // declarator node, so the declarator is optional here.
+    ncc_parse_tree_t *decl = ncc_layout_first_descendant_nt(member,
+                                                            "declarator");
+    if (decl && ncc_layout_first_descendant_nt(decl, "array_declarator")) {
+        return ALT_UNSUPPORTED;
+    }
+
+    int total = decl ? ncc_layout_pointer_depth_for_declarator(ctx, specs, decl)
+                     : ncc_layout_pointer_depth_for_specs(ctx, specs);
+
+    char *field = ncc_layout_implicit_member_field_name(member, specs);
+    char *base  = member_type_spelling(specs, field);
+    if (field) {
+        ncc_free(field);
+    }
+    if (!base) {
+        return ALT_UNSUPPORTED;
+    }
+
+    if (total == 0) {
+        // Non-pointer by value: a recognized primitive scalar carries no heap
+        // word; a by-value aggregate may hide pointers across several words and
+        // anything else is an unknown typedef — bail to a conservative scan for
+        // both (never an under-scan).
+        bool scalar = elem_type_is_scalar_no_ptr(base);
+        ncc_free(base);
+        return scalar ? ALT_NONPTR : ALT_UNSUPPORTED;
+    }
+
+    if (decl && ncc_layout_declarator_is_function_pointer(decl)) {
+        ncc_free(base);
+        return ALT_NONPTR; // code pointer, never a heap pointer
+    }
+    if (decl && subtree_has_cv_qualifier(decl)) {
+        ncc_free(base);
+        return ALT_UNSUPPORTED; // qualifier would break typehash reconstruction
+    }
+
+    // Reproduce typehash(T) exactly: the cleaned spelling is normalize(T) for
+    // the spec-level type, and we append only the EXPLICIT declarator stars (a
+    // pointer typedef is already captured by the spelling). The canonicalizer
+    // never spaces before '*', so this equals normalize(T).
+    int           stars = decl ? ncc_layout_pointer_depth_in_declarator(decl) : 0;
+    ncc_buffer_t *tb    = ncc_buffer_empty();
+    ncc_buffer_puts(tb, base);
+    for (int i = 0; i < stars; i++) {
+        ncc_buffer_puts(tb, "*");
+    }
+    *out_hash = ncc_type_hash_u64(tb->data);
+    ncc_free(base);
+    ncc_free(ncc_buffer_take(tb));
+    return ALT_PTR;
+}
+
+static int
+cmp_u64(const void *a, const void *b)
+{
+    uint64_t x = *(const uint64_t *)a;
+    uint64_t y = *(const uint64_t *)b;
+    return (x > y) - (x < y);
+}
+
+// If `spec` is an n00b_variant_t struct, return its resolved value-union
+// specifier; otherwise nullptr. The shape is exact: a struct with precisely two
+// members — `uint64_t selector;` and `union { ... } value;` whose alternatives
+// are all named with the `field_` prefix (N00B_VARIANT_FIELD). That triple
+// signature is unique to n00b_variant_t, so the selector is guaranteed to hold
+// a typehash discriminant.
+static ncc_parse_tree_t *
+variant_value_union(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *spec)
+{
+    if (ncc_layout_struct_or_union_is_union(spec)) {
+        return nullptr; // a variant is a struct, not a union
+    }
+    ncc_parse_tree_t *members = ncc_xform_find_child_nt(
+        spec, "member_declaration_list");
+    if (!members) {
+        return nullptr;
+    }
+
+    ncc_layout_parse_tree_list_t mlist = {0};
+    ncc_layout_collect_nt_children(members, "member_declaration", &mlist);
+    if (mlist.len != 2) {
+        if (mlist.data) {
+            ncc_free(mlist.data);
+        }
+        return nullptr;
+    }
+
+    bool              have_selector = false;
+    ncc_parse_tree_t *value_union   = nullptr;
+
+    for (size_t i = 0; i < mlist.len; i++) {
+        ncc_parse_tree_t *member = mlist.data[i];
+        ncc_parse_tree_t *specs  = ncc_xform_find_child_nt(
+            member, "specifier_qualifier_list");
+        if (!specs) {
+            continue;
+        }
+        char *name = ncc_layout_implicit_member_field_name(member, specs);
+        if (!name) {
+            continue;
+        }
+
+        if (strcmp(name, "selector") == 0) {
+            char *base    = member_type_spelling(specs, name);
+            have_selector = base && strcmp(base, "uint64_t") == 0;
+            if (base) {
+                ncc_free(base);
+            }
+        }
+        else if (strcmp(name, "value") == 0) {
+            ncc_parse_tree_t *agg = ncc_layout_aggregate_spec_from_specs(ctx,
+                                                                         specs);
+            if (agg) {
+                ncc_parse_tree_t *u = ncc_layout_resolve_aggregate_specifier(
+                    ctx, agg);
+                if (u && ncc_layout_struct_or_union_is_union(u)) {
+                    value_union = u;
+                }
+            }
+        }
+        ncc_free(name);
+    }
+
+    if (mlist.data) {
+        ncc_free(mlist.data);
+    }
+
+    if (!have_selector || !value_union) {
+        return nullptr;
+    }
+
+    // Confirm the n00b_variant alternative-naming convention: every union
+    // member is named `field_...`. This rules out an ordinary 2-member struct
+    // that merely happens to pair a uint64 with a union.
+    ncc_parse_tree_t *umembers = ncc_xform_find_child_nt(
+        value_union, "member_declaration_list");
+    if (!umembers) {
+        return nullptr;
+    }
+    ncc_layout_parse_tree_list_t alts = {0};
+    ncc_layout_collect_nt_children(umembers, "member_declaration", &alts);
+    bool all_field = alts.len > 0;
+    for (size_t i = 0; i < alts.len; i++) {
+        ncc_parse_tree_t *aspecs = ncc_xform_find_child_nt(
+            alts.data[i], "specifier_qualifier_list");
+        char *name = ncc_layout_implicit_member_field_name(alts.data[i], aspecs);
+        if (!name || strncmp(name, "field_", 6) != 0) {
+            all_field = false;
+        }
+        if (name) {
+            ncc_free(name);
+        }
+    }
+    if (alts.data) {
+        ncc_free(alts.data);
+    }
+
+    return all_field ? value_union : nullptr;
+}
+
+// Emit a variant descriptor for an n00b_variant_t field at `base`. `vunion` is
+// the resolved value-union specifier. On any alternative we cannot describe,
+// sets *ok = false and warns (the whole type then falls back to conservative
+// scanning, exactly as the legacy union path does — never an under-scan).
+static void
+walk_variant(ncc_xform_ctx_t *ctx, const char *elem_type,
+             ncc_parse_tree_t *vunion, const char *base, variant_acc_t *vacc,
+             bool *ok)
+{
+    ncc_parse_tree_t *members = ncc_xform_find_child_nt(
+        vunion, "member_declaration_list");
+    if (!members) {
+        *ok = false;
+        return;
+    }
+
+    ncc_layout_parse_tree_list_t alts = {0};
+    ncc_layout_collect_nt_children(members, "member_declaration", &alts);
+
+    ncc_layout_uint64_list_t hashes = {0};
+    bool                     unsupported = false;
+
+    for (size_t i = 0; i < alts.len; i++) {
+        uint64_t    h   = 0;
+        alt_class_t cls = classify_variant_alt(ctx, alts.data[i], &h);
+        if (cls == ALT_UNSUPPORTED) {
+            unsupported = true;
+            break;
+        }
+        if (cls == ALT_PTR) {
+            ncc_layout_uint64_list_push(&hashes, h);
+        }
+    }
+    if (alts.data) {
+        ncc_free(alts.data);
+    }
+
+    if (unsupported) {
+        fprintf(stderr,
+                "ncc: warning: gc-typemap: type '%s' has an n00b_variant_t with "
+                "an alternative that cannot be statically described for GC "
+                "scanning; the type loses its precise pointer map and falls "
+                "back to conservative scan (not precisely marshalable).\n",
+                elem_type ? elem_type : "(anonymous)");
+        if (hashes.data) {
+            ncc_free(hashes.data);
+        }
+        *ok = false;
+        return;
+    }
+
+    if (hashes.len == 0) {
+        // No pointer alternatives: the value word is never a heap pointer, so
+        // there is nothing to mark and the type stays precise.
+        if (hashes.data) {
+            ncc_free(hashes.data);
+        }
+        return;
+    }
+
+    // Sort ascending and dedup so the runtime can binary-search.
+    qsort(hashes.data, hashes.len, sizeof(uint64_t), cmp_u64);
+    size_t n = 0;
+    for (size_t i = 0; i < hashes.len; i++) {
+        if (n == 0 || hashes.data[i] != hashes.data[n - 1]) {
+            hashes.data[n++] = hashes.data[i];
+        }
+    }
+
+    char *sel_path = path_join(base, "selector");
+    char *val_path = path_join(base, "value");
+    char *sel_as   = offset_assert(elem_type, sel_path);
+    char *val_as   = offset_assert(elem_type, val_path);
+    char *sel_off  = offset_expr(elem_type, sel_path);
+    char *val_off  = offset_expr(elem_type, val_path);
+
+    int k = vacc->count;
+    ncc_buffer_printf(vacc->arrays, "%s%s", sel_as, val_as);
+    ncc_buffer_printf(vacc->arrays,
+                      "static const uint64_t __ncc_gcvar_h_%zu_%d[]={",
+                      vacc->rec, k);
+    for (size_t i = 0; i < n; i++) {
+        ncc_buffer_printf(vacc->arrays, "%s%lluULL", i ? "," : "",
+                          (unsigned long long)hashes.data[i]);
+    }
+    ncc_buffer_puts(vacc->arrays, "};");
+
+    if (k > 0) {
+        ncc_buffer_puts(vacc->inits, ",");
+    }
+    ncc_buffer_printf(vacc->inits,
+                      "{.selector_offset=%s,.value_offset=%s,"
+                      ".ptr_hash_count=%zuULL,.ptr_hashes=__ncc_gcvar_h_%zu_%d}",
+                      sel_off, val_off, n, vacc->rec, k);
+    vacc->count++;
+
+    ncc_free(sel_path);
+    ncc_free(val_path);
+    ncc_free(sel_as);
+    ncc_free(val_as);
+    ncc_free(sel_off);
+    ncc_free(val_off);
+    if (hashes.data) {
+        ncc_free(hashes.data);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tolerant, conservative pointer-offset walker.
 // ---------------------------------------------------------------------------
 
@@ -329,6 +698,7 @@ gc_walk(ncc_xform_ctx_t *ctx,
         ncc_buffer_t    *offs,
         ncc_buffer_t    *asserts,
         int             *count,
+        variant_acc_t   *vacc,
         bool            *ok,
         int              depth);
 
@@ -353,7 +723,8 @@ static void
 walk_struct_member(ncc_xform_ctx_t *ctx, const char *elem_type,
                    ncc_parse_tree_t *member, const char *base,
                    bool runtime_scan_shape, ncc_buffer_t *offs,
-                   ncc_buffer_t *asserts, int *count, bool *ok, int depth)
+                   ncc_buffer_t *asserts, int *count, variant_acc_t *vacc,
+                   bool *ok, int depth)
 {
     ncc_parse_tree_t *member_specs = ncc_xform_find_child_nt(
         member, "specifier_qualifier_list");
@@ -377,8 +748,8 @@ walk_struct_member(ncc_xform_ctx_t *ctx, const char *elem_type,
                                                                 member_specs);
             char *nbase = field ? path_join(base, field)
                                 : ncc_layout_copy_cstr(base);
-            gc_walk(ctx, elem_type, nspec, nbase, offs, asserts, count, ok,
-                    depth + 1);
+            gc_walk(ctx, elem_type, nspec, nbase, offs, asserts, count, vacc,
+                    ok, depth + 1);
             ncc_free(nbase);
             if (field) {
                 ncc_free(field);
@@ -487,7 +858,7 @@ walk_struct_member(ncc_xform_ctx_t *ctx, const char *elem_type,
                     ctx, member_specs);
                 if (nspec) {
                     gc_walk(ctx, elem_type, nspec, path, offs, asserts, count,
-                            ok, depth + 1);
+                            vacc, ok, depth + 1);
                 }
                 // else: scalar by-value member -> no pointer words.
             }
@@ -697,7 +1068,7 @@ walk_union(ncc_xform_ctx_t *ctx, const char *elem_type,
 static void
 gc_walk(ncc_xform_ctx_t *ctx, const char *elem_type, ncc_parse_tree_t *spec,
         const char *base, ncc_buffer_t *offs, ncc_buffer_t *asserts,
-        int *count, bool *ok, int depth)
+        int *count, variant_acc_t *vacc, bool *ok, int depth)
 {
     if (depth > 64 || *count > NCC_GCMAP_MAX_OFFSETS) {
         *ok = false;
@@ -707,6 +1078,16 @@ gc_walk(ncc_xform_ctx_t *ctx, const char *elem_type, ncc_parse_tree_t *spec,
     spec = ncc_layout_resolve_aggregate_specifier(ctx, spec);
     if (!spec) {
         *ok = false;
+        return;
+    }
+
+    // An n00b_variant_t is precisely scannable via its selector discriminant
+    // even though its value union mixes pointer and scalar alternatives. Handle
+    // it before the generic union/struct logic so the conservative union path
+    // never sees (and warns about) the variant's value union.
+    ncc_parse_tree_t *vunion = variant_value_union(ctx, spec);
+    if (vunion) {
+        walk_variant(ctx, elem_type, vunion, base, vacc, ok);
         return;
     }
 
@@ -729,7 +1110,7 @@ gc_walk(ncc_xform_ctx_t *ctx, const char *elem_type, ncc_parse_tree_t *spec,
     ncc_layout_collect_nt_children(members, "member_declaration", &mlist);
     for (size_t i = 0; i < mlist.len && *ok; i++) {
         walk_struct_member(ctx, elem_type, mlist.data[i], base,
-                           runtime_scan_shape, offs, asserts, count, ok,
+                           runtime_scan_shape, offs, asserts, count, vacc, ok,
                            depth);
     }
     if (mlist.data) {
@@ -895,17 +1276,27 @@ ncc_gc_typemap_emit(ncc_xform_ctx_t *ctx)
         ncc_buffer_t *asserts = ncc_buffer_empty();
         int           count   = 0;
         bool          ok      = true;
+        variant_acc_t vacc    = {
+                  .arrays = ncc_buffer_empty(),
+                  .inits  = ncc_buffer_empty(),
+                  .count  = 0,
+                  .rec    = i,
+        };
 
         if (!scalar_no_ptr) {
             gc_walk(ctx, records[i].elem_type, info->specifier, "", offs, asserts,
-                    &count, &ok, 0);
+                    &count, &vacc, &ok, 0);
         }
 
         if (ok) {
             char *asserts_str = ncc_buffer_take(asserts);
+            char *var_arrays  = ncc_buffer_take(vacc.arrays);
+            char *var_inits   = ncc_buffer_take(vacc.inits);
 
-            // Asserts first (file scope), then the descriptor + section entry.
+            // Asserts + per-variant ptr-hash arrays first (file scope), then the
+            // descriptor + section entry.
             ncc_buffer_printf(out, "%s", asserts_str);
+            ncc_buffer_printf(out, "%s", var_arrays);
             if (count > 0) {
                 char *offs_csv = ncc_buffer_take(offs);
                 ncc_buffer_printf(
@@ -917,15 +1308,29 @@ ncc_gc_typemap_emit(ncc_xform_ctx_t *ctx)
             else {
                 ncc_free(ncc_buffer_take(offs));
             }
+            if (vacc.count > 0) {
+                ncc_buffer_printf(
+                    out,
+                    "static const n00b_gc_variant_field_t "
+                    "__ncc_gcmap_var_%zu[]={%s};",
+                    i, var_inits);
+            }
             char *offsets_expr = count > 0
                                ? ncc_layout_format_cstr("__ncc_gcmap_off_%zu", i)
                                : ncc_layout_copy_cstr("nullptr");
+            char *variants_expr = vacc.count > 0
+                                ? ncc_layout_format_cstr("__ncc_gcmap_var_%zu", i)
+                                : ncc_layout_copy_cstr("nullptr");
             ncc_buffer_printf(
                 out,
                 "static const n00b_gc_struct_layout_t __ncc_gcmap_lay_%zu="
                 "{.stride=(sizeof(%s)/sizeof(void*)),.count=1,.offset_count=%d,"
-                ".offsets=%s};",
-                i, records[i].elem_type, count, offsets_expr);
+                ".offsets=%s,.variant_count=%dULL,.variants=%s};",
+                i, records[i].elem_type, count, offsets_expr, vacc.count,
+                variants_expr);
+            ncc_free(variants_expr);
+            ncc_free(var_arrays);
+            ncc_free(var_inits);
             ncc_buffer_printf(
                 out,
                 "%s static const n00b_gc_type_map_entry_t "
@@ -945,6 +1350,8 @@ ncc_gc_typemap_emit(ncc_xform_ctx_t *ctx)
         else {
             ncc_free(ncc_buffer_take(offs));
             ncc_free(ncc_buffer_take(asserts));
+            ncc_free(ncc_buffer_take(vacc.arrays));
+            ncc_free(ncc_buffer_take(vacc.inits));
         }
     }
 

--- a/src/xform/xform_typehash.c
+++ b/src/xform/xform_typehash.c
@@ -5,6 +5,9 @@
 
 #include "xform/xform_helpers.h"
 #include "xform/xform_gc_typemap.h"
+#include "xform/xform_data.h"
+#include "parse/type_infer.h"
+#include "util/type_normalize.h"
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -38,6 +41,33 @@ xform_typehash(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
                                                         "typeid_continuation");
     if (!atom) {
         return nullptr;
+    }
+
+    // typehash(<expression>): when the single argument is an expression (not a
+    // written type, string literal, or generic continuation), hash the
+    // expression's inferred type. This is typehash(typeof(expr)) without the
+    // user spelling out typeof. The type model recomputes the canonical type
+    // spelling identically to a written type, so the hash matches.
+    ncc_parse_tree_t *tsa = ncc_xform_find_child_nt(
+        atom, "typeof_specifier_argument");
+    if (!cont && tsa && !ncc_xform_find_child_nt(tsa, "type_name")) {
+        ncc_parse_tree_t *expr = ncc_xform_find_child_nt(tsa, "expression");
+        ncc_symtab_t     *st   = ncc_xform_get_data(ctx)->symtab;
+        char             *inferred = (expr && st) ? ncc_type_of_expr(st, expr)
+                                                  : nullptr;
+        if (inferred) {
+            uint64_t hash = ncc_type_hash_u64(inferred);
+            ncc_gc_typemap_note(ctx, inferred, hash);
+
+            char buf[32];
+            snprintf(buf, sizeof(buf), "%" PRIu64 "ULL", hash);
+            uint32_t line, col;
+            ncc_xform_first_leaf_pos(node, &line, &col);
+            ncc_parse_tree_t *replacement = ncc_xform_make_token_node(
+                NCC_TOK_INTEGER, buf, line, col);
+            ncc_free(inferred);
+            return replacement;
+        }
     }
 
     ncc_string_t type_str = ncc_xform_extract_type_string(ctx, atom, cont);

--- a/test/test_gc_typemap_variant.c
+++ b/test/test_gc_typemap_variant.c
@@ -1,0 +1,62 @@
+// test_gc_typemap_variant.c -- discriminated-union (n00b_variant_t) GC maps.
+//
+// Meson runs this source through `ncc -E` and asserts on the transformed
+// output. An n00b_variant_t is shaped `{ uint64_t selector; union {
+// T field_...; ... } value; }`, where `selector` holds typehash(T) of the
+// active alternative. ncc must describe it precisely (a variant descriptor +
+// the selector/value offsets + a pointer-alternative typehash table) instead
+// of warning and falling back to a conservative scan, both when the variant is
+// the whole object and when it is a field of a larger struct.
+//
+// The detector is SHAPE-based (selector:uint64_t + value:union whose members
+// are all named field_*), so the fixture spells the post-expansion shape with
+// plain structs rather than the n00b_variant_t macro; that is exactly what the
+// macro's `_generic_struct` resolves to by the time the GC-map walker runs.
+
+#include <stdint.h>
+
+typedef struct n00b_string_t {
+    uint64_t length;
+    char    *data;
+} n00b_string_t;
+
+typedef struct vmap_payload_t {
+    uint64_t value;
+} vmap_payload_t;
+
+// A variant with one pointer alternative and one scalar alternative: the value
+// word is a heap pointer iff the selector names the pointer alternative.
+typedef struct vmap_variant_t {
+    uint64_t selector;
+    union {
+        n00b_string_t *field_0;
+        uint64_t       field_1;
+    } value;
+} vmap_variant_t;
+
+// The same variant embedded as a field of a larger struct, alongside an
+// ordinary (unconditional) pointer field.
+typedef struct vmap_holder_t {
+    vmap_payload_t *head;
+    vmap_variant_t  choice;
+} vmap_holder_t;
+
+// An all-scalar variant carries no heap pointer: it stays precise (no variant
+// descriptor needed) and must not warn.
+typedef struct vmap_scalar_variant_t {
+    uint64_t selector;
+    union {
+        uint64_t field_0;
+        int64_t  field_1;
+    } value;
+} vmap_scalar_variant_t;
+
+static uint64_t h_variant = typehash(vmap_variant_t *);
+static uint64_t h_holder  = typehash(vmap_holder_t *);
+static uint64_t h_scalar  = typehash(vmap_scalar_variant_t *);
+
+int
+main(void)
+{
+    return (int)((h_variant ^ h_holder ^ h_scalar) == 0);
+}

--- a/test/test_typehash_expr.c
+++ b/test/test_typehash_expr.c
@@ -1,0 +1,34 @@
+// test_typehash_expr.c — typehash of an EXPRESSION resolves to the typehash of
+// the expression's inferred type (via the scoped symbol table + expression
+// typer). typehash(expr) must equal typehash(<the type of expr>), byte for
+// byte, since the type model recomputes the canonical spelling identically.
+//
+// Restricted to non-pointer RESULT types so the run compiles standalone: a
+// pointer typehash emits a GC-map descriptor that pulls in n00b runtime types
+// (those paths are covered by the preprocess-mode gc-typemap tests). Pointer
+// and address-of forms are exercised by the inference unit coverage.
+
+#include <stdint.h>
+
+static int  gi;
+static int *gp;
+
+int
+main(void)
+{
+    int ok = 1;
+
+    // Identifier: type of `gi` is `int`.
+    ok &= (typehash(gi) == typehash(int));
+
+    // Dereference: type of `*gp` is `int`.
+    ok &= (typehash(*gp) == typehash(int));
+
+    // Parenthesized: type of `(gi)` is `int`.
+    ok &= (typehash((gi)) == typehash(int));
+
+    // Cast: type of `(char)gi` is `char`.
+    ok &= (typehash((char)gi) == typehash(char));
+
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Summary:
- Adds symbol-population/type-inference helpers for typed transform analysis.
- Extends typehash/gc-typemap plumbing for typed expressions.
- Emits precise GC typemap descriptors for `n00b_variant_t` selector/value layouts, including embedded variants and scalar-only variants.

Validation:
- `env NCC_COMPILE_ARGS="./ncc:executable" NCC_TEST_ARGS="ncc_typehash_expr ncc_gc_typemap_variant_descriptor_emitted ncc_gc_typemap_variant_selector_offset ncc_gc_typemap_variant_value_offset ncc_gc_typemap_variant_embedded ncc_gc_typemap_variant_embedded_flat_offset ncc_gc_typemap_variant_all_scalar_no_descriptor" NCC_TEST=1 bash scripts/build.sh`