### PR TITLE
xform: add [[n00b::noscan]] per-struct-field GC attribute

### DIFF
--- a/include/xform/xform_helpers.h
+++ b/include/xform/xform_helpers.h
@@ -19,6 +19,17 @@ const char *ncc_xform_leaf_text(ncc_parse_tree_t *node);
 // Check if a leaf token's text matches a C string.
 bool ncc_xform_leaf_text_eq(ncc_parse_tree_t *node, const char *text);
 
+// Does any descendant <attribute_specifier_sequence> of `node` carry a
+// `[[n00b::<name>]]` attribute? Used by the GC stack-map ([[n00b::nogc]]) and
+// GC typemap ([[n00b::noscan]]) transforms.
+bool ncc_xform_subtree_carries_n00b_named_attr(ncc_parse_tree_t *node,
+                                               const char       *name);
+
+// Recursively remove every <attribute_specifier> carrying `[[n00b::<name>]]`
+// from `parent` so the attribute never reaches the C emitter.
+void ncc_xform_strip_n00b_named_attribute_specifiers(ncc_parse_tree_t *parent,
+                                                     const char       *name);
+
 // Collect type atoms from typeid/typestr/typehash argument structure.
 // Walks <typeid_atom> and <typeid_continuation> children.
 // Returns an ncc_string_t with the combined canonical type string.

--- a/meson.build
+++ b/meson.build
@@ -807,6 +807,51 @@ test('ncc_gc_typemap_runtime_near_miss_scan_user_scanned', test_runner,
   depends : ncc_exe,
 )
 
+test('ncc_gc_typemap_noscan_trailing_field_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_noscan_trailing_t,noscan_ptr)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_noscan_trailing_sibling_scanned', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_noscan_trailing_t,payload)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_noscan_prefix_field_skipped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_noscan_prefix_t,noscan_ptr)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_noscan_prefix_sibling_scanned', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap.c',
+          '__builtin_offsetof(gcmap_noscan_prefix_t,kept)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_noscan_attribute_stripped', test_runner,
+  args : [ncc_exe, 'preprocess_not_contains',
+          test_dir / 'test_gc_typemap.c',
+          'n00b::noscan']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
 test('ncc_gc_typemap_static_assert_c23', test_runner,
   args : [ncc_exe, 'preprocess_contains',
           test_dir / 'test_gc_typemap.c',

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -42,6 +42,7 @@
 #include "parse/c_tokenizer.h"
 #include "parse/emit.h"
 #include "xform/xform_gc_typemap.h"
+#include "xform/xform_helpers.h"
 #include "parse/tree_dump.h"
 #include "xform/transform.h"
 #include "xform/xform_template.h"
@@ -2303,6 +2304,12 @@ compile_file(ncc_opts_t *opts)
     // transform dicts (gc_aggregate_types) are freed below; appended to the
     // pretty-printed output further down.
     char *gc_typemap_text = ncc_gc_typemap_emit(&xctx);
+
+    // The `[[n00b::noscan]]` per-field attribute is consumed above (it tells
+    // ncc_gc_typemap_emit to omit a field from the GC typemap). Strip it from
+    // the whole tree now — AFTER the typemap detection has read it, BEFORE the
+    // tree is pretty-printed — so clang never sees this ncc-only attribute.
+    ncc_xform_strip_n00b_named_attribute_specifiers(tree, "noscan");
 
 #ifdef NCC_MEM_DEBUG
     ncc_mem_report("after transform");

--- a/src/xform/xform_gc_stack_maps.c
+++ b/src/xform/xform_gc_stack_maps.c
@@ -349,121 +349,6 @@ first_leaf_node(ncc_parse_tree_t *node)
     return nullptr;
 }
 
-static bool
-attribute_is_n00b_named(ncc_parse_tree_t *attr_node, const char *name)
-{
-    if (!attr_node || !name || ncc_tree_is_leaf(attr_node)) {
-        return false;
-    }
-
-    ncc_parse_tree_t *prefixed = ncc_layout_first_descendant_nt(
-        attr_node, "attribute_prefixed_token");
-    if (!prefixed) {
-        return false;
-    }
-
-    bool   saw_n00b = false;
-    bool   saw_name = false;
-    size_t nc       = ncc_tree_num_children(prefixed);
-    for (size_t i = 0; i < nc; i++) {
-        ncc_parse_tree_t *c = ncc_tree_child(prefixed, i);
-        if (!c) {
-            continue;
-        }
-
-        ncc_parse_tree_t *cur = c;
-        while (cur && !ncc_tree_is_leaf(cur)
-               && ncc_tree_num_children(cur) > 0) {
-            ncc_parse_tree_t *next = ncc_tree_child(cur, 0);
-            if (!next) {
-                break;
-            }
-            cur = next;
-        }
-        if (!cur || !ncc_tree_is_leaf(cur)) {
-            continue;
-        }
-
-        const char *text = ncc_xform_leaf_text(cur);
-        if (!text) {
-            continue;
-        }
-        if (!saw_n00b && strcmp(text, "n00b") == 0) {
-            saw_n00b = true;
-            continue;
-        }
-        if (saw_n00b && !saw_name && strcmp(text, name) == 0) {
-            saw_name = true;
-        }
-    }
-
-    return saw_n00b && saw_name;
-}
-
-static bool
-attribute_seq_contains_n00b_named(ncc_parse_tree_t *attr_seq,
-                                  const char *name)
-{
-    if (!attr_seq || !name || ncc_tree_is_leaf(attr_seq)) {
-        return false;
-    }
-
-    ncc_layout_parse_tree_list_t attrs = {0};
-    ncc_layout_collect_nt_children(attr_seq, "attribute", &attrs);
-    bool found = false;
-    for (size_t i = 0; i < attrs.len; i++) {
-        if (attribute_is_n00b_named(attrs.data[i], name)) {
-            found = true;
-            break;
-        }
-    }
-    ncc_free(attrs.data);
-    return found;
-}
-
-static bool
-subtree_carries_n00b_named_attr(ncc_parse_tree_t *node, const char *name)
-{
-    if (!node || !name || ncc_tree_is_leaf(node)) {
-        return false;
-    }
-
-    if (ncc_xform_nt_name_is(node, "attribute_specifier_sequence")) {
-        return attribute_seq_contains_n00b_named(node, name);
-    }
-
-    size_t nc = ncc_tree_num_children(node);
-    for (size_t i = 0; i < nc; i++) {
-        if (subtree_carries_n00b_named_attr(ncc_tree_child(node, i), name)) {
-            return true;
-        }
-    }
-    return false;
-}
-
-static void
-strip_n00b_named_attribute_specifiers(ncc_parse_tree_t *parent,
-                                      const char *name)
-{
-    if (!parent || !name || ncc_tree_is_leaf(parent)) {
-        return;
-    }
-
-    size_t i = 0;
-    while (i < ncc_tree_num_children(parent)) {
-        ncc_parse_tree_t *child = ncc_tree_child(parent, i);
-        if (child && !ncc_tree_is_leaf(child)
-            && ncc_xform_nt_name_is(child, "attribute_specifier")
-            && attribute_seq_contains_n00b_named(child, name)) {
-            ncc_xform_remove_child(parent, i);
-            continue;
-        }
-
-        strip_n00b_named_attribute_specifiers(child, name);
-        i++;
-    }
-}
-
 static void
 add_token_trivia(ncc_token_info_t *tok, const char *text, bool leading)
 {
@@ -2700,7 +2585,7 @@ scan_function_definition(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *fn)
         return;
     }
 
-    if (subtree_carries_n00b_named_attr(fn, "nogc")) {
+    if (ncc_xform_subtree_carries_n00b_named_attr(fn, "nogc")) {
         return;
     }
 
@@ -3107,13 +2992,13 @@ xform_gc_stack_translation_unit(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *tu)
 {
     ncc_xform_data_t *data = ncc_xform_get_data(ctx);
     if (!data || !data->gc_stack_maps) {
-        strip_n00b_named_attribute_specifiers(tu, "nogc");
+        ncc_xform_strip_n00b_named_attribute_specifiers(tu, "nogc");
         return nullptr;
     }
 
     collect_gc_type_info(ctx, tu);
     scan_function_definitions(ctx, tu);
-    strip_n00b_named_attribute_specifiers(tu, "nogc");
+    ncc_xform_strip_n00b_named_attribute_specifiers(tu, "nogc");
 
     if (!data->gc_stack_roots) {
         return nullptr;

--- a/src/xform/xform_gc_typemap.c
+++ b/src/xform/xform_gc_typemap.c
@@ -718,6 +718,32 @@ emit_pointer(const char *elem_type, const char *path,
     ncc_free(as);
 }
 
+// Does this member_declaration carry a *prefix* `[[n00b::noscan]]`
+// attribute_specifier_sequence — i.e. one that appears before the type and
+// therefore applies to every declarator in the declaration? (A C23 `[[...]]`
+// may sit in the prefix position OR trail an individual declarator; the
+// trailing case is detected per-declarator on the member_declarator node.)
+static bool
+member_decl_has_prefix_noscan(ncc_parse_tree_t *member)
+{
+    if (!member || ncc_tree_is_leaf(member)) {
+        return false;
+    }
+    // The prefix attribute_specifier_sequence is a (group-unwrapped) direct
+    // child of the member_declaration, per the grammar:
+    //   <member_declaration> ::= <attribute_specifier_sequence>?
+    //                            <specifier_qualifier_list>
+    //                            <member_declarator_list>? ";"
+    // ncc_xform_find_child_nt only descends into $$group_* wrappers, so it will
+    // not reach a *trailing* attribute (which lives deeper, inside the
+    // member_declarator_list subtree). That keeps a `[[n00b::noscan]]` on one
+    // declarator from leaking onto a sibling in the same declaration.
+    ncc_parse_tree_t *prefix_seq = ncc_xform_find_child_nt(
+        member, "attribute_specifier_sequence");
+    return prefix_seq
+        && ncc_xform_subtree_carries_n00b_named_attr(prefix_seq, "noscan");
+}
+
 // Walk one member_declaration of a STRUCT.
 static void
 walk_struct_member(ncc_xform_ctx_t *ctx, const char *elem_type,
@@ -731,6 +757,11 @@ walk_struct_member(ncc_xform_ctx_t *ctx, const char *elem_type,
     if (!member_specs) {
         return; // nothing typed here (e.g. a stray ';')
     }
+
+    // A prefix `[[n00b::noscan]]` (before the type) applies to every declarator
+    // in this member_declaration; a trailing one applies only to its own
+    // declarator and is tested per-declarator below.
+    bool prefix_noscan = member_decl_has_prefix_noscan(member);
 
     ncc_parse_tree_t *member_list = ncc_xform_find_child_nt(
         member, "member_declarator_list");
@@ -777,8 +808,15 @@ walk_struct_member(ncc_xform_ctx_t *ctx, const char *elem_type,
             char *field = ncc_layout_implicit_member_field_name(member,
                                                                 member_specs);
             if (field) {
-                if (!member_is_runtime_infra(runtime_scan_shape, field,
-                                             member_specs)) {
+                // No member_declarator_list wrapper here, so a trailing
+                // `[[n00b::noscan]]` (if any) lives inside `member` itself;
+                // either prefix or trailing form excludes this pointer.
+                bool noscan = prefix_noscan
+                           || ncc_xform_subtree_carries_n00b_named_attr(
+                                  member, "noscan");
+                if (!noscan
+                    && !member_is_runtime_infra(runtime_scan_shape, field,
+                                                member_specs)) {
                     char *path = path_join(base, field);
                     emit_pointer(elem_type, path, offs, asserts, count);
                     ncc_free(path);
@@ -807,6 +845,15 @@ walk_struct_member(ncc_xform_ctx_t *ctx, const char *elem_type,
             break;
         }
         if (member_is_runtime_infra(runtime_scan_shape, name, member_specs)) {
+            ncc_free(name);
+            continue;
+        }
+        // [[n00b::noscan]]: a prefix attribute on the whole declaration, or a
+        // trailing attribute on this specific member_declarator, excludes the
+        // field from the GC typemap (the GC must never scan/relocate it).
+        if (prefix_noscan
+            || ncc_xform_subtree_carries_n00b_named_attr(decls.data[i],
+                                                         "noscan")) {
             ncc_free(name);
             continue;
         }

--- a/src/xform/xform_helpers.c
+++ b/src/xform/xform_helpers.c
@@ -4,6 +4,7 @@
 #include "xform/xform_template.h"
 #include "xform/xform_data.h"
 #include "parse/type_infer.h"
+#include "xform/xform_type_layout.h"
 #include "lib/alloc.h"
 #include "lib/buffer.h"
 #include "lib/string.h"
@@ -535,6 +536,125 @@ ncc_string_t ncc_xform_node_to_text(ncc_parse_tree_t *node) {
   ncc_free(cb->data);
   ncc_free(cb);
   return result;
+}
+
+// ============================================================================
+// [[n00b::<name>]] attribute detection / stripping
+//
+// Shared between the GC stack-map transform ([[n00b::nogc]]) and the GC
+// typemap transform ([[n00b::noscan]]). The two public entry points are
+// declared in the header; the two inner helpers are static here.
+// ============================================================================
+
+// Does a single <attribute> node spell `[[n00b::<name>]]`?
+static bool ncc_xform_attribute_is_n00b_named(ncc_parse_tree_t *attr_node,
+                                              const char       *name) {
+  if (!attr_node || !name || ncc_tree_is_leaf(attr_node)) {
+    return false;
+  }
+
+  ncc_parse_tree_t *prefixed =
+      ncc_layout_first_descendant_nt(attr_node, "attribute_prefixed_token");
+  if (!prefixed) {
+    return false;
+  }
+
+  bool   saw_n00b = false;
+  bool   saw_name = false;
+  size_t nc       = ncc_tree_num_children(prefixed);
+  for (size_t i = 0; i < nc; i++) {
+    ncc_parse_tree_t *c = ncc_tree_child(prefixed, i);
+    if (!c) {
+      continue;
+    }
+
+    ncc_parse_tree_t *cur = c;
+    while (cur && !ncc_tree_is_leaf(cur) && ncc_tree_num_children(cur) > 0) {
+      ncc_parse_tree_t *next = ncc_tree_child(cur, 0);
+      if (!next) {
+        break;
+      }
+      cur = next;
+    }
+    if (!cur || !ncc_tree_is_leaf(cur)) {
+      continue;
+    }
+
+    const char *text = ncc_xform_leaf_text(cur);
+    if (!text) {
+      continue;
+    }
+    if (!saw_n00b && strcmp(text, "n00b") == 0) {
+      saw_n00b = true;
+      continue;
+    }
+    if (saw_n00b && !saw_name && strcmp(text, name) == 0) {
+      saw_name = true;
+    }
+  }
+
+  return saw_n00b && saw_name;
+}
+
+// Does an <attribute_specifier_sequence> contain `[[n00b::<name>]]`?
+static bool ncc_xform_attribute_seq_contains_n00b_named(
+    ncc_parse_tree_t *attr_seq, const char *name) {
+  if (!attr_seq || !name || ncc_tree_is_leaf(attr_seq)) {
+    return false;
+  }
+
+  ncc_layout_parse_tree_list_t attrs = {0};
+  ncc_layout_collect_nt_children(attr_seq, "attribute", &attrs);
+  bool found = false;
+  for (size_t i = 0; i < attrs.len; i++) {
+    if (ncc_xform_attribute_is_n00b_named(attrs.data[i], name)) {
+      found = true;
+      break;
+    }
+  }
+  ncc_free(attrs.data);
+  return found;
+}
+
+bool ncc_xform_subtree_carries_n00b_named_attr(ncc_parse_tree_t *node,
+                                               const char       *name) {
+  if (!node || !name || ncc_tree_is_leaf(node)) {
+    return false;
+  }
+
+  if (ncc_xform_nt_name_is(node, "attribute_specifier_sequence")) {
+    return ncc_xform_attribute_seq_contains_n00b_named(node, name);
+  }
+
+  size_t nc = ncc_tree_num_children(node);
+  for (size_t i = 0; i < nc; i++) {
+    if (ncc_xform_subtree_carries_n00b_named_attr(ncc_tree_child(node, i),
+                                                  name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ncc_xform_strip_n00b_named_attribute_specifiers(ncc_parse_tree_t *parent,
+                                                     const char       *name) {
+  if (!parent || !name || ncc_tree_is_leaf(parent)) {
+    return;
+  }
+
+  size_t i = 0;
+  while (i < ncc_tree_num_children(parent)) {
+    ncc_parse_tree_t *child = ncc_tree_child(parent, i);
+    if (child && !ncc_tree_is_leaf(child)
+        && ncc_xform_nt_name_is(child, "attribute_specifier")
+        && ncc_xform_attribute_seq_contains_n00b_named(child, name)) {
+      ncc_xform_remove_child(parent, i);
+      continue;
+    }
+
+    ncc_xform_strip_n00b_named_attribute_specifiers(child, name);
+    i++;
+  }
 }
 
 // ============================================================================

--- a/test/test_gc_typemap.c
+++ b/test/test_gc_typemap.c
@@ -60,6 +60,21 @@ typedef union gcmap_union_mixed_t {
     gcmap_payload_t *payload;
 } gcmap_union_mixed_t;
 
+// [[n00b::noscan]] in the TRAILING declarator position: `noscan_ptr` must be
+// omitted from the typemap; its sibling `payload` (same struct) must remain.
+typedef struct gcmap_noscan_trailing_t {
+    gcmap_payload_t  *payload;
+    gcmap_payload_t  *noscan_ptr [[n00b::noscan]];
+} gcmap_noscan_trailing_t;
+
+// [[n00b::noscan]] in the PREFIX position (before the type): excludes the
+// declared field. `kept` (a separate, un-attributed member_declaration) must
+// remain in the typemap.
+typedef struct gcmap_noscan_prefix_t {
+    gcmap_payload_t          *kept;
+    [[n00b::noscan]] gcmap_payload_t *noscan_ptr;
+} gcmap_noscan_prefix_t;
+
 static uint64_t h_direct = typehash(gcmap_direct_fn_t *);
 static uint64_t h_typedef = typehash(gcmap_typedef_fn_t *);
 static uint64_t h_user    = typehash(gcmap_user_scan_field_t *);
@@ -67,11 +82,13 @@ static uint64_t h_runtime = typehash(gcmap_runtime_shape_t *);
 static uint64_t h_near    = typehash(gcmap_runtime_near_miss_t *);
 static uint64_t h_array   = typehash(gcmap_pointer_array_t *);
 static uint64_t h_union   = typehash(gcmap_union_mixed_t *);
+static uint64_t h_nstrail = typehash(gcmap_noscan_trailing_t *);
+static uint64_t h_nspref  = typehash(gcmap_noscan_prefix_t *);
 
 int
 main(void)
 {
     return (int)((h_direct ^ h_typedef ^ h_user ^ h_runtime ^ h_near
-                  ^ h_array ^ h_union)
+                  ^ h_array ^ h_union ^ h_nstrail ^ h_nspref)
                  == 0);
 }


### PR DESCRIPTION
Rebased onto current `main`; single commit, mergeable (the expr-typing base it was originally drafted on is already merged as #28/#27).

## `[[n00b::noscan]]`
The WP-020 GC typemap transform auto-skips only specific fields by name+type
(allocator/lock/scan-shape runtime infra, function pointers). It cannot exclude
a *pointer-typed* field that points at non-GC memory (a stack pointer, an
arena/pool reference, an in-flight allocation reservation), so the collector
wrongly follows such a field as a heap pointer.

`[[n00b::noscan]]` excludes a member from the emitted GC pointer map. Both C23
placements are handled: **prefix** (before the type → applies to every
declarator in the member_declaration) and **trailing** (after a declarator →
only that declarator, no sibling leakage). The attribute is stripped from the
tree after typemap emission and before pretty-printing, so clang never sees it.

The four `[[n00b::<name>]]` detect/strip helpers were promoted from `static`
defs in `xform_gc_stack_maps.c` to shared `ncc_xform_*` functions in
`xform_helpers.c` (declared in `xform_helpers.h`); `xform_gc_stack_maps.c` now
calls them for `[[n00b::nogc]]` with identical behavior.

## Tests
5 new `gc_typemap` cases (prefix + trailing skip, sibling still scanned,
attribute stripped from output). Full ncc suite: **Ok 265, Fail 0**.

Motivation: a libn00b conservative-scan livelock traced to the collector
following non-pointer / arena-reference words in a struct scanned without a
precise map; `[[n00b::noscan]]` is the building block to make such structs
(e.g. `n00b_thread_t`) precisely scannable. Addresses #7 toward #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)