### PR TITLE
contracts: old() — refer to entry-state values in ensures

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1925,6 +1925,10 @@ ncc_error_contains_tests = {
     test_dir / 'err_function_contract_call.c',
     'function calls are not allowed in function contracts',
   ],
+  'err_function_contract_old_requires': [
+    test_dir / 'err_function_contract_old_requires.c',
+    'old(...) is not allowed in a \'requires\' clause',
+  ],
   'err_function_contract_return': [
     test_dir / 'err_function_contract_return.c',
     'return is not allowed in function contracts',

--- a/src/xform/xform_contracts.c
+++ b/src/xform/xform_contracts.c
@@ -795,6 +795,37 @@ static bool postfix_expression_is_call(ncc_parse_tree_t *node) {
   return false;
 }
 
+// True if a call node's callee is exactly the identifier `old`, i.e. this is an
+// `old(E)` entry-value reference rather than an ordinary (forbidden) call.
+static bool postfix_call_callee_is_old(ncc_parse_tree_t *node) {
+  size_t nc = ncc_tree_num_children(node);
+  for (size_t i = 0; i < nc; i++) {
+    ncc_parse_tree_t *child = ncc_tree_child(node, i);
+    if (!child || ncc_tree_is_leaf(child)) {
+      continue;
+    }
+    if (!ncc_xform_nt_name_is(child, "postfix_expression")) {
+      continue;
+    }
+    ncc_string_t t       = ncc_xform_node_to_text(child);
+    bool         is_old  = false;
+    if (t.data) {
+      const char *s = t.data;
+      while (*s && isspace((unsigned char)*s)) {
+        s++;
+      }
+      size_t len = strlen(s);
+      while (len > 0 && isspace((unsigned char)s[len - 1])) {
+        len--;
+      }
+      is_old = (len == 3 && memcmp(s, "old", 3) == 0);
+      ncc_free(t.data);
+    }
+    return is_old;
+  }
+  return false;
+}
+
 static bool postfix_expression_is_inc_dec(ncc_parse_tree_t *node) {
   return ncc_xform_nt_name_is(node, "postfix_expression") &&
          (node_has_direct_leaf(node, "++") ||
@@ -1079,11 +1110,13 @@ static void analyze_contract_semantics_node(contract_semantic_ctx_t *cctx,
     }
   }
 
-  if (postfix_expression_is_call(node)) {
+  if (postfix_expression_is_call(node) && !postfix_call_callee_is_old(node)) {
     contract_semantic_error(node,
                             "function calls are not allowed in function "
                             "contracts");
   }
+  // An `old(E)` reference is permitted (it is not a real call); fall through so
+  // its argument E is still validated — no calls or mutations inside old().
 
   ncc_parse_tree_t *lhs = assignment_lhs(node);
   if (lhs) {
@@ -1295,6 +1328,130 @@ static void build_helper_signature_parts(const char *params,
   *out_names = ncc_buffer_take(name_buf);
 }
 
+// --- old(<expr>) capture: entry-state values for `ensures` ------------------
+//
+// `ensures` runs in the wrapper AFTER the body helper returns, so a bare
+// expression there observes post-call state. `old(E)` lets a clause refer to
+// E's value at function ENTRY: each distinct E is captured into a temp at the
+// top of the wrapper and the reference is rewritten to that temp. The temp is
+// declared `typeof(E)`, so it works for any expression type (scalars, pointers,
+// aggregates), and E is evaluated exactly once at entry.
+
+// True if `old` appears as a call (an `old` identifier followed by `(`) in any
+// item — used to reject `old()` in a `requires` clause, where entry state is
+// just the current state.
+static bool contract_items_use_old(strvec_t *items) {
+  for (size_t i = 0; i < items->len; i++) {
+    const char *p = items->items[i];
+    while (*p) {
+      if (*p == '"' || *p == '\'') {
+        p = skip_quoted(p);
+        continue;
+      }
+      if (is_ident_start_char(*p)) {
+        const char *ids = p;
+        while (*p && is_ident_char(*p)) {
+          p++;
+        }
+        if ((size_t)(p - ids) == 3 && memcmp(ids, "old", 3) == 0
+            && *skip_spaces(p) == '(') {
+          return true;
+        }
+        continue;
+      }
+      p++;
+    }
+  }
+  return false;
+}
+
+// Rewrite one ensures item, replacing each `old(E)` with its capture temp.
+// New captures are appended to `decls` as `typeof(E) __ncc_old_N = (E);`;
+// `exprs` holds the captured E texts for dedup (index N == position in both).
+static char *rewrite_old_in_item(const char *item, strvec_t *exprs,
+                                 strvec_t *decls) {
+  ncc_buffer_t *out = ncc_buffer_empty();
+  const char   *p   = item;
+
+  while (*p) {
+    if (*p == '"' || *p == '\'') {
+      const char *q = skip_quoted(p);
+      ncc_buffer_append(out, p, (size_t)(q - p));
+      p = q;
+      continue;
+    }
+    if (is_ident_start_char(*p)) {
+      const char *ids = p;
+      while (*p && is_ident_char(*p)) {
+        p++;
+      }
+      size_t      idlen   = (size_t)(p - ids);
+      const char *aftersp = skip_spaces(p);
+
+      if (idlen == 3 && memcmp(ids, "old", 3) == 0 && *aftersp == '(') {
+        const char *close = skip_balanced_text(aftersp);  // just past ')'
+        const char *es    = aftersp + 1;                  // start of E
+        const char *ee    = close - 1;                    // the ')'
+        while (es < ee && isspace((unsigned char)*es)) {
+          es++;
+        }
+        while (ee > es && isspace((unsigned char)ee[-1])) {
+          ee--;
+        }
+        size_t elen  = (size_t)(ee - es);
+        char  *etext = ncc_alloc_size(1, elen + 1);
+        memcpy(etext, es, elen);
+        etext[elen] = '\0';
+
+        int idx = -1;
+        for (size_t i = 0; i < exprs->len; i++) {
+          if (strcmp(exprs->items[i], etext) == 0) {
+            idx = (int)i;
+            break;
+          }
+        }
+        char tmpname[32];
+        if (idx < 0) {
+          idx = (int)exprs->len;
+          snprintf(tmpname, sizeof(tmpname), "__ncc_old_%d", idx);
+          strvec_push(exprs, etext);  // takes ownership
+          ncc_buffer_t *d = ncc_buffer_empty();
+          ncc_buffer_printf(d, "typeof(%s) %s = (%s);", etext, tmpname, etext);
+          strvec_push(decls, ncc_buffer_take(d));
+        } else {
+          snprintf(tmpname, sizeof(tmpname), "__ncc_old_%d", idx);
+          ncc_free(etext);
+        }
+        ncc_buffer_puts(out, tmpname);
+        p = close;
+        continue;
+      }
+
+      ncc_buffer_append(out, ids, idlen);
+      continue;
+    }
+    ncc_buffer_putc(out, *p);
+    p++;
+  }
+
+  return ncc_buffer_take(out);
+}
+
+// Rewrite all ensures items in place, collecting entry-value capture decls.
+static void collect_old_captures(strvec_t *ensures_items, strvec_t *decls) {
+  strvec_t exprs;
+  strvec_init(&exprs);
+
+  for (size_t i = 0; i < ensures_items->len; i++) {
+    char *rewritten = rewrite_old_in_item(ensures_items->items[i], &exprs,
+                                           decls);
+    ncc_free(ensures_items->items[i]);
+    ensures_items->items[i] = rewritten;
+  }
+
+  strvec_free(&exprs);
+}
+
 static void emit_contract_block(ncc_buffer_t *src, strvec_t *items) {
   ncc_buffer_puts(src, "{\n");
   for (size_t i = 0; i < items->len; i++) {
@@ -1327,6 +1484,28 @@ static void emit_contract_wrapper(ncc_buffer_t *src, bool void_ret,
     ncc_buffer_putc(src, '\n');
   }
 
+  // `old(E)` is an entry-state value, only meaningful in `ensures` (in
+  // `requires`, entry state IS the current state).
+  if (has_requires && contract_items_use_old(requires_items)) {
+    fprintf(stderr,
+            "ncc: error: old(...) is not allowed in a 'requires' clause "
+            "(entry state equals the current state there)\n");
+    exit(1);
+  }
+
+  // Capture old(E) entry values before any user code runs, and rewrite the
+  // ensures references to the captured temps. Placed after kargs extraction so
+  // old() may also refer to unpacked keyword arguments.
+  strvec_t old_decls;
+  strvec_init(&old_decls);
+  if (has_ensures) {
+    collect_old_captures(ensures_items, &old_decls);
+    for (size_t i = 0; i < old_decls.len; i++) {
+      ncc_buffer_puts(src, old_decls.items[i]);
+      ncc_buffer_putc(src, '\n');
+    }
+  }
+
   if (has_requires) {
     emit_contract_block(src, requires_items);
   }
@@ -1347,6 +1526,8 @@ static void emit_contract_wrapper(ncc_buffer_t *src, bool void_ret,
   } else {
     ncc_buffer_puts(src, "return result;\n}\n");
   }
+
+  strvec_free(&old_decls);
 }
 
 static ncc_parse_tree_t *raw_token(const char *text) {

--- a/test/err_function_contract_old_requires.c
+++ b/test/err_function_contract_old_requires.c
@@ -1,0 +1,15 @@
+// err_function_contract_old_requires - old(...) is meaningless in a
+// precondition: at entry, the entry state IS the current state.
+
+int
+old_in_requires(int x)
+    requires { old(x) == x; }
+{
+    return x;
+}
+
+int
+main(void)
+{
+    return old_in_requires(1);
+}

--- a/test/test_function_contracts.c
+++ b/test/test_function_contracts.c
@@ -28,6 +28,28 @@ record_value(int *out, int value)
     *out = value;
 }
 
+// old(E) captures the entry value of E. `*out` here appears twice, exercising
+// capture dedup (a single entry temp).
+static void
+increment_pointee(int *out)
+    requires { out != nullptr; }
+    ensures { *out == old(*out) + 1; *out > old(*out); }
+{
+    *out = *out + 1;
+}
+
+// The canonical old() case: each result is stated in terms of the OTHER's
+// entry value, which is unstateable without capturing pre-state.
+static void
+swap_ints(int *a, int *b)
+    requires { a != nullptr; b != nullptr; }
+    ensures { *a == old(*b); *b == old(*a); }
+{
+    int t = *a;
+    *a    = *b;
+    *b    = t;
+}
+
 static int
 with_keyword_bias(int x)
     _kargs { int bias = 2; }
@@ -265,6 +287,19 @@ main(void)
     }
     if (statement_keyword_default_counter != 0) {
         return 22;
+    }
+
+    int pointee = 10;
+    increment_pointee(&pointee);
+    if (pointee != 11) {
+        return 23;
+    }
+
+    int lhs = 3;
+    int rhs = 7;
+    swap_ints(&lhs, &rhs);
+    if (lhs != 7 || rhs != 3) {
+        return 24;
     }
 
     return 0;


### PR DESCRIPTION
## contracts: `old()` — entry-state values in `ensures`

A function contract's `ensures` clause runs in the generated wrapper **after** the
body returns, so a bare expression there observes post-call state. `old(E)` lets a
clause refer to `E`'s value at function **entry** — which is what makes "did this
function change X?" assertions expressible at all:

```c
void bump(int *p)        ensures { *p == old(*p) + 1; }              { *p += 1; }
void swap(int *a,int *b) ensures { *a == old(*b); *b == old(*a); }   { int t=*a; *a=*b; *b=t; }
```

### Lowering
Each distinct `old(E)` is captured at the top of the wrapper into
`typeof(E) __ncc_old_N = (E);` (after kargs extraction, before `requires`), and the
`ensures` references are rewritten to the temp. `typeof(E)` handles any type and
flows to clang; `E` is evaluated exactly once at entry (captures are deduped by
expression text). This rides directly on the type model — `typeof` of an arbitrary
expression is exactly what TS-1…TS-5 made reliable.

### Rules
- `old(...)` in a `requires` clause is rejected (at entry, entry state *is* the
  current state).
- The contracts "no function calls" validator is exempted for the `old` callee,
  while still validating `old`'s argument, so calls/mutations inside `old()` stay
  rejected.

### Tests
- `test_function_contracts.c` gains a pointee-increment (exercises `old` capture
  dedup) and the canonical `swap`.
- `err_function_contract_old_requires.c` covers the `requires` rejection.
- **246/246** ncc tests; **full clean libn00b build (2033/2033)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
