### PR TITLE
_defer: scope-exit defer statement (N3199 semantics)

### DIFF
--- a/c_ncc.bnf
+++ b/c_ncc.bnf
@@ -831,3 +831,9 @@
     | <attribute_specifier_sequence>? <primary_block>
     | <attribute_specifier_sequence>? <jump_statement>
     | <gcc_asm_statement>
+    | <defer_statement>
+
+# ncc `_defer <secondary-block>` (N3199-semantics defer, spelled `_defer` to
+# avoid colliding with libn00b's existing `defer` macro). The block runs at exit
+# of the enclosing scope, LIFO, on all exit paths; lowered by xform_defer.
+<defer_statement> ::= %"_defer" <secondary_block>

--- a/meson.build
+++ b/meson.build
@@ -191,6 +191,7 @@ src_xform = files(
   'src/xform/xform_constexpr.c',
   'src/xform/xform_constexpr_paste.c',
   'src/xform/xform_contracts.c',
+  'src/xform/xform_defer.c',
   'src/xform/xform_generic_struct.c',
   'src/xform/xform_gc_globals.c',
   'src/xform/xform_gc_stack_maps.c',
@@ -409,6 +410,7 @@ ncc_compile_tests = {
                         test_dir / 'test_kargs_void_params.c'],
   'kargs_many_metadata': ['compile_run',
                           test_dir / 'test_kargs_many_metadata.c'],
+  'defer': ['compile_run', test_dir / 'test_defer.c'],
   'function_contracts': ['compile_run',
                          test_dir / 'test_function_contracts.c'],
   'function_contracts_parse': ['preprocess',
@@ -1928,6 +1930,14 @@ ncc_error_contains_tests = {
   'err_function_contract_old_requires': [
     test_dir / 'err_function_contract_old_requires.c',
     'old(...) is not allowed in a \'requires\' clause',
+  ],
+  'err_defer_goto': [
+    test_dir / 'err_defer_goto.c',
+    'may not (yet) also use goto',
+  ],
+  'err_defer_escape': [
+    test_dir / 'err_defer_escape.c',
+    'control transfer (return/break/continue/goto) inside a _defer body',
   ],
   'err_function_contract_return': [
     test_dir / 'err_function_contract_return.c',

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -72,6 +72,7 @@ extern void ncc_register_constexpr_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_constexpr_paste_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_kargs_vargs_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_contracts_xform(ncc_xform_registry_t *reg);
+extern void ncc_register_defer_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_option_xform(ncc_xform_registry_t *reg);
 extern void ncc_register_array_literal_xform(ncc_xform_registry_t *reg);
 #include "scanner/scan_builtins.h"
@@ -2013,6 +2014,10 @@ compile_file(ncc_opts_t *opts)
     // already-mangled signatures.
     ncc_register_rpc_xform(&xreg);
     ncc_register_generic_struct_xform(&xreg);
+    // _defer lowers a function body's defers into source at each scope exit.
+    // Runs early so the relocated bodies still flow through the type-query,
+    // option, kargs, and contracts passes below.
+    ncc_register_defer_xform(&xreg);
     ncc_register_typeid_xform(&xreg);
     ncc_register_option_xform(&xreg);
     ncc_register_typestr_xform(&xreg);

--- a/src/xform/xform_defer.c
+++ b/src/xform/xform_defer.c
@@ -1,0 +1,474 @@
+// xform_defer.c — `_defer <secondary-block>` lowering (N3199 semantics).
+//
+// `_defer S` registers S when control reaches it and runs S at exit of the
+// enclosing block, in LIFO order, on every exit path. The block runs with
+// current variable values (no capture). `_defer` is spelled with a leading
+// underscore to avoid colliding with libn00b's `defer` macro.
+//
+// Lowering (clang has no nested functions, so __attribute__((cleanup)) cannot
+// host an inline body that references locals): the deferred bodies are injected
+// as source at each scope exit. In structured code the set of *registered*
+// defers at any exit is statically the textually-preceding defers of the
+// enclosing scopes, so no runtime flags are needed — this pass walks the body
+// once, tracking a scope stack of active defer bodies, and emits them reversed:
+//   - return E;   ->  { typeof(E) __ncc_defer_ret = (E); <all scopes>; return __ncc_defer_ret; }
+//   - break;      ->  { <scopes up to & incl. nearest loop/switch>; break; }
+//   - continue;   ->  { <scopes up to & incl. nearest loop>; continue; }
+//   - fall-through->  the enclosing block's defers, reversed, before its `}`.
+//
+// v1 scope (see commit message): return / break / continue / fall-through and
+// nested blocks are fully handled. `goto` (and labeled break/continue, computed
+// goto) in a region with active defers, and control transfer OUT of a defer
+// body, are rejected with a diagnostic rather than mis-compiled.
+
+#include "lib/alloc.h"
+#include "lib/buffer.h"
+#include "parse/parse_tree.h"
+#include "xform/xform_data.h"
+#include "xform/xform_helpers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// ----------------------------------------------------------------------------
+// Scope stack
+// ----------------------------------------------------------------------------
+
+typedef enum {
+    DS_FUNC,    // the function body
+    DS_BLOCK,   // an ordinary compound statement (incl. if/else bodies)
+    DS_LOOP,    // for / while / do body
+    DS_SWITCH,  // switch body
+} dscope_kind_t;
+
+typedef struct dscope {
+    dscope_kind_t   kind;
+    char          **defers;  // active defer body texts, registration order
+    size_t          len;
+    size_t          cap;
+    struct dscope  *parent;
+} dscope_t;
+
+static void
+dscope_register(dscope_t *s, char *body_text)
+{
+    if (s->len >= s->cap) {
+        s->cap    = s->cap ? s->cap * 2 : 4;
+        s->defers = ncc_realloc(s->defers, s->cap * sizeof(char *));
+    }
+    s->defers[s->len++] = body_text;
+}
+
+static void
+dscope_free(dscope_t *s)
+{
+    for (size_t i = 0; i < s->len; i++) {
+        ncc_free(s->defers[i]);
+    }
+    ncc_free(s->defers);
+}
+
+// Emit one scope's active defers, LIFO (reverse registration order). Each body
+// is wrapped in its own braces so a single-statement defer and a compound defer
+// lower identically and the body cannot leak declarations into the exit site.
+static void
+emit_scope_defers(ncc_buffer_t *buf, dscope_t *s)
+{
+    for (size_t i = s->len; i-- > 0;) {
+        ncc_buffer_puts(buf, "{ ");
+        ncc_buffer_puts(buf, s->defers[i]);
+        ncc_buffer_puts(buf, " } ");
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Subtree predicates
+// ----------------------------------------------------------------------------
+
+static bool
+subtree_has_nt(ncc_parse_tree_t *node, const char *nt)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+    if (ncc_xform_nt_name_is(node, nt)) {
+        return true;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (subtree_has_nt(ncc_tree_child(node, i), nt)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// A jump this pass cannot yet combine with _defer: `goto` (plain or computed),
+// or a labeled `break`/`continue`. Correctly running the right defers across
+// such a jump needs label-scope analysis (a planned follow-up), so a function
+// mixing these with _defer is rejected rather than mis-lowered.
+static bool
+is_unsupported_jump(ncc_parse_tree_t *node)
+{
+    if (!ncc_xform_nt_name_is(node, "jump_statement")) {
+        return false;
+    }
+    const char *kw = ncc_xform_get_first_leaf_text(node);
+    if (kw && strcmp(kw, "goto") == 0) {
+        return true;
+    }
+    // Labeled break/continue carry an identifier operand.
+    if (kw && (strcmp(kw, "break") == 0 || strcmp(kw, "continue") == 0)) {
+        return ncc_xform_find_child_nt(node, "identifier") != nullptr;
+    }
+    return false;
+}
+
+static bool
+subtree_has_unsupported_jump(ncc_parse_tree_t *node)
+{
+    if (!node || ncc_tree_is_leaf(node)) {
+        return false;
+    }
+    if (is_unsupported_jump(node)) {
+        return true;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (subtree_has_unsupported_jump(ncc_tree_child(node, i))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static void
+defer_error(ncc_parse_tree_t *at, const char *msg)
+{
+    uint32_t line = 0;
+    uint32_t col  = 0;
+    ncc_xform_first_leaf_pos(at, &line, &col);
+    fprintf(stderr, "ncc: error: %s (line %u, col %u)\n", msg, line, col);
+    exit(1);
+}
+
+// ----------------------------------------------------------------------------
+// Emitter
+// ----------------------------------------------------------------------------
+
+static void emit_item(ncc_buffer_t *buf, ncc_parse_tree_t *node, dscope_t *scope,
+                      bool *exited);
+static void emit_compound(ncc_buffer_t *buf, ncc_parse_tree_t *compound,
+                          dscope_t *parent, dscope_kind_t kind);
+static void emit_body(ncc_buffer_t *buf, ncc_parse_tree_t *secondary_block,
+                      dscope_t *parent, dscope_kind_t kind);
+
+// Run defers from `scope` outward to the function root (used by `return`).
+static void
+emit_defers_to_func(ncc_buffer_t *buf, dscope_t *scope)
+{
+    for (dscope_t *s = scope; s; s = s->parent) {
+        emit_scope_defers(buf, s);
+    }
+}
+
+// Run defers from `scope` outward, stopping after the nearest loop (continue)
+// or loop/switch (break).
+static void
+emit_defers_to_loop(ncc_buffer_t *buf, dscope_t *scope, bool stop_at_switch)
+{
+    for (dscope_t *s = scope; s; s = s->parent) {
+        emit_scope_defers(buf, s);
+        if (s->kind == DS_LOOP || (stop_at_switch && s->kind == DS_SWITCH)) {
+            return;
+        }
+    }
+}
+
+// Lower a jump_statement. Sets *exited when it is an unconditional exit.
+static void
+emit_jump(ncc_buffer_t *buf, ncc_parse_tree_t *node, dscope_t *scope,
+          bool *exited)
+{
+    const char *kw = ncc_xform_get_first_leaf_text(node);
+
+    if (kw && strcmp(kw, "return") == 0) {
+        ncc_parse_tree_t *expr = ncc_xform_find_child_nt(node, "expression");
+        ncc_buffer_puts(buf, "{ ");
+        if (expr) {
+            ncc_string_t etext = ncc_xform_node_to_text(expr);
+            ncc_buffer_puts(buf, "typeof (");
+            ncc_buffer_puts(buf, etext.data ? etext.data : "");
+            ncc_buffer_puts(buf, ") __ncc_defer_ret = (");
+            ncc_buffer_puts(buf, etext.data ? etext.data : "");
+            ncc_buffer_puts(buf, "); ");
+            if (etext.data) {
+                ncc_free(etext.data);
+            }
+            emit_defers_to_func(buf, scope);
+            ncc_buffer_puts(buf, "return __ncc_defer_ret; }");
+        }
+        else {
+            emit_defers_to_func(buf, scope);
+            ncc_buffer_puts(buf, "return; }");
+        }
+        *exited = true;
+        return;
+    }
+
+    // Plain `break;` / `continue;` (no label).
+    bool labeled = ncc_xform_find_child_nt(node, "identifier") != nullptr;
+    if (!labeled && kw && strcmp(kw, "break") == 0) {
+        ncc_buffer_puts(buf, "{ ");
+        emit_defers_to_loop(buf, scope, /*stop_at_switch=*/true);
+        ncc_buffer_puts(buf, "break; }");
+        *exited = true;
+        return;
+    }
+    if (!labeled && kw && strcmp(kw, "continue") == 0) {
+        ncc_buffer_puts(buf, "{ ");
+        emit_defers_to_loop(buf, scope, /*stop_at_switch=*/false);
+        ncc_buffer_puts(buf, "continue; }");
+        *exited = true;
+        return;
+    }
+
+    // goto / computed goto / labeled break/continue: rejected up front for any
+    // _defer-using function (see xform_defer_funcdef), so this is unreachable.
+    defer_error(node,
+                "goto / labeled break/continue with _defer is not yet "
+                "supported");
+    *exited = true;
+}
+
+// Emit any statement/block-item, descending transparently through wrapper
+// nonterminals. Sets *exited if this item is an unconditional exit (so the
+// caller can suppress unreachable fall-through defers).
+static void
+emit_item(ncc_buffer_t *buf, ncc_parse_tree_t *node, dscope_t *scope,
+          bool *exited)
+{
+    if (!node) {
+        return;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        const char *t = ncc_xform_leaf_text(node);
+        if (t) {
+            ncc_buffer_puts(buf, t);
+            ncc_buffer_putc(buf, ' ');
+        }
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "defer_statement")) {
+        ncc_parse_tree_t *sb = ncc_xform_find_child_nt(node, "secondary_block");
+        if (!sb) {
+            return;
+        }
+        if (subtree_has_nt(sb, "jump_statement")) {
+            // A return/break/continue/goto that transfers control OUT of the
+            // defer body is forbidden; an in-body loop's own break is rare and
+            // also rejected conservatively for v1.
+            defer_error(node,
+                        "control transfer (return/break/continue/goto) inside a "
+                        "_defer body is not allowed");
+        }
+        ncc_string_t body = ncc_xform_node_to_text(sb);
+        char        *bt   = body.data;
+        if (!bt) {
+            bt    = ncc_alloc_size(1, 1);
+            bt[0] = '\0';
+        }
+        dscope_register(scope, bt);
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "compound_statement")) {
+        emit_compound(buf, node, scope, DS_BLOCK);
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "jump_statement")) {
+        emit_jump(buf, node, scope, exited);
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "iteration_statement")) {
+        size_t nc = ncc_tree_num_children(node);
+        for (size_t i = 0; i < nc; i++) {
+            ncc_parse_tree_t *c = ncc_tree_child(node, i);
+            if (c && !ncc_tree_is_leaf(c)
+                && ncc_xform_nt_name_is(c, "secondary_block")) {
+                emit_body(buf, c, scope, DS_LOOP);
+            }
+            else {
+                bool sub_exit = false;
+                emit_item(buf, c, scope, &sub_exit);
+            }
+        }
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(node, "selection_statement")) {
+        const char  *kw   = ncc_xform_get_first_leaf_text(node);
+        dscope_kind_t bk  = (kw && strcmp(kw, "switch") == 0) ? DS_SWITCH
+                                                              : DS_BLOCK;
+        size_t        nc  = ncc_tree_num_children(node);
+        for (size_t i = 0; i < nc; i++) {
+            ncc_parse_tree_t *c = ncc_tree_child(node, i);
+            if (c && !ncc_tree_is_leaf(c)
+                && ncc_xform_nt_name_is(c, "secondary_block")) {
+                emit_body(buf, c, scope, bk);
+            }
+            else {
+                bool sub_exit = false;
+                emit_item(buf, c, scope, &sub_exit);
+            }
+        }
+        return;
+    }
+
+    // A plain statement / declaration / wrapper. If it contains nothing this
+    // pass must rewrite, emit it verbatim; otherwise descend into its children
+    // (this transparently handles block_item / unlabeled_statement /
+    // primary_block / statement / labeled_statement wrappers).
+    if (!subtree_has_nt(node, "defer_statement")
+        && !subtree_has_nt(node, "jump_statement")) {
+        ncc_string_t t = ncc_xform_node_to_text(node);
+        ncc_buffer_puts(buf, t.data ? t.data : "");
+        ncc_buffer_putc(buf, ' ');
+        if (t.data) {
+            ncc_free(t.data);
+        }
+        return;
+    }
+
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        emit_item(buf, ncc_tree_child(node, i), scope, exited);
+    }
+}
+
+// Emit a compound statement, opening a fresh scope of `kind`.
+static void
+emit_compound(ncc_buffer_t *buf, ncc_parse_tree_t *compound, dscope_t *parent,
+              dscope_kind_t kind)
+{
+    dscope_t scope = {.kind = kind, .parent = parent};
+
+    ncc_buffer_puts(buf, "{ ");
+
+    ncc_parse_tree_t *list = ncc_xform_find_child_nt(compound,
+                                                     "block_item_list");
+    bool exited = false;
+    if (list) {
+        size_t nc = ncc_tree_num_children(list);
+        for (size_t i = 0; i < nc; i++) {
+            exited = false;
+            emit_item(buf, ncc_tree_child(list, i), &scope, &exited);
+        }
+    }
+
+    // Fall-through: run this scope's defers (reversed). Skip if the block ended
+    // in an unconditional exit (the defers were already emitted there, and
+    // emitting again would be unreachable).
+    if (!exited) {
+        emit_scope_defers(buf, &scope);
+    }
+
+    ncc_buffer_puts(buf, "}");
+    dscope_free(&scope);
+}
+
+// Emit a loop/if/switch body (a secondary_block), giving its block the scope
+// kind so break/continue resolve to it. A single-statement body is wrapped in a
+// synthetic block so a defer in it still runs at body end.
+static void
+emit_body(ncc_buffer_t *buf, ncc_parse_tree_t *secondary_block,
+          dscope_t *parent, dscope_kind_t kind)
+{
+    ncc_parse_tree_t *compound = ncc_xform_find_child_nt(secondary_block,
+                                                         "compound_statement");
+    if (compound) {
+        emit_compound(buf, compound, parent, kind);
+        return;
+    }
+
+    // Single-statement body.
+    dscope_t scope  = {.kind = kind, .parent = parent};
+    bool     exited = false;
+    ncc_buffer_puts(buf, "{ ");
+    emit_item(buf, secondary_block, &scope, &exited);
+    if (!exited) {
+        emit_scope_defers(buf, &scope);
+    }
+    ncc_buffer_puts(buf, "}");
+    dscope_free(&scope);
+}
+
+// ----------------------------------------------------------------------------
+// Entry: rewrite a function definition whose body uses _defer
+// ----------------------------------------------------------------------------
+
+static ncc_parse_tree_t *
+xform_defer_funcdef(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *node)
+{
+    ncc_parse_tree_t *body = ncc_xform_find_child_nt(node, "function_body");
+    if (!body) {
+        return nullptr;
+    }
+    ncc_parse_tree_t *compound = ncc_xform_find_child_nt(body,
+                                                         "compound_statement");
+    if (!compound || !subtree_has_nt(compound, "defer_statement")) {
+        return nullptr;
+    }
+
+    // v1 limitation: correctly running defers across a goto / labeled
+    // break-continue needs label-scope analysis, so reject the combination
+    // rather than mis-lower it.
+    if (subtree_has_unsupported_jump(compound)) {
+        defer_error(compound,
+                    "a function using _defer may not (yet) also use goto, "
+                    "computed goto, or labeled break/continue");
+    }
+
+    // Rewrite the body.
+    ncc_buffer_t *body_buf = ncc_buffer_empty();
+    emit_compound(body_buf, compound, nullptr, DS_FUNC);
+    char *new_body = ncc_buffer_take(body_buf);
+
+    // Rebuild the function definition text, replacing the body verbatim-wise.
+    ncc_buffer_t *fbuf = ncc_buffer_empty();
+    size_t        nc   = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *c = ncc_tree_child(node, i);
+        if (c == body) {
+            ncc_buffer_puts(fbuf, new_body ? new_body : "{ }");
+            ncc_buffer_putc(fbuf, ' ');
+        }
+        else {
+            ncc_string_t t = ncc_xform_node_to_text(c);
+            ncc_buffer_puts(fbuf, t.data ? t.data : "");
+            ncc_buffer_putc(fbuf, ' ');
+            if (t.data) {
+                ncc_free(t.data);
+            }
+        }
+    }
+    ncc_free(new_body);
+
+    char *ftext = ncc_buffer_take(fbuf);
+    ncc_parse_tree_t *result = ncc_xform_parse_source(
+        ctx->grammar, "function_definition", ftext ? ftext : "", "xform_defer");
+    ncc_free(ftext);
+
+    return result;
+}
+
+void
+ncc_register_defer_xform(ncc_xform_registry_t *reg)
+{
+    ncc_xform_register(reg, "function_definition", xform_defer_funcdef,
+                       "defer");
+}

--- a/test/err_defer_escape.c
+++ b/test/err_defer_escape.c
@@ -1,0 +1,14 @@
+// err_defer_escape - control may not be transferred out of a _defer body.
+
+int
+f(void)
+{
+    _defer { return 1; }
+    return 0;
+}
+
+int
+main(void)
+{
+    return f();
+}

--- a/test/err_defer_goto.c
+++ b/test/err_defer_goto.c
@@ -1,0 +1,17 @@
+// err_defer_goto - a function using _defer may not (yet) also use goto;
+// running the right defers across the jump needs label-scope analysis.
+
+int
+f(int x)
+{
+    _defer { x = 0; }
+    goto done;
+done:
+    return x;
+}
+
+int
+main(void)
+{
+    return f(1);
+}

--- a/test/test_defer.c
+++ b/test/test_defer.c
@@ -1,0 +1,104 @@
+// test_defer.c — behavioral test for `_defer` (N3199 semantics).
+//
+// Verifies: deferred blocks run at scope exit in LIFO order; on early return;
+// on loop continue/break; that the return value is computed BEFORE deferred
+// blocks run; and that defers see current variable values.
+
+int idx = 0;
+int log_[64];
+
+static void
+rec(int v)
+{
+    log_[idx++] = v;
+}
+
+static int
+basic(void)
+{
+    rec(1);
+    _defer { rec(99); }
+    rec(2);
+    return 0;
+} // expect: 1, 2, 99
+
+static int
+lifo(void)
+{
+    _defer { rec(10); }
+    _defer { rec(20); }
+    return 0;
+} // expect: 20, 10
+
+static int
+early(int x)
+{
+    _defer { rec(5); }
+    if (x) {
+        return 1;
+    }
+    rec(6);
+    return 0;
+}
+
+static int
+loopy(void)
+{
+    for (int i = 0; i < 3; i++) {
+        _defer { rec(100 + i); } // runs at end of each iteration's body
+        if (i == 1) {
+            continue;
+        }
+        if (i == 2) {
+            break;
+        }
+        rec(i);
+    }
+    return 0;
+} // expect: 0, 100, 101, 102
+
+// The return value is computed before deferred blocks run, so the mutation of
+// `v` in the defer does not affect the returned value.
+static int
+retval(void)
+{
+    int v = 7;
+    _defer { v = 999; }
+    return v;
+} // returns 7
+
+#define CHECK(cond)        \
+    do {                   \
+        if (!(cond)) {     \
+            return __LINE__; \
+        }                  \
+    } while (0)
+
+int
+main(void)
+{
+    idx = 0;
+    basic();
+    CHECK(idx == 3 && log_[0] == 1 && log_[1] == 2 && log_[2] == 99);
+
+    idx = 0;
+    lifo();
+    CHECK(idx == 2 && log_[0] == 20 && log_[1] == 10);
+
+    idx = 0;
+    early(1);
+    CHECK(idx == 1 && log_[0] == 5);
+
+    idx = 0;
+    early(0);
+    CHECK(idx == 2 && log_[0] == 6 && log_[1] == 5);
+
+    idx = 0;
+    loopy();
+    CHECK(idx == 4 && log_[0] == 0 && log_[1] == 100 && log_[2] == 101
+          && log_[3] == 102);
+
+    CHECK(retval() == 7);
+
+    return 0;
+}


### PR DESCRIPTION
## `_defer` — scope-exit defer statement (N3199 semantics)

Adds a defer statement, spelled **`_defer`** to avoid colliding with libn00b's
existing `defer` macro. `_defer <secondary-block>` registers the block when
control reaches it and runs it at exit of the enclosing scope — **LIFO, on every
exit path**, with current variable values (no capture) — matching the C defer
proposal [N3199](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3199.htm).

```c
void use(FILE *f) {
    _defer { fclose(f); }      // closed on every exit path
    ...
}

_defer { unlock(m); }          // runs LIFO with earlier defers
```

### Lowering (`src/xform/xform_defer.c`)
clang has no nested functions, so `__attribute__((cleanup))` can't host an
inline body that references locals. Instead the deferred bodies are **injected
as source at each scope exit**. In structured code the *registered* defer set at
any exit is statically the textually-preceding defers of the enclosing scopes,
so no runtime flags are needed. A `return` captures its value into
`typeof(E) __ncc_defer_ret` **before** running defers (return value computed
first, per N3199). The pass runs early so relocated bodies still flow through
the type-query / option / kargs / contracts passes.

Handled: `return`, `break` (to nearest loop/switch), `continue` (to nearest
loop), fall-through, and nested blocks.

### v1 limitation (diagnosed, not mis-compiled)
Correctly running defers across a `goto` / computed goto / labeled
break-continue needs label-scope analysis, so a `_defer`-using function that
also uses those is **rejected with a diagnostic** — a forward `goto` over a
`_defer` would otherwise skip its registration. Control transfer *out of* a
defer body is likewise rejected. Both are planned follow-ups (label-scope
analysis to support `goto`-leaving).

### Tests
- `test_defer.c` — LIFO, early `return`, loop `continue`/`break`, and
  return-value-before-defer ordering.
- `err_defer_goto.c`, `err_defer_escape.c` — the diagnostics.
- **249/249** ncc tests; **full clean libn00b build (2033/2033)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
