### PR TITLE
ncc type system: expression typing + type-aware parse disambiguation

### DIFF
--- a/c_ncc.bnf
+++ b/c_ncc.bnf
@@ -27,8 +27,16 @@
 <typedef_name_terminal> ::= %TYPEDEF_NAME
 
 # Ambiguity-aware typedef: the parser considers both interpretations
-# (typedef name vs plain identifier).  Tree scoring resolves the ambiguity.
-<typedef_name> ::= <typedef_name_terminal> | %IDENTIFIER
+# (typedef name vs plain identifier).  Tree scoring resolves the ambiguity:
+# @disambig(id_is_value) penalizes reading an identifier as a TYPE when the
+# symbol table says it names a value (variable/parameter/function), so a value
+# expression that mis-parsed as a type_name (e.g. `lp[2]`) loses to its
+# expression reading at forest->tree extraction. The penalty is deliberately
+# one-directional: it fires only on value names, never on a typedef name being
+# *declared* (a binding occurrence routes through the declarator/identifier, not
+# typedef_name), so it cannot disturb typedef declarations. Typedef *uses*
+# already resolve correctly under the default last-alternative policy.
+<typedef_name> @disambig(id_is_value) ::= <typedef_name_terminal> | %IDENTIFIER
 
 <non_bracket_token> ::= %IDENTIFIER
     | %INTEGER

--- a/include/internal/parse/grammar_internal.h
+++ b/include/internal/parse/grammar_internal.h
@@ -53,6 +53,15 @@ struct ncc_parse_rule_t {
     int32_t                               cost;
     int32_t                               link_ix;
     ncc_string_t                         doc;
+    // TS-5 disambiguation scoring: a NORMAL participating rule (unlike
+    // penalty_rule, which is skipped in graph build) that carries a
+    // symtab-conditional penalty consulted only at forest->tree extraction.
+    // disambig_predicate names a predicate registered with the extractor; when
+    // it holds for this rule's extracted subtree, disambig_cost is added to the
+    // alternative's score and the lowest-scoring alternative is chosen. Empty
+    // predicate => no disambiguation penalty.
+    ncc_string_t                         disambig_predicate;
+    int32_t                               disambig_cost;
     bool                                  penalty_rule;
     bool                                  first_has_any;
     void                                 *thunk;

--- a/include/internal/parse/pwz_internal.h
+++ b/include/internal/parse/pwz_internal.h
@@ -168,4 +168,8 @@ struct ncc_pwz_parser_t {
 
     pwz_mem_t                   *mem_bottom;
     pwz_exp_t                   *exp_bottom;
+
+    // TS-5 type-aware disambiguation oracle (nullptr => default last-alt policy).
+    ncc_pwz_disambig_fn         disambig_cb;
+    void                       *disambig_ud;
 };

--- a/include/parse/pwz.h
+++ b/include/parse/pwz.h
@@ -10,8 +10,33 @@
 
 #include "parse/grammar.h"
 #include "parse/parse_forest.h"
+#include "parse/token.h"
 
 typedef struct ncc_token_stream_t ncc_token_stream_t;
+
+// ============================================================================
+// Type-aware disambiguation (TS-5)
+// ============================================================================
+
+/**
+ * @brief Predicate callback consulted at forest->tree extraction.
+ *
+ * The grammar annotates ambiguous productions with `@disambig(<predicate>)`.
+ * When a rule carrying such an annotation is a candidate at an ambiguity node,
+ * the extractor invokes this callback with the predicate name and the rule's
+ * leading token. A true result adds the rule's disambiguation cost to the
+ * alternative's score; the lowest-scoring (most type-consistent) alternative
+ * wins. This lets the symbol table — passed back through @p ud — resolve the
+ * C typedef/identifier ambiguity at the parse layer.
+ *
+ * @param ud         Opaque user data (the symbol table).
+ * @param predicate  Predicate name from the `@disambig` annotation.
+ * @param tok        The leading token of the candidate rule's span.
+ * @return True if the predicate holds (penalty applies).
+ */
+typedef bool (*ncc_pwz_disambig_fn)(void             *ud,
+                                    const char       *predicate,
+                                    ncc_token_info_t *tok);
 
 // ============================================================================
 // Opaque parser state
@@ -91,6 +116,36 @@ bool ncc_pwz_parse(ncc_pwz_parser_t   *p,
  * @return The parse tree, or nullptr if the last parse failed.
  */
 ncc_parse_tree_t *ncc_pwz_get_tree(ncc_pwz_parser_t *p);
+
+/**
+ * @brief Install (or clear) the type-aware disambiguation oracle.
+ *
+ * With an oracle set, the next extraction (see ncc_pwz_reextract) scores
+ * ambiguous alternatives via `@disambig` annotations + this callback and picks
+ * the lowest-scoring parse. Pass @p cb == nullptr to restore the default
+ * (grammar-order, last-alternative) policy.
+ *
+ * @param p   PWZ parser.
+ * @param cb  Predicate callback (nullptr to clear).
+ * @param ud  Opaque user data passed to @p cb (the symbol table).
+ */
+void ncc_pwz_set_disambiguator(ncc_pwz_parser_t    *p,
+                               ncc_pwz_disambig_fn  cb,
+                               void                *ud);
+
+/**
+ * @brief Re-extract a single tree from the retained forest of the last parse.
+ *
+ * Re-runs forest->tree extraction over the forest from the last successful
+ * parse, applying the currently-installed disambiguation oracle. Valid only
+ * before ncc_pwz_release_parse_state(). Returns the new tree (also stored as
+ * the parser's current result tree), or the existing tree if no forest is
+ * retained.
+ *
+ * @param p  PWZ parser.
+ * @return The re-extracted parse tree.
+ */
+ncc_parse_tree_t *ncc_pwz_reextract(ncc_pwz_parser_t *p);
 
 /**
  * @brief Get all parse trees from an ambiguous parse.

--- a/include/parse/type_infer.h
+++ b/include/parse/type_infer.h
@@ -34,3 +34,11 @@ char *ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr);
  */
 ncc_parse_tree_t *ncc_symtab_aggregate_spec(ncc_symtab_t *st,
                                             const char *type_name);
+
+/**
+ * @brief True if a parsed `type_name` is really a mis-parsed expression — its
+ *        base is an identifier naming a value (variable/parameter/function),
+ *        not a type. Used to disambiguate `type_name` vs `expression` where the
+ *        grammar's permissive typedef-name rule made them ambiguous.
+ */
+bool ncc_type_name_is_value_expr(ncc_symtab_t *st, ncc_parse_tree_t *type_name);

--- a/include/parse/type_infer.h
+++ b/include/parse/type_infer.h
@@ -18,6 +18,7 @@
 #include "parse/types.h"
 #include "parse/parse_tree.h"
 #include "parse/symtab.h"
+#include "parse/token.h"
 
 /**
  * @brief Canonical type spelling of expression @p expr under symbol table
@@ -36,9 +37,12 @@ ncc_parse_tree_t *ncc_symtab_aggregate_spec(ncc_symtab_t *st,
                                             const char *type_name);
 
 /**
- * @brief True if a parsed `type_name` is really a mis-parsed expression — its
- *        base is an identifier naming a value (variable/parameter/function),
- *        not a type. Used to disambiguate `type_name` vs `expression` where the
- *        grammar's permissive typedef-name rule made them ambiguous.
+ * @brief `@disambig` predicate evaluator for type-aware parse disambiguation
+ *        (TS-5). Signature matches ncc_pwz_disambig_fn: @p ud is the
+ *        `ncc_symtab_t *`. Returns true when @p predicate holds for @p tok's
+ *        identifier text:
+ *          - "id_is_value":   names a variable, parameter, or function
+ *          - "id_is_typedef": names a typedef
+ *        so the extractor can prefer the value-expression vs type reading.
  */
-bool ncc_type_name_is_value_expr(ncc_symtab_t *st, ncc_parse_tree_t *type_name);
+bool ncc_disambig_eval(void *ud, const char *predicate, ncc_token_info_t *tok);

--- a/include/parse/type_infer.h
+++ b/include/parse/type_infer.h
@@ -24,3 +24,13 @@
  *        @p st, or nullptr if the form is not yet typeable. Caller frees.
  */
 char *ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr);
+
+/**
+ * @brief Resolve a type name (e.g. "foo_t", "struct foo") to its aggregate
+ *        specifier carrying a member body, via the symbol table (following a
+ *        typedef to its underlying tag). Returns the specifier or nullptr.
+ *        Resolves types the legacy aggregate table misses, notably
+ *        `_generic_struct` typedefs.
+ */
+ncc_parse_tree_t *ncc_symtab_aggregate_spec(ncc_symtab_t *st,
+                                            const char *type_name);

--- a/include/xform/xform_helpers.h
+++ b/include/xform/xform_helpers.h
@@ -71,3 +71,13 @@ ncc_string_t pprint_subtree(ncc_grammar_t *g, ncc_parse_tree_t *node);
 ncc_parse_tree_t **collect_arguments(ncc_parse_tree_t *arglist, int *nargs);
 char *collect_file_scope_declarations(ncc_xform_ctx_t *ctx,
                                       ncc_parse_tree_t *call_node);
+
+// For a single (non-continuation) typeid_atom argument, return the canonical
+// type spelling if the argument is — or, via the symbol table, is really — an
+// EXPRESSION (so its inferred type should be used) rather than a written type.
+// Returns nullptr when the argument is a genuine type or a string literal, so
+// the caller falls back to its written-type path. Caller frees. This is where
+// `typehash`/`typeid`/`typestr` of expressions resolve, including expressions
+// the grammar mis-parsed as type_names (e.g. `lp[2]`).
+char *ncc_xform_expr_arg_type(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *atom,
+                              ncc_parse_tree_t *cont);

--- a/meson.build
+++ b/meson.build
@@ -940,6 +940,18 @@ test('ncc_gc_typemap_variant_all_scalar_no_descriptor', test_runner,
   depends : ncc_exe,
 )
 
+# A _generic_struct variant (the real n00b_variant_t shape) resolves via the
+# type model and gets a precise variant descriptor, even though the legacy
+# aggregate table cannot resolve its typedef alias.
+test('ncc_gc_typemap_variant_generic_struct', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          '__builtin_offsetof(vmap_generic_variant_t,selector)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
 if host_machine.system() != 'windows' and cc.has_header('pthread.h')
   test('ncc_constexpr_pthread', test_runner,
     args : [ncc_exe, 'compile_run', test_dir / 'test_constexpr_pthread.c']

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -37,6 +37,7 @@
 #include "parse/pwz.h"
 #include "parse/typedef_walk.h"
 #include "parse/symbol_populate.h"
+#include "parse/type_infer.h"
 #include "parse/c_tokenizer.h"
 #include "parse/emit.h"
 #include "xform/xform_gc_typemap.h"
@@ -1959,22 +1960,42 @@ compile_file(ncc_opts_t *opts)
     ncc_pwz_report_stats();
 #endif
 
-    // Release PWZ per-parse intermediate state (arena, worklists) now that
-    // the tree has been extracted.  This drops peak live memory before the
-    // transform and emit stages run.
-    ncc_pwz_release_parse_state(parser);
-
-#ifdef NCC_MEM_DEBUG
-    ncc_mem_report("after arena release");
-#endif
-
-    // Stage 5: Reclassify walk (typedef tracking).
+    // Stage 5: Reclassify walk (typedef tracking).  Runs on the provisional
+    // tree (extracted under the default last-alternative policy). typedef
+    // DECLARATIONS are unambiguous, so this classifies every typedef name
+    // correctly regardless of how their USE sites were provisionally parsed.
     int32_t reclassified = ncc_typedef_walk(
         g, tree, ts->tokens, ts->token_count);
 
     if (reclassified > 0) {
         ncc_verbose("reclassified %d tokens", reclassified);
     }
+
+    // Stage 5b (TS-5): type-aware re-extraction. Build a provisional symbol
+    // table from the provisional tree, install it as the forest->tree
+    // disambiguation oracle, and re-extract the retained forest so the C
+    // typedef/identifier ambiguity (e.g. `lp[2]` as a value subscript vs an
+    // array-of-`lp` type) is resolved at the parse layer rather than patched up
+    // by downstream xforms. The provisional symtab's typedef classification is
+    // reliable because it derives from unambiguous declarations.
+    {
+        ncc_symtab_t *prov_symtab = ncc_populate_symbols(g, tree);
+
+        ncc_pwz_set_disambiguator(parser, ncc_disambig_eval, prov_symtab);
+        tree = ncc_pwz_reextract(parser);
+        ncc_pwz_set_disambiguator(parser, nullptr, nullptr);
+
+        ncc_symtab_free(prov_symtab);
+    }
+
+    // Release PWZ per-parse intermediate state (arena, worklists) now that the
+    // final tree has been (re-)extracted.  Drops peak live memory before the
+    // transform and emit stages run.
+    ncc_pwz_release_parse_state(parser);
+
+#ifdef NCC_MEM_DEBUG
+    ncc_mem_report("after arena release");
+#endif
 
     // Stage 5.5: Dump pre-transform tree.
     if (opts->dump_tree) {

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -2247,6 +2247,15 @@ compile_file(ncc_opts_t *opts)
         ncc_verbose("transforms: %d nodes replaced", xctx.nodes_replaced);
     }
 
+    // Rebuild the symbol table against the fully-transformed tree so emit-time
+    // type resolution sees resolved forms (e.g. _generic_struct lowered to
+    // `struct __mangled`). The pre-transform table served expression typing
+    // during the passes; gc-typemap emission needs the post-transform view.
+    if (xdata.symtab) {
+        ncc_symtab_free(xdata.symtab);
+    }
+    xdata.symtab = ncc_populate_symbols(g, tree);
+
     // WP-020 / D-049: emit link-time GC pointer-map descriptors for the
     // pointer-to-aggregate types this TU typehash'd. Must run before the
     // transform dicts (gc_aggregate_types) are freed below; appended to the

--- a/src/parse/bnf.c
+++ b/src/parse/bnf.c
@@ -780,10 +780,13 @@ bnf_walk_expression(ncc_nt_node_t *pn, void *children, void *thunk)
 // Annotation walk data (annotations parsed and discarded)
 // ============================================================================
 
-// Penalty info extracted from @penalty annotations (the only
-// annotation that has a runtime effect on the grammar).
+// Info extracted from @annotations that have a runtime effect on the grammar:
+// @penalty(N) (error-recovery cost) and @disambig(predicate[, cost]) (TS-5
+// forest->tree disambiguation: a symtab-conditional extraction penalty).
 typedef struct {
-    int32_t penalty_cost;
+    int32_t      penalty_cost;
+    ncc_string_t disambig_predicate;  // .data == nullptr when absent
+    int32_t      disambig_cost;
 } bnf_annot_info_t;
 
 static void *
@@ -854,7 +857,9 @@ bnf_walk_annotation(ncc_nt_node_t *pn, void *children, void *thunk)
     }
 
     bnf_annot_info_t *info = ncc_alloc(bnf_annot_info_t);
-    info->penalty_cost = 0;
+    info->penalty_cost       = 0;
+    info->disambig_predicate = (ncc_string_t){0};
+    info->disambig_cost      = 0;
 
     ncc_string_t annot_str = tok_str(name_tok);
 
@@ -867,6 +872,26 @@ bnf_walk_annotation(ncc_nt_node_t *pn, void *children, void *thunk)
         }
         if (info->penalty_cost <= 0)
             info->penalty_cost = 1;
+    }
+    else if (str_eq_lit(annot_str, "disambig")) {
+        // @disambig(<predicate>[, <cost>]) — names a predicate evaluated against
+        // the symbol table at forest->tree extraction; when it holds, <cost>
+        // (default 1) is added to the alternative's score so the lowest-scoring
+        // (most type-consistent) parse is chosen.
+        if (args && args->len >= 1) {
+            ncc_token_info_t *pred_tok = (ncc_token_info_t *)slist_get(args, 0);
+            ncc_string_t      pred_val = tok_str(pred_tok);
+            if (pred_val.data)
+                info->disambig_predicate = ncc_string_from_cstr(pred_val.data);
+        }
+        if (args && args->len >= 2) {
+            ncc_token_info_t *cost_tok = (ncc_token_info_t *)slist_get(args, 1);
+            ncc_string_t      cost_val = tok_str(cost_tok);
+            if (cost_val.data)
+                info->disambig_cost = (int32_t)strtol(cost_val.data, nullptr, 10);
+        }
+        if (info->disambig_cost <= 0)
+            info->disambig_cost = 1;
     }
 
     if (args_r) {
@@ -1523,7 +1548,9 @@ populate_grammar(ncc_grammar_t *user_g, bnf_result_t *result,
             continue;
         }
 
-        int32_t penalty_cost = 0;
+        int32_t       penalty_cost       = 0;
+        ncc_string_t  disambig_predicate = {0};
+        int32_t       disambig_cost      = 0;
         bnf_result_t *annots_r = (pair->len >= 3) ? slist_get(pair, 2) : nullptr;
 
         if (annots_r && annots_r->tag == BNF_LIST) {
@@ -1537,6 +1564,10 @@ populate_grammar(ncc_grammar_t *user_g, bnf_result_t *result,
 
                     if (info->penalty_cost > 0) {
                         penalty_cost = info->penalty_cost;
+                    }
+                    if (info->disambig_predicate.data) {
+                        disambig_predicate = info->disambig_predicate;
+                        disambig_cost      = info->disambig_cost;
                     }
                 }
             }
@@ -1580,6 +1611,16 @@ populate_grammar(ncc_grammar_t *user_g, bnf_result_t *result,
                     ncc_match_t empty = {.kind = NCC_MATCH_EMPTY};
                     rule_p = ncc_add_rule_v(user_g, nt_id, 1, &empty);
                 }
+            }
+
+            // Attach the TS-5 disambiguation penalty to the (normal) rule. Set
+            // immediately after creation, before the next add_rule may realloc
+            // g->rules. Copy the predicate string — the bnf annotation info is
+            // freed during result cleanup.
+            if (rule_p && disambig_predicate.data) {
+                rule_p->disambig_predicate =
+                    ncc_string_from_cstr(disambig_predicate.data);
+                rule_p->disambig_cost = disambig_cost;
             }
 
             ncc_free(items);

--- a/src/parse/pwz.c
+++ b/src/parse/pwz.c
@@ -17,6 +17,7 @@
 #include "scanner/token_stream.h"
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -1015,6 +1016,98 @@ typedef struct {
     ncc_pwz_parser_t *parser;
 } tree_convert_state_t;
 
+// ----------------------------------------------------------------------------
+// TS-5 type-aware disambiguation scoring
+// ----------------------------------------------------------------------------
+
+// Resolve a result PWZ_SEQ exp to its grammar rule. exp->rule_ix is the LOCAL
+// rule index (position in the nonterminal's rule_ids); convert to the global
+// index, mirroring ncc_get_node_rule for parse-tree nodes.
+static ncc_parse_rule_t *
+exp_to_rule(ncc_pwz_parser_t *p, pwz_exp_t *exp)
+{
+    if (!exp || exp->kind != PWZ_SEQ || exp->nt_id < 0 || exp->rule_ix < 0) {
+        return nullptr;
+    }
+
+    ncc_nonterm_t *nt = ncc_get_nonterm(p->grammar, exp->nt_id);
+
+    if (!nt || (size_t)exp->rule_ix >= ncc_list_len(nt->rule_ids)) {
+        return nullptr;
+    }
+
+    return ncc_get_rule(p->grammar, nt->rule_ids.data[exp->rule_ix]);
+}
+
+// Disambiguation cost of a result-exp subtree: the sum of `@disambig` rule
+// penalties whose predicate holds (per the installed oracle), with nested
+// ambiguities resolved to their own minimum — exactly as convert_exp_to_tree
+// will resolve them. `*pos` advances over the consumed tokens (all alternatives
+// of an ambiguity span the same tokens, so the span length is well-defined).
+static int32_t
+score_exp(ncc_pwz_parser_t *p, pwz_exp_t *exp, int32_t *pos)
+{
+    if (!exp || exp == p->exp_bottom) {
+        return 0;
+    }
+
+    switch (exp->kind) {
+    case PWZ_TOK:
+    case PWZ_CLASS:
+    case PWZ_ANY:
+        (*pos)++;
+        return 0;
+
+    case PWZ_SEQ: {
+        int32_t           cost  = 0;
+        ncc_parse_rule_t *rule  = exp_to_rule(p, exp);
+
+        if (rule && rule->disambig_predicate.data && p->disambig_cb) {
+            // The annotated rule's decisive token is its leading token (the
+            // routed identifier for the typedef/value rules).
+            ncc_token_info_t *tok = get_token(p, *pos);
+
+            if (p->disambig_cb(p->disambig_ud, rule->disambig_predicate.data,
+                               tok)) {
+                cost += rule->disambig_cost;
+            }
+        }
+
+        for (int32_t i = 0; i < exp->nchildren; i++) {
+            cost += score_exp(p, exp->seq.children[i], pos);
+        }
+
+        return cost;
+    }
+
+    case PWZ_ALT: {
+        size_t nalts = ncc_list_len(exp->alt.alts);
+
+        if (nalts == 0) {
+            return 0;
+        }
+
+        int32_t best     = INT32_MAX;
+        int32_t best_end = *pos;
+
+        for (size_t i = 0; i < nalts; i++) {
+            int32_t p2 = *pos;
+            int32_t c  = score_exp(p, exp->alt.alts.data[i], &p2);
+
+            if (c <= best) {  // ties resolve to the last alternative
+                best     = c;
+                best_end = p2;
+            }
+        }
+
+        *pos = best_end;
+        return best;
+    }
+    }
+
+    return 0;
+}
+
 static ncc_parse_tree_t *
 convert_exp_to_tree(ncc_pwz_parser_t *p, pwz_exp_t *exp,
                     tree_convert_state_t *st)
@@ -1116,11 +1209,31 @@ convert_exp_to_tree(ncc_pwz_parser_t *p, pwz_exp_t *exp,
     case PWZ_ALT: {
         size_t nalts = ncc_list_len(exp->alt.alts);
 
-        if (nalts > 0) {
-            return convert_exp_to_tree(p, exp->alt.alts.data[nalts - 1], st);
+        if (nalts == 0) {
+            return make_epsilon_node(st->pos);
         }
 
-        return make_epsilon_node(st->pos);
+        // Default policy: last alternative (grammar order). With a TS-5
+        // disambiguation oracle installed, score each alternative and pick the
+        // lowest-scoring (most type-consistent) one; ties keep the last-alt
+        // default.
+        size_t pick = nalts - 1;
+
+        if (p->disambig_cb && nalts > 1) {
+            int32_t best = INT32_MAX;
+
+            for (size_t i = 0; i < nalts; i++) {
+                int32_t pos = st->pos;
+                int32_t c   = score_exp(p, exp->alt.alts.data[i], &pos);
+
+                if (c <= best) {  // ties resolve to the last alternative
+                    best = c;
+                    pick = i;
+                }
+            }
+        }
+
+        return convert_exp_to_tree(p, exp->alt.alts.data[pick], st);
     }
     }
 
@@ -1239,6 +1352,8 @@ ncc_pwz_new(ncc_grammar_t *g)
     p->worklist      = ncc_list_new(pwz_zipper_t);
     p->worklist_swap = ncc_list_new(pwz_zipper_t);
     p->tops          = ncc_list_new(pwz_exp_ptr_t);
+    p->disambig_cb   = nullptr;
+    p->disambig_ud   = nullptr;
 
     // Sentinel nodes.
     p->exp_bottom       = ncc_alloc(pwz_exp_t);
@@ -1348,6 +1463,33 @@ ncc_pwz_parse(ncc_pwz_parser_t   *p,
 ncc_parse_tree_t *
 ncc_pwz_get_tree(ncc_pwz_parser_t *p)
 {
+    return p->result_tree;
+}
+
+void
+ncc_pwz_set_disambiguator(ncc_pwz_parser_t    *p,
+                          ncc_pwz_disambig_fn  cb,
+                          void                *ud)
+{
+    if (!p) {
+        return;
+    }
+
+    p->disambig_cb = cb;
+    p->disambig_ud = ud;
+}
+
+ncc_parse_tree_t *
+ncc_pwz_reextract(ncc_pwz_parser_t *p)
+{
+    if (!p || ncc_list_len(p->tops) == 0) {
+        return p ? p->result_tree : nullptr;
+    }
+
+    // The forest top is retained until ncc_pwz_release_parse_state; rebuild a
+    // single tree from it under the currently-installed disambiguation oracle.
+    p->result_tree = build_result_tree(p, p->tops.data[0]);
+
     return p->result_tree;
 }
 

--- a/src/parse/symbol_populate.c
+++ b/src/parse/symbol_populate.c
@@ -148,15 +148,52 @@ ns_tag(void)
 static void scan_params(ncc_symtab_t *st, ncc_parse_tree_t *node,
                         int64_t id_tid);
 
-// True if a declarator subtree is a function declarator (has a parameter list).
+// In-order leaf scan deciding whether a declarator declares a FUNCTION (vs a
+// variable or function-pointer). A function declaration's name precedes its
+// parameter parenthesis (`f(args)`, `*f(args)`); a function-pointer variable
+// parenthesizes the name first (`(*fp)(args)`). So: the first '(' falls AFTER
+// the first identifier, and a parameter list exists.
+typedef struct {
+    bool seen_id;
+    int  decision; // 0 = undecided, 1 = function, 2 = not-a-function
+} fn_scan_t;
+
+static void
+fn_scan(ncc_parse_tree_t *node, fn_scan_t *s)
+{
+    if (!node || s->decision != 0) {
+        return;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
+        ncc_string_t      t   = (tok && ncc_option_is_set(tok->value))
+                                    ? ncc_option_get(tok->value)
+                                    : ncc_string_empty();
+        if (tok && tok->tid == NCC_TOK_IDENTIFIER) {
+            s->seen_id = true;
+        }
+        else if (t.data && strcmp(t.data, "(") == 0) {
+            s->decision = s->seen_id ? 1 : 2;
+        }
+        return;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc && s->decision == 0; i++) {
+        fn_scan(ncc_tree_child(node, i), s);
+    }
+}
+
 static bool
 declarator_is_function(ncc_parse_tree_t *declarator)
 {
     if (!declarator) {
         return false;
     }
-    return child_nt(declarator, "parameter_type_list") != nullptr
-        || child_nt(declarator, "parameter_list") != nullptr;
+    // decision == 1 requires a '(' after an identifier — i.e. a parameter list
+    // on the declared name, so no separate param-list check is needed.
+    fn_scan_t s = {.seen_id = false, .decision = 0};
+    fn_scan(declarator, &s);
+    return s.decision == 1;
 }
 
 static void

--- a/src/parse/type_infer.c
+++ b/src/parse/type_infer.c
@@ -457,33 +457,47 @@ ncc_symtab_aggregate_spec(ncc_symtab_t *st, const char *type_name)
     return result;
 }
 
-// True if a parsed `type_name` is really a mis-parsed expression: its base is a
-// plain identifier that names a VALUE (variable / parameter / function) rather
-// than a type. The grammar lets any identifier stand in as a typedef-name, so
-// expressions like `lp[2]` or `gp` can parse as type_names; the symbol table
-// disambiguates. struct/union/enum specifiers and builtin keywords are real
-// types; an unknown identifier is treated conservatively as a type.
+// `@disambig` predicate evaluator (TS-5). Matches ncc_pwz_disambig_fn: `ud` is
+// the symbol table. Classifies `tok`'s identifier against the symbol table so
+// the forest->tree extractor can resolve the C typedef/value ambiguity:
+//   - "id_is_value":   the identifier names a variable/parameter/function, so a
+//                      parse treating it as a TYPE (typedef_name) is penalized.
+//   - "id_is_typedef": the identifier names a typedef, so a parse treating it as
+//                      a VALUE (provided_identifier) is penalized.
+// An unknown identifier (not in the symtab) matches neither — both readings
+// score equally and the default last-alternative policy applies, preserving the
+// pre-TS-5 behavior for forward-referenced or out-of-scope names.
 bool
-ncc_type_name_is_value_expr(ncc_symtab_t *st, ncc_parse_tree_t *type_name)
+ncc_disambig_eval(void *ud, const char *predicate, ncc_token_info_t *tok)
 {
-    if (!st || !type_name) {
+    ncc_symtab_t *st = (ncc_symtab_t *)ud;
+
+    if (!st || !predicate || !tok || !ncc_option_is_set(tok->value)) {
         return false;
     }
-    if (find_descendant_nt(type_name, "struct_or_union_specifier")
-        || find_descendant_nt(type_name, "enum_specifier")) {
+
+    ncc_string_t name = ncc_option_get(tok->value);
+
+    if (!name.data || name.u8_bytes == 0) {
         return false;
     }
-    ncc_parse_tree_t *tdn = find_descendant_nt(type_name, "typedef_name");
-    if (!tdn) {
-        return false; // a builtin/keyword type, not an identifier
+
+    ncc_sym_entry_t *sym = ncc_symtab_lookup(st, ncc_string_empty(), name);
+
+    if (!sym) {
+        return false;
     }
-    ncc_string_t     id  = identifier_text(tdn);
-    ncc_sym_entry_t *sym = id.data ? ncc_symtab_lookup(st, ncc_string_empty(),
-                                                       id)
-                                   : nullptr;
-    return sym
-        && (sym->kind == NCC_SYM_VARIABLE || sym->kind == NCC_SYM_PARAM
-            || sym->kind == NCC_SYM_FUNCTION);
+
+    if (strcmp(predicate, "id_is_value") == 0) {
+        return sym->kind == NCC_SYM_VARIABLE || sym->kind == NCC_SYM_PARAM
+            || sym->kind == NCC_SYM_FUNCTION;
+    }
+
+    if (strcmp(predicate, "id_is_typedef") == 0) {
+        return sym->kind == NCC_SYM_TYPEDEF;
+    }
+
+    return false;
 }
 
 // Type spelling of a single member_declaration whose field name is `fname`.

--- a/src/parse/type_infer.c
+++ b/src/parse/type_infer.c
@@ -379,8 +379,13 @@ ncc_symtab_aggregate_spec(ncc_symtab_t *st, const char *type_name)
     }
 
     // A tag-reference spelling ("struct foo") resolves directly in the tag ns
-    // by its bare tag name.
-    const char *bare = type_name;
+    // by its bare tag name. A BARE identifier (no struct/union/enum keyword) is
+    // a type only via a typedef — never directly via the tag namespace — so the
+    // tag fallback below is gated on an explicit keyword. (Otherwise a bare name
+    // that happens to match a struct tag — e.g. md4c's `MD_SPAN_WIKILINK`, both
+    // an enum constant and a struct tag — would wrongly resolve as that struct.)
+    bool        had_prefix = false;
+    const char *bare       = type_name;
     for (const char *kw = nullptr;;) {
         kw = nullptr;
         if (strncmp(bare, "struct ", 7) == 0) {
@@ -398,7 +403,8 @@ ncc_symtab_aggregate_spec(ncc_symtab_t *st, const char *type_name)
         while (*kw == ' ') {
             kw++;
         }
-        bare = kw;
+        bare       = kw;
+        had_prefix = true;
     }
 
     ncc_string_t      nm     = ncc_string_from_cstr(type_name);
@@ -406,7 +412,14 @@ ncc_symtab_aggregate_spec(ncc_symtab_t *st, const char *type_name)
     ncc_parse_tree_t *result = nullptr;
 
     ncc_sym_entry_t *sym = ncc_symtab_lookup(st, ncc_string_empty(), nm);
-    if (sym && sym->kind == NCC_SYM_TYPEDEF && sym->type_node) {
+    // A pointer/array typedef (e.g. `typedef struct MIR_item *MIR_item_t;`)
+    // aliases a VALUE, not a by-value aggregate. Its specifiers still contain
+    // the pointee's struct, so resolving it here would wrongly report the
+    // pointee as a by-value aggregate (and a caller would emit offsetof through
+    // a pointer). Only a typedef whose declarator adds no `*`/`[]` is a genuine
+    // aggregate alias.
+    if (sym && sym->kind == NCC_SYM_TYPEDEF && sym->type_node
+        && declarator_ptr_depth(sym->decl_node) == 0) {
         ncc_parse_tree_t *su = find_descendant_nt(sym->type_node,
                                                   "struct_or_union_specifier");
         if (su && child_nt(su, "member_declaration_list")) {
@@ -425,7 +438,8 @@ ncc_symtab_aggregate_spec(ncc_symtab_t *st, const char *type_name)
             }
         }
     }
-    if (!result) {
+    if (!result && had_prefix) {
+        // Only an explicit `struct X` / `union X` reaches the tag namespace.
         ncc_sym_entry_t *te = ncc_symtab_lookup(st, NCC_STRING_STATIC("tag"),
                                                 barenm);
         if (te && te->type_node

--- a/src/parse/type_infer.c
+++ b/src/parse/type_infer.c
@@ -265,6 +265,218 @@ type_of_symbol(ncc_sym_entry_t *sym)
 }
 
 // ============================================================================
+// Aggregate / member resolution
+// ============================================================================
+
+// First descendant (incl. self) with NT name `name`.
+static ncc_parse_tree_t *
+find_descendant_nt(ncc_parse_tree_t *node, const char *name)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return nullptr;
+    }
+    if (nt_is(node, name)) {
+        return node;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *f = find_descendant_nt(ncc_tree_child(node, i), name);
+        if (f) {
+            return f;
+        }
+    }
+    return nullptr;
+}
+
+// Text of the first IDENTIFIER/TYPEDEF_NAME leaf at or under `node`.
+static ncc_string_t
+identifier_text(ncc_parse_tree_t *node)
+{
+    if (!node) {
+        return ncc_string_empty();
+    }
+    if (ncc_tree_is_leaf(node)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
+        if (tok
+            && (tok->tid == NCC_TOK_IDENTIFIER
+                || tok->tid == NCC_TOK_TYPEDEF_NAME)) {
+            return leaf_text(node);
+        }
+        return ncc_string_empty();
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_string_t t = identifier_text(ncc_tree_child(node, i));
+        if (t.data && t.u8_bytes > 0) {
+            return t;
+        }
+    }
+    return ncc_string_empty();
+}
+
+// Last IDENTIFIER leaf in DFS order under a member_declaration — its declared
+// field name — skipping nested aggregate bodies and parameter lists (whose
+// identifiers belong to inner declarations, not this field). Works whether the
+// name sits in the declarator (`T *x`) or folds into the specifiers (`T x`).
+static void
+last_field_identifier(ncc_parse_tree_t *node, ncc_string_t *out)
+{
+    if (!node) {
+        return;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
+        if (tok && tok->tid == NCC_TOK_IDENTIFIER) {
+            *out = leaf_text(node);
+        }
+        return;
+    }
+    if (nt_is(node, "member_declaration_list") || nt_is(node, "parameter_type_list")
+        || nt_is(node, "parameter_list")) {
+        return;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        last_field_identifier(ncc_tree_child(node, i), out);
+    }
+}
+
+// Resolve a type name to its aggregate specifier (one carrying a member body)
+// via the scoped symbol table, following a typedef to its underlying tag. A
+// leading struct/union/enum keyword (a tag-reference spelling) is handled.
+// Catches types the legacy aggregate table misses (notably _generic_struct
+// typedefs). Returns a specifier with a member_declaration_list, or nullptr.
+ncc_parse_tree_t *
+ncc_symtab_aggregate_spec(ncc_symtab_t *st, const char *type_name)
+{
+    if (!st || !type_name) {
+        return nullptr;
+    }
+
+    // A tag-reference spelling ("struct foo") resolves directly in the tag ns
+    // by its bare tag name.
+    const char *bare = type_name;
+    for (const char *kw = nullptr;;) {
+        kw = nullptr;
+        if (strncmp(bare, "struct ", 7) == 0) {
+            kw = bare + 7;
+        }
+        else if (strncmp(bare, "union ", 6) == 0) {
+            kw = bare + 6;
+        }
+        else if (strncmp(bare, "enum ", 5) == 0) {
+            kw = bare + 5;
+        }
+        if (!kw) {
+            break;
+        }
+        while (*kw == ' ') {
+            kw++;
+        }
+        bare = kw;
+    }
+
+    ncc_string_t      nm     = ncc_string_from_cstr(type_name);
+    ncc_string_t      barenm = ncc_string_from_cstr(bare);
+    ncc_parse_tree_t *result = nullptr;
+
+    ncc_sym_entry_t *sym = ncc_symtab_lookup(st, ncc_string_empty(), nm);
+    if (sym && sym->kind == NCC_SYM_TYPEDEF && sym->type_node) {
+        ncc_parse_tree_t *su = find_descendant_nt(sym->type_node,
+                                                  "struct_or_union_specifier");
+        if (su && child_nt(su, "member_declaration_list")) {
+            result = su;
+        }
+        else if (su) {
+            ncc_parse_tree_t *tagn = child_nt(su, "tag_name");
+            if (tagn) {
+                ncc_string_t     tag = identifier_text(tagn);
+                ncc_sym_entry_t *te  = ncc_symtab_lookup(
+                    st, NCC_STRING_STATIC("tag"), tag);
+                if (te && te->type_node
+                    && child_nt(te->type_node, "member_declaration_list")) {
+                    result = te->type_node;
+                }
+            }
+        }
+    }
+    if (!result) {
+        ncc_sym_entry_t *te = ncc_symtab_lookup(st, NCC_STRING_STATIC("tag"),
+                                                barenm);
+        if (te && te->type_node
+            && child_nt(te->type_node, "member_declaration_list")) {
+            result = te->type_node;
+        }
+    }
+
+    if (nm.data) {
+        ncc_free(nm.data);
+    }
+    if (barenm.data) {
+        ncc_free(barenm.data);
+    }
+    return result;
+}
+
+// Type spelling of a single member_declaration whose field name is `fname`.
+static char *
+member_decl_type(ncc_parse_tree_t *m, ncc_string_t fname)
+{
+    ncc_parse_tree_t *specs = child_nt(m, "specifier_qualifier_list");
+    if (!specs) {
+        return nullptr;
+    }
+    ncc_parse_tree_t *declr = find_descendant_nt(m, "declarator");
+    int               depth = declr ? declarator_ptr_depth(declr) : 0;
+    if (depth < 0) {
+        return nullptr; // array / function member — not yet typed
+    }
+    char *base = canonical_base(specs, fname);
+    return base ? append_stars(base, depth) : nullptr;
+}
+
+// Find member `name` and return its type spelling, recursing through the
+// (left-recursive) member_declaration_list structure but NOT into a member's
+// own nested aggregate body. Returns the type, or nullptr if not found / not
+// yet typeable. `*found` is set when the name matched (even if untypeable).
+static char *
+find_member_type(ncc_parse_tree_t *node, ncc_string_t name, bool *found)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return nullptr;
+    }
+    if (nt_is(node, "member_declaration")) {
+        ncc_string_t fname = ncc_string_empty();
+        last_field_identifier(node, &fname);
+        if (fname.data && ncc_string_eq(fname, name)) {
+            *found = true;
+            return member_decl_type(node, fname);
+        }
+        return nullptr; // a different field — do not descend into its body
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        char *r = find_member_type(ncc_tree_child(node, i), name, found);
+        if (*found) {
+            return r;
+        }
+    }
+    return nullptr;
+}
+
+// Type spelling of member `name` within aggregate `spec`, or nullptr.
+static char *
+type_of_member(ncc_parse_tree_t *spec, ncc_string_t name)
+{
+    ncc_parse_tree_t *members = child_nt(spec, "member_declaration_list");
+    if (!members || !name.data) {
+        return nullptr;
+    }
+    bool found = false;
+    return find_member_type(members, name, &found);
+}
+
+// ============================================================================
 // Expression typing
 // ============================================================================
 
@@ -354,6 +566,49 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
         }
     }
 
+    // postfix member access: base ('.' | '->') member.
+    if (nt_is(expr, "postfix_expression")) {
+        bool              arrow = false;
+        bool              dot   = false;
+        ncc_parse_tree_t *base  = nullptr;
+        ncc_parse_tree_t *mem   = nullptr;
+        size_t            nc    = ncc_tree_num_children(expr);
+        for (size_t i = 0; i < nc; i++) {
+            ncc_parse_tree_t *c = ncc_tree_child(expr, i);
+            if (!c) {
+                continue;
+            }
+            ncc_string_t t = leaf_text(c);
+            if (t.data && strcmp(t.data, "->") == 0) {
+                arrow = true;
+            }
+            else if (t.data && strcmp(t.data, ".") == 0) {
+                dot = true;
+            }
+            else if (!base) {
+                base = c; // first non-operator child is the aggregate operand
+            }
+            else {
+                mem = c; // last is the member name
+            }
+        }
+        if ((arrow || dot) && base && mem) {
+            char *btype = ncc_type_of_expr(st, base);
+            if (arrow) {
+                btype = strip_one_star(btype); // p->m : deref then member
+            }
+            char *result = nullptr;
+            if (btype) {
+                ncc_parse_tree_t *spec = ncc_symtab_aggregate_spec(st, btype);
+                if (spec) {
+                    result = type_of_member(spec, identifier_text(mem));
+                }
+                ncc_free(btype);
+            }
+            return result;
+        }
+    }
+
     // Pass-through precedence cascade: a single meaningful child.
     {
         ncc_parse_tree_t *only = nullptr;
@@ -362,5 +617,5 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
         }
     }
 
-    return nullptr; // member access, calls, subscripts, arithmetic: TODO
+    return nullptr; // calls, subscripts, arithmetic: TODO
 }

--- a/src/parse/type_infer.c
+++ b/src/parse/type_infer.c
@@ -443,6 +443,35 @@ ncc_symtab_aggregate_spec(ncc_symtab_t *st, const char *type_name)
     return result;
 }
 
+// True if a parsed `type_name` is really a mis-parsed expression: its base is a
+// plain identifier that names a VALUE (variable / parameter / function) rather
+// than a type. The grammar lets any identifier stand in as a typedef-name, so
+// expressions like `lp[2]` or `gp` can parse as type_names; the symbol table
+// disambiguates. struct/union/enum specifiers and builtin keywords are real
+// types; an unknown identifier is treated conservatively as a type.
+bool
+ncc_type_name_is_value_expr(ncc_symtab_t *st, ncc_parse_tree_t *type_name)
+{
+    if (!st || !type_name) {
+        return false;
+    }
+    if (find_descendant_nt(type_name, "struct_or_union_specifier")
+        || find_descendant_nt(type_name, "enum_specifier")) {
+        return false;
+    }
+    ncc_parse_tree_t *tdn = find_descendant_nt(type_name, "typedef_name");
+    if (!tdn) {
+        return false; // a builtin/keyword type, not an identifier
+    }
+    ncc_string_t     id  = identifier_text(tdn);
+    ncc_sym_entry_t *sym = id.data ? ncc_symtab_lookup(st, ncc_string_empty(),
+                                                       id)
+                                   : nullptr;
+    return sym
+        && (sym->kind == NCC_SYM_VARIABLE || sym->kind == NCC_SYM_PARAM
+            || sym->kind == NCC_SYM_FUNCTION);
+}
+
 // Type spelling of a single member_declaration whose field name is `fname`.
 static char *
 member_decl_type(ncc_parse_tree_t *m, ncc_string_t fname)

--- a/src/parse/type_infer.c
+++ b/src/parse/type_infer.c
@@ -134,6 +134,31 @@ declarator_ptr_depth(ncc_parse_tree_t *node)
     return total;
 }
 
+// Pointer depth of a function declarator's RETURN type: the `*` stars outside
+// the parameter list (and array dimensions). Unlike declarator_ptr_depth this
+// does not bail on the parameter list — it skips it. `int *f(args)` -> 1.
+static int
+return_ptr_depth(ncc_parse_tree_t *node)
+{
+    if (!node) {
+        return 0;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        ncc_string_t t = leaf_text(node);
+        return (t.data && strcmp(t.data, "*") == 0) ? 1 : 0;
+    }
+    if (nt_is(node, "parameter_type_list") || nt_is(node, "parameter_list")
+        || nt_is(node, "array_declarator")) {
+        return 0;
+    }
+    int    total = 0;
+    size_t nc    = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        total += return_ptr_depth(ncc_tree_child(node, i));
+    }
+    return total;
+}
+
 // Storage-class and function specifiers are not part of a value's type; drop
 // them from a normalized specifier spelling (keep const/volatile, which are).
 static bool
@@ -566,10 +591,10 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
         }
     }
 
-    // postfix member access: base ('.' | '->') member.
+    // Postfix forms: member access (e.f / e->f), call (f(args)), subscript
+    // (a[i]). One scan classifies the operator and captures the operand(s).
     if (nt_is(expr, "postfix_expression")) {
-        bool              arrow = false;
-        bool              dot   = false;
+        bool              arrow = false, dot = false, call = false, sub = false;
         ncc_parse_tree_t *base  = nullptr;
         ncc_parse_tree_t *mem   = nullptr;
         size_t            nc    = ncc_tree_num_children(expr);
@@ -578,34 +603,76 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
             if (!c) {
                 continue;
             }
-            ncc_string_t t = leaf_text(c);
-            if (t.data && strcmp(t.data, "->") == 0) {
-                arrow = true;
+            if (ncc_tree_is_leaf(c)) {
+                const char *s = leaf_text(c).data;
+                s             = s ? s : "";
+                if (strcmp(s, "->") == 0) {
+                    arrow = true;
+                }
+                else if (strcmp(s, ".") == 0) {
+                    dot = true;
+                }
+                else if (strcmp(s, "(") == 0) {
+                    call = true;
+                }
+                else if (strcmp(s, "[") == 0) {
+                    sub = true;
+                }
+                // ) ] , ++ -- ! and other punctuation are ignored; a non-punct
+                // leaf (e.g. a member-name identifier) falls through below.
+                else if (strcmp(s, ")") == 0 || strcmp(s, "]") == 0
+                         || strcmp(s, ",") == 0 || strcmp(s, "++") == 0
+                         || strcmp(s, "--") == 0 || strcmp(s, "!") == 0) {
+                    continue;
+                }
+                else {
+                    if (!base) {
+                        base = c;
+                    }
+                    else if (!mem) {
+                        mem = c;
+                    }
+                }
+                continue;
             }
-            else if (t.data && strcmp(t.data, ".") == 0) {
-                dot = true;
+            if (!base) {
+                base = c; // first nonterminal: aggregate / callee / array
             }
-            else if (!base) {
-                base = c; // first non-operator child is the aggregate operand
-            }
-            else {
-                mem = c; // last is the member name
+            else if (!mem) {
+                mem = c; // member name / argument list / index
             }
         }
+
         if ((arrow || dot) && base && mem) {
-            char *btype = ncc_type_of_expr(st, base);
+            char *bt = ncc_type_of_expr(st, base);
             if (arrow) {
-                btype = strip_one_star(btype); // p->m : deref then member
+                bt = strip_one_star(bt); // p->m : deref then member
             }
             char *result = nullptr;
-            if (btype) {
-                ncc_parse_tree_t *spec = ncc_symtab_aggregate_spec(st, btype);
+            if (bt) {
+                ncc_parse_tree_t *spec = ncc_symtab_aggregate_spec(st, bt);
                 if (spec) {
                     result = type_of_member(spec, identifier_text(mem));
                 }
-                ncc_free(btype);
+                ncc_free(bt);
             }
             return result;
+        }
+        if (sub && base) {
+            // a[i] : element type of a pointer (array decay handled as pointer).
+            return strip_one_star(ncc_type_of_expr(st, base));
+        }
+        if (call && base) {
+            ncc_string_t     fn  = identifier_text(base);
+            ncc_sym_entry_t *sym = fn.data ? ncc_symtab_lookup(
+                                       st, ncc_string_empty(), fn)
+                                           : nullptr;
+            if (sym && sym->kind == NCC_SYM_FUNCTION && sym->type_node) {
+                char *b = canonical_base(sym->type_node, fn);
+                if (b) {
+                    return append_stars(b, return_ptr_depth(sym->decl_node));
+                }
+            }
         }
     }
 

--- a/src/xform/xform_array_literal.c
+++ b/src/xform/xform_array_literal.c
@@ -1104,12 +1104,6 @@ format_cstr(const char *fmt, ...)
     return ncc_buffer_take(buf);
 }
 
-static ncc_dict_t *
-array_aggregate_types(ncc_xform_ctx_t *ctx)
-{
-    ncc_xform_data_t *data = ncc_xform_get_data(ctx);
-    return data ? &data->gc_aggregate_types : nullptr;
-}
 
 static ncc_dict_t *
 array_pointer_typedefs(ncc_xform_ctx_t *ctx)
@@ -1204,15 +1198,8 @@ aggregate_specifier_has_members(ncc_parse_tree_t *su)
 static array_aggregate_type_info_t *
 lookup_aggregate_type(ncc_xform_ctx_t *ctx, const char *key)
 {
-    ncc_dict_t *types = array_aggregate_types(ctx);
-    if (!types || !key) {
-        return nullptr;
-    }
-
-    bool found = false;
-    array_aggregate_type_info_t *info =
-        ncc_dict_get(types, (void *)key, &found);
-    return found ? info : nullptr;
+    // Delegate to the shared symtab-backed resolver (single source of truth).
+    return ncc_layout_lookup_aggregate_type(ctx, key);
 }
 
 static ncc_parse_tree_t *

--- a/src/xform/xform_gc_stack_maps.c
+++ b/src/xform/xform_gc_stack_maps.c
@@ -1320,13 +1320,6 @@ has_parenthesized_pointer_array(ncc_parse_tree_t *declarator)
 }
 
 static ncc_dict_t *
-gc_aggregate_types(ncc_xform_ctx_t *ctx)
-{
-    ncc_xform_data_t *data = ncc_xform_get_data(ctx);
-    return data ? &data->gc_aggregate_types : nullptr;
-}
-
-static ncc_dict_t *
 gc_pointer_typedefs(ncc_xform_ctx_t *ctx)
 {
     ncc_xform_data_t *data = ncc_xform_get_data(ctx);
@@ -1373,14 +1366,10 @@ aggregate_specifier_has_members(ncc_parse_tree_t *su)
 static aggregate_type_info_t *
 lookup_aggregate_type(ncc_xform_ctx_t *ctx, const char *key)
 {
-    ncc_dict_t *types = gc_aggregate_types(ctx);
-    if (!types || !key) {
-        return nullptr;
-    }
-
-    bool found = false;
-    aggregate_type_info_t *info = ncc_dict_get(types, (void *)key, &found);
-    return found ? info : nullptr;
+    // Delegate to the shared resolver (single source of truth): it consults the
+    // aggregate table and falls back to the symbol table, so this pass resolves
+    // _generic_struct / generic types too. The info structs are the same type.
+    return ncc_layout_lookup_aggregate_type(ctx, key);
 }
 
 static ncc_parse_tree_t *

--- a/src/xform/xform_gc_typemap.c
+++ b/src/xform/xform_gc_typemap.c
@@ -21,6 +21,7 @@
 
 #include "lib/alloc.h"
 #include "lib/buffer.h"
+#include "parse/type_infer.h"
 #include "util/type_normalize.h"
 #include "xform/xform_data.h"
 #include "xform/xform_gc_typemap.h"
@@ -1235,66 +1236,17 @@ derive_gcidx_attr(const char *stobj_attr)
     return derive_gc_section_attr(stobj_attr, "n00b_gcidx");
 }
 
-// Resolve a type name to its aggregate specifier (one carrying a member body)
-// via the scoped symbol table, following a typedef to its underlying tag. This
-// catches types the legacy aggregate table misses — notably _generic_struct
-// typedefs (n00b_variant_t, generic containers), whose alias the lazy collector
-// registers before generic-struct lowering and therefore cannot resolve.
-// Returns a struct/union specifier with a member_declaration_list, or nullptr.
+// Resolve a type name to its aggregate specifier via the type model, then keep
+// it only if it is file-scope: the descriptors are emitted at file scope, so a
+// block-local tag would dangle.
 static ncc_parse_tree_t *
 symtab_resolve_aggregate(ncc_symtab_t *st, const char *name)
 {
-    if (!st || !name) {
-        return nullptr;
-    }
-    ncc_string_t      nm   = ncc_string_from_cstr(name);
-    ncc_sym_entry_t  *sym  = ncc_symtab_lookup(st, ncc_string_empty(), nm);
-    ncc_parse_tree_t *spec = nullptr;
-
-    if (sym && sym->kind == NCC_SYM_TYPEDEF && sym->type_node) {
-        ncc_parse_tree_t *su = ncc_layout_first_descendant_nt(
-            sym->type_node, "struct_or_union_specifier");
-        if (su && ncc_xform_find_child_nt(su, "member_declaration_list")) {
-            spec = su; // typedef with an inline aggregate body
-        }
-        else if (su) {
-            // Tag reference: resolve the tag's definition via the tag namespace.
-            ncc_parse_tree_t *tagn = ncc_xform_find_child_nt(su, "tag_name");
-            if (tagn) {
-                // tag_name is a single identifier, so its text needs no trim.
-                ncc_string_t     tag = ncc_xform_node_to_text(tagn);
-                ncc_sym_entry_t *te  = ncc_symtab_lookup(
-                    st, NCC_STRING_STATIC("tag"), tag);
-                if (te && te->type_node
-                    && ncc_xform_find_child_nt(te->type_node,
-                                               "member_declaration_list")) {
-                    spec = te->type_node;
-                }
-                if (tag.data) {
-                    ncc_free(tag.data);
-                }
-            }
-        }
-    }
-
-    if (!spec) {
-        // The name may itself be a struct/union tag.
-        ncc_sym_entry_t *te = ncc_symtab_lookup(st, NCC_STRING_STATIC("tag"), nm);
-        if (te && te->type_node
-            && ncc_xform_find_child_nt(te->type_node, "member_declaration_list")) {
-            spec = te->type_node;
-        }
-    }
-    if (nm.data) {
-        ncc_free(nm.data);
-    }
-
-    // Only file-scope aggregates are usable: the descriptors are emitted at file
-    // scope, so a block-local tag would dangle.
+    ncc_parse_tree_t *spec = ncc_symtab_aggregate_spec(st, name);
     if (spec
         && (ncc_xform_find_ancestor(spec, "compound_statement")
             || ncc_xform_find_ancestor(spec, "function_definition"))) {
-        spec = nullptr;
+        return nullptr;
     }
     return spec;
 }

--- a/src/xform/xform_gc_typemap.c
+++ b/src/xform/xform_gc_typemap.c
@@ -1235,6 +1235,70 @@ derive_gcidx_attr(const char *stobj_attr)
     return derive_gc_section_attr(stobj_attr, "n00b_gcidx");
 }
 
+// Resolve a type name to its aggregate specifier (one carrying a member body)
+// via the scoped symbol table, following a typedef to its underlying tag. This
+// catches types the legacy aggregate table misses — notably _generic_struct
+// typedefs (n00b_variant_t, generic containers), whose alias the lazy collector
+// registers before generic-struct lowering and therefore cannot resolve.
+// Returns a struct/union specifier with a member_declaration_list, or nullptr.
+static ncc_parse_tree_t *
+symtab_resolve_aggregate(ncc_symtab_t *st, const char *name)
+{
+    if (!st || !name) {
+        return nullptr;
+    }
+    ncc_string_t      nm   = ncc_string_from_cstr(name);
+    ncc_sym_entry_t  *sym  = ncc_symtab_lookup(st, ncc_string_empty(), nm);
+    ncc_parse_tree_t *spec = nullptr;
+
+    if (sym && sym->kind == NCC_SYM_TYPEDEF && sym->type_node) {
+        ncc_parse_tree_t *su = ncc_layout_first_descendant_nt(
+            sym->type_node, "struct_or_union_specifier");
+        if (su && ncc_xform_find_child_nt(su, "member_declaration_list")) {
+            spec = su; // typedef with an inline aggregate body
+        }
+        else if (su) {
+            // Tag reference: resolve the tag's definition via the tag namespace.
+            ncc_parse_tree_t *tagn = ncc_xform_find_child_nt(su, "tag_name");
+            if (tagn) {
+                // tag_name is a single identifier, so its text needs no trim.
+                ncc_string_t     tag = ncc_xform_node_to_text(tagn);
+                ncc_sym_entry_t *te  = ncc_symtab_lookup(
+                    st, NCC_STRING_STATIC("tag"), tag);
+                if (te && te->type_node
+                    && ncc_xform_find_child_nt(te->type_node,
+                                               "member_declaration_list")) {
+                    spec = te->type_node;
+                }
+                if (tag.data) {
+                    ncc_free(tag.data);
+                }
+            }
+        }
+    }
+
+    if (!spec) {
+        // The name may itself be a struct/union tag.
+        ncc_sym_entry_t *te = ncc_symtab_lookup(st, NCC_STRING_STATIC("tag"), nm);
+        if (te && te->type_node
+            && ncc_xform_find_child_nt(te->type_node, "member_declaration_list")) {
+            spec = te->type_node;
+        }
+    }
+    if (nm.data) {
+        ncc_free(nm.data);
+    }
+
+    // Only file-scope aggregates are usable: the descriptors are emitted at file
+    // scope, so a block-local tag would dangle.
+    if (spec
+        && (ncc_xform_find_ancestor(spec, "compound_statement")
+            || ncc_xform_find_ancestor(spec, "function_definition"))) {
+        spec = nullptr;
+    }
+    return spec;
+}
+
 char *
 ncc_gc_typemap_emit(ncc_xform_ctx_t *ctx)
 {
@@ -1257,17 +1321,22 @@ ncc_gc_typemap_emit(ncc_xform_ctx_t *ctx)
         }
 
         bool scalar_no_ptr = elem_type_is_scalar_no_ptr(records[i].elem_type);
-        ncc_layout_aggregate_type_info_t *info = nullptr;
+        ncc_parse_tree_t *spec = nullptr;
         if (!scalar_no_ptr) {
-            info = ncc_layout_aggregate_info_from_type_name(ctx,
-                                                            records[i].elem_type);
-            if (!info || !info->specifier) {
-                continue;
+            ncc_layout_aggregate_type_info_t *info =
+                ncc_layout_aggregate_info_from_type_name(ctx,
+                                                         records[i].elem_type);
+            if (info && info->specifier && aggregate_type_is_file_visible(info)
+                && !info->is_atomic) {
+                spec = info->specifier;
             }
-            if (!aggregate_type_is_file_visible(info)) {
-                continue;
+            else {
+                // The legacy aggregate table missed it (e.g. a _generic_struct
+                // typedef). Resolve through the type model instead.
+                spec = symtab_resolve_aggregate(
+                    ncc_xform_get_data(ctx)->symtab, records[i].elem_type);
             }
-            if (info->is_atomic) {
+            if (!spec) {
                 continue;
             }
         }
@@ -1284,7 +1353,7 @@ ncc_gc_typemap_emit(ncc_xform_ctx_t *ctx)
         };
 
         if (!scalar_no_ptr) {
-            gc_walk(ctx, records[i].elem_type, info->specifier, "", offs, asserts,
+            gc_walk(ctx, records[i].elem_type, spec, "", offs, asserts,
                     &count, &vacc, &ok, 0);
         }
 

--- a/src/xform/xform_gc_typemap.c
+++ b/src/xform/xform_gc_typemap.c
@@ -21,7 +21,6 @@
 
 #include "lib/alloc.h"
 #include "lib/buffer.h"
-#include "parse/type_infer.h"
 #include "util/type_normalize.h"
 #include "xform/xform_data.h"
 #include "xform/xform_gc_typemap.h"
@@ -1236,21 +1235,6 @@ derive_gcidx_attr(const char *stobj_attr)
     return derive_gc_section_attr(stobj_attr, "n00b_gcidx");
 }
 
-// Resolve a type name to its aggregate specifier via the type model, then keep
-// it only if it is file-scope: the descriptors are emitted at file scope, so a
-// block-local tag would dangle.
-static ncc_parse_tree_t *
-symtab_resolve_aggregate(ncc_symtab_t *st, const char *name)
-{
-    ncc_parse_tree_t *spec = ncc_symtab_aggregate_spec(st, name);
-    if (spec
-        && (ncc_xform_find_ancestor(spec, "compound_statement")
-            || ncc_xform_find_ancestor(spec, "function_definition"))) {
-        return nullptr;
-    }
-    return spec;
-}
-
 char *
 ncc_gc_typemap_emit(ncc_xform_ctx_t *ctx)
 {
@@ -1275,22 +1259,17 @@ ncc_gc_typemap_emit(ncc_xform_ctx_t *ctx)
         bool scalar_no_ptr = elem_type_is_scalar_no_ptr(records[i].elem_type);
         ncc_parse_tree_t *spec = nullptr;
         if (!scalar_no_ptr) {
+            // Aggregate resolution now flows through the type model: the shared
+            // lookup falls back to the symbol table, so _generic_struct typedefs
+            // (the n00b_variant_t / generic-container shape) resolve here too.
             ncc_layout_aggregate_type_info_t *info =
                 ncc_layout_aggregate_info_from_type_name(ctx,
                                                          records[i].elem_type);
-            if (info && info->specifier && aggregate_type_is_file_visible(info)
-                && !info->is_atomic) {
-                spec = info->specifier;
-            }
-            else {
-                // The legacy aggregate table missed it (e.g. a _generic_struct
-                // typedef). Resolve through the type model instead.
-                spec = symtab_resolve_aggregate(
-                    ncc_xform_get_data(ctx)->symtab, records[i].elem_type);
-            }
-            if (!spec) {
+            if (!info || !info->specifier
+                || !aggregate_type_is_file_visible(info) || info->is_atomic) {
                 continue;
             }
+            spec = info->specifier;
         }
 
         ncc_buffer_t *offs    = ncc_buffer_empty();

--- a/src/xform/xform_generic_struct.c
+++ b/src/xform/xform_generic_struct.c
@@ -16,8 +16,11 @@
 
 #include "lib/alloc.h"
 #include "lib/dict.h"
+#include "lib/string.h"
+#include "parse/symtab.h"
 #include "xform/xform_data.h"
 #include "xform/xform_helpers.h"
+#include "xform/xform_type_layout.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -211,6 +214,29 @@ static ncc_parse_tree_t *xform_generic_struct(ncc_xform_ctx_t *ctx,
         }
 
         ncc_xform_insert_child(container, insert_pos, decl_tree);
+      }
+
+      // Register the freshly-minted concrete tag in the symbol table. This
+      // struct is created mid-xform, so it is absent from the pre-xform symtab
+      // that the shared aggregate resolver (ncc_layout_lookup_aggregate_type ->
+      // ncc_symtab_aggregate_spec) consults. Adding it here keeps the symtab the
+      // single source of truth for aggregate resolution — which is what lets the
+      // eager aggregate-definition collector stay retired: later passes
+      // (gc-globals/auto-roots, gc-stack-maps, array-literal) resolve `struct
+      // <tag>` fields of static aggregates through the symtab rather than a
+      // separate definition walk.
+      ncc_symtab_t *st = ncc_xform_get_data(ctx)->symtab;
+      if (st) {
+        ncc_parse_tree_t *spec = ncc_layout_first_descendant_nt(
+            decl_tree, "struct_or_union_specifier");
+        if (spec && ncc_xform_find_child_nt(spec, "member_declaration_list")) {
+          ncc_sym_entry_t *e = ncc_symtab_add(st, NCC_STRING_STATIC("tag"),
+                                              ncc_string_from_cstr(tag),
+                                              NCC_SYM_TAG, spec);
+          if (e) {
+            e->type_node = spec;
+          }
+        }
       }
     }
   }

--- a/src/xform/xform_helpers.c
+++ b/src/xform/xform_helpers.c
@@ -2,6 +2,8 @@
 
 #include "xform/xform_helpers.h"
 #include "xform/xform_template.h"
+#include "xform/xform_data.h"
+#include "parse/type_infer.h"
 #include "lib/alloc.h"
 #include "lib/buffer.h"
 #include "lib/string.h"
@@ -553,4 +555,49 @@ ncc_string_t ncc_xform_extract_type_string(ncc_xform_ctx_t *ctx,
   ncc_free(cb->data);
   ncc_free(cb);
   return result;
+}
+
+// ============================================================================
+// Typed argument resolution (typehash / typeid / typestr of expressions)
+// ============================================================================
+
+char *
+ncc_xform_expr_arg_type(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *atom,
+                        ncc_parse_tree_t *cont) {
+  if (!ctx || !atom || cont) {
+    return nullptr; // a continuation is a multi-arg generic form, not an expr
+  }
+  ncc_symtab_t *st = ncc_xform_get_data(ctx)->symtab;
+  if (!st) {
+    return nullptr;
+  }
+  ncc_parse_tree_t *tsa =
+      ncc_xform_find_child_nt(atom, "typeof_specifier_argument");
+  if (!tsa) {
+    return nullptr;
+  }
+
+  // A direct expression argument.
+  ncc_parse_tree_t *expr = ncc_xform_find_child_nt(tsa, "expression");
+  if (expr) {
+    return ncc_type_of_expr(st, expr);
+  }
+
+  // A type_name argument that is really a value expression (e.g. `lp[2]`): the
+  // grammar's permissive typedef-name rule let an expression parse as a type.
+  // Re-parse its text as an expression and type that.
+  ncc_parse_tree_t *tn = ncc_xform_find_child_nt(tsa, "type_name");
+  if (tn && ncc_type_name_is_value_expr(st, tn)) {
+    ncc_string_t      text = ncc_xform_node_to_text(tn);
+    ncc_parse_tree_t *re =
+        text.data ? ncc_xform_parse_source(ctx->grammar, "expression",
+                                           text.data, "expr_arg_reinterpret")
+                  : nullptr;
+    char *result = re ? ncc_type_of_expr(st, re) : nullptr;
+    if (text.data) {
+      ncc_free(text.data);
+    }
+    return result;
+  }
+  return nullptr;
 }

--- a/src/xform/xform_helpers.c
+++ b/src/xform/xform_helpers.c
@@ -577,27 +577,15 @@ ncc_xform_expr_arg_type(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *atom,
     return nullptr;
   }
 
-  // A direct expression argument.
+  // A direct expression argument. Since TS-5 (type-aware parse
+  // disambiguation), a value expression that the permissive typedef-name
+  // grammar could have mis-parsed as a `type_name` (e.g. `lp[2]`) is resolved
+  // to its expression reading at forest->tree extraction, so it arrives here as
+  // a genuine `<expression>` — no type_name reinterpretation is needed.
   ncc_parse_tree_t *expr = ncc_xform_find_child_nt(tsa, "expression");
   if (expr) {
     return ncc_type_of_expr(st, expr);
   }
 
-  // A type_name argument that is really a value expression (e.g. `lp[2]`): the
-  // grammar's permissive typedef-name rule let an expression parse as a type.
-  // Re-parse its text as an expression and type that.
-  ncc_parse_tree_t *tn = ncc_xform_find_child_nt(tsa, "type_name");
-  if (tn && ncc_type_name_is_value_expr(st, tn)) {
-    ncc_string_t      text = ncc_xform_node_to_text(tn);
-    ncc_parse_tree_t *re =
-        text.data ? ncc_xform_parse_source(ctx->grammar, "expression",
-                                           text.data, "expr_arg_reinterpret")
-                  : nullptr;
-    char *result = re ? ncc_type_of_expr(st, re) : nullptr;
-    if (text.data) {
-      ncc_free(text.data);
-    }
-    return result;
-  }
   return nullptr;
 }

--- a/src/xform/xform_type_layout.c
+++ b/src/xform/xform_type_layout.c
@@ -5,6 +5,7 @@
 #include "lib/alloc.h"
 #include "lib/buffer.h"
 #include "lib/dict.h"
+#include "parse/type_infer.h"
 #include "xform/xform_data.h"
 #include "xform/xform_helpers.h"
 
@@ -749,6 +750,11 @@ ncc_layout_aggregate_specifier_has_members(ncc_parse_tree_t *su)
         && ncc_xform_find_child_nt(su, "member_declaration_list") != nullptr;
 }
 
+static void
+record_aggregate_type(ncc_xform_ctx_t *ctx, const char *key,
+                      ncc_parse_tree_t *specifier, bool is_atomic,
+                      const char *offset_type);
+
 ncc_layout_aggregate_type_info_t *
 ncc_layout_lookup_aggregate_type(ncc_xform_ctx_t *ctx, const char *key)
 {
@@ -760,7 +766,26 @@ ncc_layout_lookup_aggregate_type(ncc_xform_ctx_t *ctx, const char *key)
     bool found = false;
     ncc_layout_aggregate_type_info_t *info =
         ncc_dict_get(types, (void *)key, &found);
-    return found ? info : nullptr;
+    if (found) {
+        return info;
+    }
+
+    // Fall back to the symbol table — the single source of truth for types.
+    // The eager collector populates `types` from declarations as it sees them,
+    // but misses forms it cannot resolve at collection time (notably
+    // _generic_struct typedefs: the real n00b_variant_t / generic-container
+    // shape). The symbol table resolves those; cache the result so later
+    // lookups hit the dict. The resolver returns a spec only for a genuine
+    // aggregate (it yields null for pointer typedefs), so this never turns a
+    // pointer into a by-value aggregate.
+    ncc_symtab_t *st = ncc_xform_get_data(ctx)->symtab;
+    ncc_parse_tree_t *spec = st ? ncc_symtab_aggregate_spec(st, key) : nullptr;
+    if (spec) {
+        record_aggregate_type(ctx, key, spec, false, key);
+        info = ncc_dict_get(types, (void *)key, &found);
+        return found ? info : nullptr;
+    }
+    return nullptr;
 }
 
 static void

--- a/src/xform/xform_type_layout.c
+++ b/src/xform/xform_type_layout.c
@@ -780,7 +780,16 @@ ncc_layout_lookup_aggregate_type(ncc_xform_ctx_t *ctx, const char *key)
     // pointer into a by-value aggregate.
     ncc_symtab_t *st = ncc_xform_get_data(ctx)->symtab;
     ncc_parse_tree_t *spec = st ? ncc_symtab_aggregate_spec(st, key) : nullptr;
-    if (spec) {
+    // The symbol table records system-header tags too (it has no system gate),
+    // but layout/GC passes must NOT resolve a system aggregate to its definition:
+    // the eager collector deliberately excluded system-header definitions
+    // (!node_starts_in_system_header), so those types were scanned conservatively
+    // rather than descended into. Descending breaks on system shapes the GC walker
+    // can't address — e.g. `struct sigaction`, whose handler pointers live in an
+    // anonymous union reached only through a macro, yielding bogus member paths
+    // (`sa.__sa_handler`). Preserve that policy here so the symtab is the single
+    // source of truth WITHOUT widening which types get descended.
+    if (spec && !ncc_layout_node_starts_in_system_header(spec)) {
         record_aggregate_type(ctx, key, spec, false, key);
         info = ncc_dict_get(types, (void *)key, &found);
         return found ? info : nullptr;
@@ -1218,29 +1227,6 @@ contains_leaf_text(ncc_parse_tree_t *node, const char *text)
 }
 
 static void
-collect_aggregate_definitions(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
-{
-    if (!node || ncc_tree_is_leaf(node)) {
-        return;
-    }
-
-    if (ncc_xform_nt_name_is(node, "struct_or_union_specifier")
-        && ncc_layout_aggregate_specifier_has_members(node)
-        && !ncc_layout_node_starts_in_system_header(node)) {
-        char *key = ncc_layout_aggregate_key_from_specifier(node);
-        if (key) {
-            record_aggregate_type(ctx, key, node, false, key);
-            ncc_free(key);
-        }
-    }
-
-    size_t nc = ncc_tree_num_children(node);
-    for (size_t i = 0; i < nc; i++) {
-        collect_aggregate_definitions(ctx, ncc_tree_child(node, i));
-    }
-}
-
-static void
 collect_typedef_aliases_from_decl(ncc_xform_ctx_t *ctx,
                                   ncc_parse_tree_t *decl)
 {
@@ -1329,6 +1315,15 @@ collect_typedef_aliases(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
 void
 ncc_layout_collect_type_info(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu)
 {
-    collect_aggregate_definitions(ctx, tu);
+    // The eager struct/union *definition* walk is retired: the symbol table is
+    // now the single source of truth for aggregate-tag resolution. Every pass
+    // resolves through ncc_layout_lookup_aggregate_type, which falls back to the
+    // symtab (and caches) when the legacy dict misses, so a standalone
+    // `struct X { ... }` tag no longer needs to be pre-recorded here.
+    //
+    // The typedef-alias walk stays: it performs the load-bearing pointer- and
+    // function-pointer-typedef classification (and records aggregate *aliases*
+    // with their precise offset_type/is_atomic info) that the symtab fallback
+    // does not reproduce.
     collect_typedef_aliases(ctx, tu);
 }

--- a/src/xform/xform_typehash.c
+++ b/src/xform/xform_typehash.c
@@ -5,8 +5,6 @@
 
 #include "xform/xform_helpers.h"
 #include "xform/xform_gc_typemap.h"
-#include "xform/xform_data.h"
-#include "parse/type_infer.h"
 #include "util/type_normalize.h"
 
 #include <inttypes.h>
@@ -43,31 +41,24 @@ xform_typehash(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
         return nullptr;
     }
 
-    // typehash(<expression>): when the single argument is an expression (not a
-    // written type, string literal, or generic continuation), hash the
-    // expression's inferred type. This is typehash(typeof(expr)) without the
-    // user spelling out typeof. The type model recomputes the canonical type
-    // spelling identically to a written type, so the hash matches.
-    ncc_parse_tree_t *tsa = ncc_xform_find_child_nt(
-        atom, "typeof_specifier_argument");
-    if (!cont && tsa && !ncc_xform_find_child_nt(tsa, "type_name")) {
-        ncc_parse_tree_t *expr = ncc_xform_find_child_nt(tsa, "expression");
-        ncc_symtab_t     *st   = ncc_xform_get_data(ctx)->symtab;
-        char             *inferred = (expr && st) ? ncc_type_of_expr(st, expr)
-                                                  : nullptr;
-        if (inferred) {
-            uint64_t hash = ncc_type_hash_u64(inferred);
-            ncc_gc_typemap_note(ctx, inferred, hash);
+    // typehash(<expression>): hash the expression's inferred type (this is
+    // typehash(typeof(expr)) without spelling out typeof). The type model
+    // recomputes the canonical type spelling identically to a written type, so
+    // the hash matches. Also catches expressions the grammar mis-parsed as
+    // type_names (e.g. `lp[2]`).
+    char *inferred = ncc_xform_expr_arg_type(ctx, atom, cont);
+    if (inferred) {
+        uint64_t hash = ncc_type_hash_u64(inferred);
+        ncc_gc_typemap_note(ctx, inferred, hash);
 
-            char buf[32];
-            snprintf(buf, sizeof(buf), "%" PRIu64 "ULL", hash);
-            uint32_t line, col;
-            ncc_xform_first_leaf_pos(node, &line, &col);
-            ncc_parse_tree_t *replacement = ncc_xform_make_token_node(
-                NCC_TOK_INTEGER, buf, line, col);
-            ncc_free(inferred);
-            return replacement;
-        }
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%" PRIu64 "ULL", hash);
+        uint32_t line, col;
+        ncc_xform_first_leaf_pos(node, &line, &col);
+        ncc_parse_tree_t *replacement = ncc_xform_make_token_node(
+            NCC_TOK_INTEGER, buf, line, col);
+        ncc_free(inferred);
+        return replacement;
     }
 
     ncc_string_t type_str = ncc_xform_extract_type_string(ctx, atom, cont);

--- a/src/xform/xform_typeid.c
+++ b/src/xform/xform_typeid.c
@@ -4,8 +4,6 @@
 // typeid(int *) becomes __aB3cD5eF... (SHA256-based identifier).
 
 #include "xform/xform_helpers.h"
-#include "xform/xform_data.h"
-#include "parse/type_infer.h"
 #include "util/type_normalize.h"
 
 #include <stdlib.h>
@@ -61,23 +59,16 @@ xform_typeid(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
     // typeid(<expression>): mangle the expression's inferred type, matching the
     // mangle of the same type written explicitly. (See xform_typehash for the
     // companion typehash(<expression>) path.)
-    ncc_parse_tree_t *tsa = ncc_xform_find_child_nt(
-        atom, "typeof_specifier_argument");
-    if (!cont && tsa && !ncc_xform_find_child_nt(tsa, "type_name")) {
-        ncc_parse_tree_t *expr = ncc_xform_find_child_nt(tsa, "expression");
-        ncc_symtab_t     *st   = ncc_xform_get_data(ctx)->symtab;
-        char             *inferred = (expr && st) ? ncc_type_of_expr(st, expr)
-                                                  : nullptr;
-        if (inferred) {
-            ncc_string_t mangled = ncc_type_mangle(inferred);
-            uint32_t     line, col;
-            ncc_xform_first_leaf_pos(node, &line, &col);
-            ncc_parse_tree_t *replacement = ncc_xform_make_token_node(
-                NCC_TOK_IDENTIFIER, mangled.data, line, col);
-            ncc_free(inferred);
-            ncc_free(mangled.data);
-            return replacement;
-        }
+    char *inferred = ncc_xform_expr_arg_type(ctx, atom, cont);
+    if (inferred) {
+        ncc_string_t mangled = ncc_type_mangle(inferred);
+        uint32_t     line, col;
+        ncc_xform_first_leaf_pos(node, &line, &col);
+        ncc_parse_tree_t *replacement = ncc_xform_make_token_node(
+            NCC_TOK_IDENTIFIER, mangled.data, line, col);
+        ncc_free(inferred);
+        ncc_free(mangled.data);
+        return replacement;
     }
 
     ncc_string_t type_str = ncc_xform_extract_type_string(ctx, atom, cont);

--- a/src/xform/xform_typeid.c
+++ b/src/xform/xform_typeid.c
@@ -4,6 +4,9 @@
 // typeid(int *) becomes __aB3cD5eF... (SHA256-based identifier).
 
 #include "xform/xform_helpers.h"
+#include "xform/xform_data.h"
+#include "parse/type_infer.h"
+#include "util/type_normalize.h"
 
 #include <stdlib.h>
 
@@ -53,6 +56,28 @@ xform_typeid(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
 
     if (!atom) {
         return nullptr;
+    }
+
+    // typeid(<expression>): mangle the expression's inferred type, matching the
+    // mangle of the same type written explicitly. (See xform_typehash for the
+    // companion typehash(<expression>) path.)
+    ncc_parse_tree_t *tsa = ncc_xform_find_child_nt(
+        atom, "typeof_specifier_argument");
+    if (!cont && tsa && !ncc_xform_find_child_nt(tsa, "type_name")) {
+        ncc_parse_tree_t *expr = ncc_xform_find_child_nt(tsa, "expression");
+        ncc_symtab_t     *st   = ncc_xform_get_data(ctx)->symtab;
+        char             *inferred = (expr && st) ? ncc_type_of_expr(st, expr)
+                                                  : nullptr;
+        if (inferred) {
+            ncc_string_t mangled = ncc_type_mangle(inferred);
+            uint32_t     line, col;
+            ncc_xform_first_leaf_pos(node, &line, &col);
+            ncc_parse_tree_t *replacement = ncc_xform_make_token_node(
+                NCC_TOK_IDENTIFIER, mangled.data, line, col);
+            ncc_free(inferred);
+            ncc_free(mangled.data);
+            return replacement;
+        }
     }
 
     ncc_string_t type_str = ncc_xform_extract_type_string(ctx, atom, cont);

--- a/src/xform/xform_typestr.c
+++ b/src/xform/xform_typestr.c
@@ -5,8 +5,6 @@
 
 #include "lib/alloc.h"
 #include "xform/xform_helpers.h"
-#include "xform/xform_data.h"
-#include "parse/type_infer.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -54,16 +52,7 @@ static ncc_parse_tree_t *xform_typestr(ncc_xform_ctx_t *ctx,
 
   // typestr(<expression>): spell the expression's inferred type. Falls back to
   // the written-type path when the expression is not yet typeable.
-  ncc_parse_tree_t *tsa = ncc_xform_find_child_nt(atom,
-                                                  "typeof_specifier_argument");
-  char *inferred = nullptr;
-  if (!cont && tsa && !ncc_xform_find_child_nt(tsa, "type_name")) {
-    ncc_parse_tree_t *expr = ncc_xform_find_child_nt(tsa, "expression");
-    ncc_symtab_t     *st   = ncc_xform_get_data(ctx)->symtab;
-    if (expr && st) {
-      inferred = ncc_type_of_expr(st, expr);
-    }
-  }
+  char *inferred = ncc_xform_expr_arg_type(ctx, atom, cont);
 
   ncc_string_t type_str = {0};
   if (inferred) {

--- a/src/xform/xform_typestr.c
+++ b/src/xform/xform_typestr.c
@@ -5,6 +5,8 @@
 
 #include "lib/alloc.h"
 #include "xform/xform_helpers.h"
+#include "xform/xform_data.h"
+#include "parse/type_infer.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -50,7 +52,27 @@ static ncc_parse_tree_t *xform_typestr(ncc_xform_ctx_t *ctx,
     return nullptr;
   }
 
-  ncc_string_t type_str = ncc_xform_extract_type_string(ctx, atom, cont);
+  // typestr(<expression>): spell the expression's inferred type. Falls back to
+  // the written-type path when the expression is not yet typeable.
+  ncc_parse_tree_t *tsa = ncc_xform_find_child_nt(atom,
+                                                  "typeof_specifier_argument");
+  char *inferred = nullptr;
+  if (!cont && tsa && !ncc_xform_find_child_nt(tsa, "type_name")) {
+    ncc_parse_tree_t *expr = ncc_xform_find_child_nt(tsa, "expression");
+    ncc_symtab_t     *st   = ncc_xform_get_data(ctx)->symtab;
+    if (expr && st) {
+      inferred = ncc_type_of_expr(st, expr);
+    }
+  }
+
+  ncc_string_t type_str = {0};
+  if (inferred) {
+    type_str.data     = inferred;
+    type_str.u8_bytes = strlen(inferred);
+  }
+  else {
+    type_str = ncc_xform_extract_type_string(ctx, atom, cont);
+  }
 
   // Build quoted string: "\"type_str\""
   size_t len = type_str.u8_bytes;

--- a/test/test_gc_typemap_variant.c
+++ b/test/test_gc_typemap_variant.c
@@ -51,12 +51,25 @@ typedef struct vmap_scalar_variant_t {
     } value;
 } vmap_scalar_variant_t;
 
+// The real n00b_variant_t shape: a _generic_struct typedef. The legacy
+// aggregate table cannot resolve this (its alias is recorded before
+// generic-struct lowering), so it used to be skipped silently. The type model
+// resolves it, so it now gets a precise variant descriptor too.
+typedef _generic_struct typeid("n00b_variant", n00b_string_t *, uint64_t) {
+    uint64_t selector;
+    union {
+        n00b_string_t *field_0;
+        uint64_t       field_1;
+    } value;
+} vmap_generic_variant_t;
+
 static uint64_t h_variant = typehash(vmap_variant_t *);
 static uint64_t h_holder  = typehash(vmap_holder_t *);
 static uint64_t h_scalar  = typehash(vmap_scalar_variant_t *);
+static uint64_t h_generic = typehash(vmap_generic_variant_t *);
 
 int
 main(void)
 {
-    return (int)((h_variant ^ h_holder ^ h_scalar) == 0);
+    return (int)((h_variant ^ h_holder ^ h_scalar ^ h_generic) == 0);
 }

--- a/test/test_typehash_expr.c
+++ b/test/test_typehash_expr.c
@@ -20,6 +20,11 @@ static int         *gp;
 static tpe_point_t  gs;
 static tpe_point_t *gpp;
 
+// Prototypes for call typing (never actually called — typehash is a
+// compile-time type query — so no definition is needed).
+int         tpe_id_fn(int);
+tpe_point_t tpe_mk_fn(void);
+
 int
 main(void)
 {
@@ -46,6 +51,12 @@ main(void)
     ok &= (typehash(gs.y) == typehash(long));
     ok &= (typehash(gpp->x) == typehash(int));
     ok &= (typehash(gpp->y) == typehash(long));
+
+    // Function call: type of `f(args)` is f's return type.
+    ok &= (typehash(tpe_id_fn(0)) == typehash(int));
+
+    // Member access on a call result: type of `mk().y` is the field type.
+    ok &= (typehash(tpe_mk_fn().y) == typehash(long));
 
     return ok ? 0 : 1;
 }

--- a/test/test_typehash_expr.c
+++ b/test/test_typehash_expr.c
@@ -10,8 +10,15 @@
 
 #include <stdint.h>
 
-static int  gi;
-static int *gp;
+typedef struct tpe_point {
+    int  x;
+    long y;
+} tpe_point_t;
+
+static int          gi;
+static int         *gp;
+static tpe_point_t  gs;
+static tpe_point_t *gpp;
 
 int
 main(void)
@@ -33,6 +40,12 @@ main(void)
     // typestr(expr) spells the inferred type, matching typestr(<that type>).
     ok &= (__builtin_strcmp(typestr(gi), typestr(int)) == 0);
     ok &= (__builtin_strcmp(typestr(*gp), typestr(int)) == 0);
+
+    // Member access: `s.field` (first and later members) and `p->field`.
+    ok &= (typehash(gs.x) == typehash(int));
+    ok &= (typehash(gs.y) == typehash(long));
+    ok &= (typehash(gpp->x) == typehash(int));
+    ok &= (typehash(gpp->y) == typehash(long));
 
     return ok ? 0 : 1;
 }

--- a/test/test_typehash_expr.c
+++ b/test/test_typehash_expr.c
@@ -30,5 +30,9 @@ main(void)
     // Cast: type of `(char)gi` is `char`.
     ok &= (typehash((char)gi) == typehash(char));
 
+    // typestr(expr) spells the inferred type, matching typestr(<that type>).
+    ok &= (__builtin_strcmp(typestr(gi), typestr(int)) == 0);
+    ok &= (__builtin_strcmp(typestr(*gp), typestr(int)) == 0);
+
     return ok ? 0 : 1;
 }

--- a/test/test_typehash_expr.c
+++ b/test/test_typehash_expr.c
@@ -58,5 +58,9 @@ main(void)
     // Member access on a call result: type of `mk().y` is the field type.
     ok &= (typehash(tpe_mk_fn().y) == typehash(long));
 
+    // Subscript `gp[1]` is `int`. The grammar mis-parses this as a type_name;
+    // the symbol table reinterprets it as an expression.
+    ok &= (typehash(gp[1]) == typehash(int));
+
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
## ncc type system: expression typing → model-driven xforms → type-aware parse disambiguation

Builds a real type model in ncc (the latent scoped `ncc_symtab`) and routes the
shape-matching passes through it, instead of pattern-matching parse-tree shapes.
This removes the root cause of fragile `_generic_struct` handling, ambiguous
parses folding field names into types, and gc-typemap brittleness.

### What's here (TS-1 … TS-5)

- **TS-1 — symbol population.** Populate the previously-dead `ncc_symtab`
  (typedefs, vars, funcs, params, struct/union/enum tags, enum constants) with
  type subtrees; built post-`typedef_walk`.
- **TS-2 — expression typing.** `ncc_type_of_expr(symtab, expr)` returns a
  canonical type spelling for identifiers, casts, `&`/`*`, member access
  (`.`/`->`), calls (return type), and subscripts. Functions are classified
  correctly (in-order leaf scan).
- **TS-3 — type queries of expressions.** `typeof` / `typehash` / `typeid` /
  `typestr` of an *expression* argument resolve via the typer, byte-identical to
  the same type written explicitly.
- **TS-4 — migrate shape-matching xforms onto the model.** gc-typemap variant
  detection, gc-stack-maps, array-literal, and auto-gc-roots all resolve
  aggregate types through a single symtab-backed resolver
  (`ncc_layout_lookup_aggregate_type`). The eager aggregate-definition collector
  is retired; `_generic_struct` lowering registers its mid-xform-minted concrete
  tag into the symtab; the resolver keeps the system-header policy so system
  aggregates (e.g. `struct sigaction`) are never wrongly descended.
- **TS-5 — type-aware parse disambiguation.** The grammar lets any identifier
  stand in as a typedef-name, so a value expression like `lp[2]` parses both as
  a subscript and as an array-of-`lp` type. A new declarative grammar annotation
  `@disambig(<predicate>)` attaches a symtab-conditional scoring penalty to a
  rule; the forest→tree extractor scores ambiguous alternatives and picks the
  most type-consistent parse. This resolves the ambiguity at the parse layer and
  lets the downstream type-query reinterpretation workaround be removed.

### Design notes

- The disambiguation penalty is **one-directional** (`id_is_value` on
  `typedef_name`): it penalizes reading a *value* as a *type*, and never fires on
  a typedef name being *declared* (a binding occurrence routes through the
  declarator), so typedef declarations are undisturbed.
- The pwz parser stays independent of the symbol table — the oracle is a
  registered callback; the symtab lives behind it.

### Validation

- **245/245** ncc tests.
- **Full clean libn00b build: 2033/2033 targets**, repeated at the TS-4 and TS-5
  tips. (The full libn00b build is the essential guard: it catches GC-corruption
  bugs the ncc suite cannot — two such latent bugs were found and fixed this way.)
- TS-5's parse-layer fix is *proven* by deleting the reinterpreter workaround and
  still passing the suite.

> Note: the base of this stack is the parallel `codex/gc-typemap-variants` work
> (concrete `n00b_variant_t` GC support); this PR carries the full type-system
> stack on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
