### PR TITLE
ncc: scope-aware expression typing + must-check (nodiscard) result returns

### DIFF
--- a/c_ncc.bnf
+++ b/c_ncc.bnf
@@ -476,7 +476,7 @@
 # reading when the symbol table says the identifier names a typedef, so the type
 # reading wins. Real function specifiers (inline/_Noreturn/_Once) are never
 # typedefs, so they are unaffected.
-<function_specifier> @disambig(id_is_typedef) ::= <_kw_kw_fn_specifier>
+<function_specifier> @disambig(id_is_known) ::= <_kw_kw_fn_specifier>
     | %"_Once"
 
 <_kw_kw_gcc_asm> ::= %"__asm__"

--- a/include/parse/nodiscard.h
+++ b/include/parse/nodiscard.h
@@ -1,0 +1,29 @@
+#pragma once
+
+/**
+ * @file nodiscard.h
+ * @brief Must-check result returns ([[nodiscard]]-style, for result types).
+ *
+ * A function whose return type carries the result protocol (an aggregate with
+ * both an `is_ok` and an `err` member — i.e. `n00b_result_t(T)`) advertises a
+ * value the caller is expected to inspect. Calling such a function as a bare
+ * expression statement (`f(x);`) discards the result, silently dropping the
+ * error — the classic "forgot to check the return" bug.
+ *
+ * This pass warns on that. The opt-out is an explicit void cast (`(void)f(x);`),
+ * matching real `nodiscard`. It is read-only: it emits diagnostics and never
+ * transforms the tree. Run it after transforms so `_generic_struct` result
+ * types are lowered to concrete tags resolvable through the symbol table (and
+ * `_try`, which consumes a result, is already lowered away).
+ */
+
+#include "parse/types.h"
+#include "parse/parse_tree.h"
+#include "parse/symtab.h"
+
+/**
+ * @brief Warn for each call whose result-protocol return value is discarded.
+ *        Returns the number of warnings emitted.
+ */
+int ncc_nodiscard_check(ncc_grammar_t *g, ncc_parse_tree_t *tu,
+                        ncc_symtab_t *symtab);

--- a/include/parse/symtab.h
+++ b/include/parse/symtab.h
@@ -63,6 +63,14 @@ struct ncc_scope_t {
     int32_t           depth;
     ncc_sym_entry_t *first_in_scope;
     ncc_string_t     adt_kind;
+    // The parse node that created this scope (function_definition /
+    // compound_statement), or nullptr. Used to map an expression back to its
+    // lexical scope for scoped lookup. Set via ncc_symtab_set_scope_node.
+    ncc_parse_tree_t *node;
+    // Retained-scope chain: every scope ever pushed is linked here so the full
+    // scope tree survives until the symtab is freed (scopes are no longer freed
+    // on pop), enabling location-based lexical lookup after population.
+    ncc_scope_t     *all_next;
 };
 
 // ============================================================================
@@ -84,6 +92,8 @@ struct ncc_symtab_t {
     ncc_namespace_t *namespaces;
     int32_t           ns_count;
     int32_t           ns_cap;
+    // Head of the retained-scope list (every pushed scope, all namespaces).
+    ncc_scope_t     *all_scopes;
 };
 
 // ============================================================================
@@ -117,6 +127,23 @@ ncc_sym_entry_t *ncc_symtab_add(ncc_symtab_t *st, ncc_string_t ns_name,
 
 ncc_sym_entry_t *ncc_symtab_lookup(ncc_symtab_t *st, ncc_string_t ns_name,
                                        ncc_string_t name);
+
+// Tag the current scope of namespace @p ns_name with the parse node that
+// created it (function_definition / compound_statement).
+void ncc_symtab_set_scope_node(ncc_symtab_t *st, ncc_string_t ns_name,
+                               ncc_parse_tree_t *node);
+
+// The retained scope created by parse node @p node (or nullptr). Scopes are
+// kept after population, so this works post-walk.
+ncc_scope_t *ncc_symtab_scope_for_node(ncc_symtab_t *st,
+                                       ncc_parse_tree_t *node);
+
+// Lexical lookup starting from @p scope, walking up the parent-scope chain;
+// falls back to a global (file-scope) lookup in namespace @p ns_name. A null
+// @p scope is a plain global lookup.
+ncc_sym_entry_t *ncc_symtab_lookup_scoped(ncc_symtab_t *st, ncc_scope_t *scope,
+                                          ncc_string_t ns_name,
+                                          ncc_string_t name);
 
 bool ncc_symtab_is_typedef(ncc_symtab_t *st, ncc_string_t name);
 

--- a/meson.build
+++ b/meson.build
@@ -195,6 +195,7 @@ src_xform = files(
   'src/xform/xform_try.c',
   'src/xform/xform_nullable.c',
   'src/xform/nullability.c',
+  'src/xform/nodiscard.c',
   'src/xform/xform_generic_struct.c',
   'src/xform/xform_gc_globals.c',
   'src/xform/xform_gc_stack_maps.c',
@@ -400,6 +401,8 @@ ncc_static_descriptor_flags = [
 ncc_compile_tests = {
   'bang':          ['compile_run',  test_dir / 'test_bang.c'],
   'typehash_expr': ['compile_run',  test_dir / 'test_typehash_expr.c'],
+  'typehash_scoped': ['compile_run',  test_dir / 'test_typehash_scoped.c'],
+  'typehash_autotag': ['compile_run',  test_dir / 'test_typehash_autotag.c'],
   'array_literal': ['compile_run',  test_dir / 'test_array_literal.c'],
   'list_literal':  ['compile_run',  test_dir / 'test_list_literal.c'],
   'dict_literal':  ['compile_run',  test_dir / 'test_dict_literal.c'],
@@ -1432,6 +1435,25 @@ test('ncc_nullable_guards', test_runner,
   args : [ncc_exe, 'preprocess_stderr_omits',
           test_dir / 'test_nullable_guards.c',
           'null dereference']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_nodiscard_warn', test_runner,
+  args : [ncc_exe, 'preprocess_stderr_contains',
+          test_dir / 'test_nodiscard_warn.c',
+          'result of \'mk()\' is ignored',
+          '_generic_struct']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_nodiscard_ok', test_runner,
+  args : [ncc_exe, 'preprocess_stderr_omits',
+          test_dir / 'test_nodiscard_ok.c',
+          'is ignored']
          + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
   suite : 'ncc',
   depends : ncc_exe,

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -39,6 +39,7 @@
 #include "parse/symbol_populate.h"
 #include "parse/type_infer.h"
 #include "parse/nullability.h"
+#include "parse/nodiscard.h"
 #include "parse/c_tokenizer.h"
 #include "parse/emit.h"
 #include "xform/xform_gc_typemap.h"
@@ -1983,7 +1984,14 @@ compile_file(ncc_opts_t *opts)
     // array-of-`lp` type) is resolved at the parse layer rather than patched up
     // by downstream xforms. The provisional symtab's typedef classification is
     // reliable because it derives from unambiguous declarations.
-    {
+    //
+    // Iterate to a fixed point (bounded): the first pass resolves ambiguities
+    // visible from unambiguous declarations (typedefs), which can in turn make
+    // a previously mis-parsed definition (e.g. `int f(int v){…}` where `f`
+    // matched the function-specifier soft keyword) parse correctly — so the
+    // next pass's symbol table knows `f` is a value and can fix its call sites
+    // (`f(x);` mis-read as a declaration). Two passes suffice in practice.
+    for (int pass = 0; pass < 2; pass++) {
         ncc_symtab_t *prov_symtab = ncc_populate_symbols(g, tree);
 
         ncc_pwz_set_disambiguator(parser, ncc_disambig_eval, prov_symtab);
@@ -2274,6 +2282,12 @@ compile_file(ncc_opts_t *opts)
                             ncc_hash_cstring, ncc_dict_cstr_eq);
     ncc_dict_init(&xdata.gc_function_pointer_typedefs,
                             ncc_hash_cstring, ncc_dict_cstr_eq);
+    // Parent pointers let expression typing map an expression back to its
+    // lexical scope (scope_for_expr walks up to the enclosing scope node).
+    // Set before any ncc_type_of_expr use (nodiscard below, typehash/typeid/
+    // typestr xforms later); xform mutations keep them current via set_child.
+    ncc_xform_set_parent_pointers(tree);
+
     // Build the scoped symbol table for the type model. Runs after the typedef
     // reclassification walk so declarator names are settled.
     xdata.symtab = ncc_populate_symbols(g, tree);
@@ -2281,6 +2295,12 @@ compile_file(ncc_opts_t *opts)
     // Flow-sensitive null-state analysis: must run before transforms strip the
     // `?` nullable markers from the tree.
     ncc_nullability_check(g, tree, xdata.symtab);
+
+    // Must-check results: warn on a discarded result-protocol return value.
+    // Runs on the fully-structured pre-transform tree (like nullability);
+    // `_try`, which consumes a result, is still spelled `_try E` here and is
+    // skipped by the discard check.
+    ncc_nodiscard_check(g, tree, xdata.symtab);
 
     xctx.user_data = &xdata;
     ncc_verbose("applying transforms");

--- a/src/parse/symbol_populate.c
+++ b/src/parse/symbol_populate.c
@@ -214,6 +214,36 @@ add_named(ncc_symtab_t *st, ncc_string_t ns, ncc_token_info_t *name_tok,
     }
 }
 
+// The name token of a tag_name node, accepting either an IDENTIFIER or a
+// TYPEDEF_NAME leaf. A tag whose name coincides with a typedef of the same name
+// — C's ubiquitous `typedef struct X X;` — tokenizes the tag name as
+// TYPEDEF_NAME, which declared_name_tok (IDENTIFIER-only) would miss, leaving
+// the tag unrecorded and its members unresolvable.
+static ncc_token_info_t *
+tag_name_tok(ncc_parse_tree_t *node, int64_t id_tid)
+{
+    if (!node) {
+        return nullptr;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
+        if (tok
+            && (tok->tid == (int32_t)id_tid
+                || tok->tid == NCC_TOK_TYPEDEF_NAME)) {
+            return tok;
+        }
+        return nullptr;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_token_info_t *t = tag_name_tok(ncc_tree_child(node, i), id_tid);
+        if (t) {
+            return t;
+        }
+    }
+    return nullptr;
+}
+
 // Register a struct/union/enum tag (with body) found in a specifier subtree.
 static void
 record_tag(ncc_symtab_t *st, ncc_parse_tree_t *spec, int64_t id_tid)
@@ -222,7 +252,15 @@ record_tag(ncc_symtab_t *st, ncc_parse_tree_t *spec, int64_t id_tid)
     if (!tag) {
         return;
     }
-    ncc_token_info_t *tok = declared_name_tok(tag, id_tid);
+    // A _generic_struct's tag is a `typeid(...)` expression, not a simple name
+    // (e.g. n00b_list_t(T) is `typeid("n00b_list", T)`). Recording it here would
+    // grab the type argument T as the tag name and shadow T's real struct with
+    // the list's body. Its concrete minted tag is registered during
+    // generic_struct lowering, so skip it in this pass.
+    if (subtree_has_token(tag, "typeid")) {
+        return;
+    }
+    ncc_token_info_t *tok = tag_name_tok(tag, id_tid);
     add_named(st, ns_tag(), tok, NCC_SYM_TAG, spec, spec);
 }
 
@@ -354,14 +392,16 @@ scan_params(ncc_symtab_t *st, ncc_parse_tree_t *node, int64_t id_tid)
     }
 }
 
-// Record the parameters of a function declarator into the current scope.
+// Record the parameters of a function declarator into the current scope. The
+// parameter_type_list nests under direct_declarator/function_declarator (not a
+// direct child reachable by child_nt, which only traverses group wrappers), so
+// scan the whole declarator for parameter_declarations directly. scan_params
+// does not descend into a parameter's own nested declarators, so only this
+// function's parameters are recorded.
 static void
 record_parameters(ncc_symtab_t *st, ncc_parse_tree_t *declarator, int64_t id_tid)
 {
-    ncc_parse_tree_t *ptl = child_nt(declarator, "parameter_type_list");
-    if (ptl) {
-        scan_params(st, ptl, id_tid);
-    }
+    scan_params(st, declarator, id_tid);
 }
 
 // ============================================================================
@@ -375,10 +415,26 @@ walk(ncc_symtab_t *st, ncc_parse_tree_t *node, int64_t id_tid)
         return;
     }
 
+    // Bind a function definition's name in the ENCLOSING scope, before the body
+    // scope is pushed, so it stays resolvable after the body is popped — needed
+    // for call typing and for type-aware parse disambiguation of bare-call
+    // statements (`f(x);`) when the definition has no separate prototype.
+    if (nt_is(node, "function_definition")) {
+        ncc_parse_tree_t *fdeclr = child_nt(node, "declarator");
+        if (fdeclr) {
+            ncc_parse_tree_t *fspecs = child_nt(node, "declaration_specifiers");
+            ncc_token_info_t *fname  = declared_name_tok(fdeclr, id_tid);
+            add_named(st, ns_ord(), fname, NCC_SYM_FUNCTION, fdeclr, fspecs);
+        }
+    }
+
     bool pushed = false;
     if (nt_is(node, "function_definition") || nt_is(node, "compound_statement")) {
         ncc_symtab_push_scope(st, ns_ord(), ncc_string_empty());
         ncc_symtab_push_scope(st, ns_tag(), ncc_string_empty());
+        // Tag the value (ord) scope with its creating node so expression typing
+        // can map an expression back to this lexical scope after the walk.
+        ncc_symtab_set_scope_node(st, ns_ord(), node);
         pushed = true;
     }
 
@@ -393,10 +449,9 @@ walk(ncc_symtab_t *st, ncc_parse_tree_t *node, int64_t id_tid)
             record_specifier_tags(st, specs, id_tid);
         }
         if (declr) {
-            // The function name binds in the ENCLOSING scope, but recording it
-            // in the body scope still makes it resolvable while typing the
-            // body; the enclosing file-scope prototype (if any) also recorded
-            // it. Good enough for the type model's needs.
+            // Also bind the name in the body scope (it is already bound in the
+            // enclosing scope above) so it resolves while typing the body, e.g.
+            // recursive calls.
             ncc_token_info_t *name = declared_name_tok(declr, id_tid);
             add_named(st, ns_ord(), name, NCC_SYM_FUNCTION, declr, specs);
             record_parameters(st, declr, id_tid);

--- a/src/parse/symtab.c
+++ b/src/parse/symtab.c
@@ -69,24 +69,24 @@ ncc_symtab_free(ncc_symtab_t *st)
         return;
     }
 
+    // Scopes are retained (pop no longer frees), so free every scope and its
+    // entries via the retained list. Each entry belongs to exactly one scope's
+    // chain, so this frees each exactly once.
+    ncc_scope_t *scope = st->all_scopes;
+    while (scope) {
+        ncc_scope_t     *next_scope = scope->all_next;
+        ncc_sym_entry_t *entry      = scope->first_in_scope;
+        while (entry) {
+            ncc_sym_entry_t *next = entry->next_in_scope;
+            ncc_free(entry);
+            entry = next;
+        }
+        ncc_free(scope);
+        scope = next_scope;
+    }
+
     for (int32_t i = 0; i < st->ns_count; i++) {
         ncc_namespace_t *ns = &st->namespaces[i];
-
-        while (ns->current) {
-            ncc_scope_t *scope = ns->current;
-            ns->current         = scope->parent;
-
-            // Free entries in this scope.
-            ncc_sym_entry_t *entry = scope->first_in_scope;
-            while (entry) {
-                ncc_sym_entry_t *next = entry->next_in_scope;
-                ncc_free(entry);
-                entry = next;
-            }
-
-            ncc_free(scope);
-        }
-
         if (ns->symbols) {
             ncc_dict_free((ncc_dict_t *)ns->symbols);
             ncc_free(ns->symbols);
@@ -161,6 +161,12 @@ ncc_symtab_push_scope(ncc_symtab_t *st, ncc_string_t ns_name,
     scope->name   = scope_name;
     scope->depth  = ns->depth;
 
+    // Retain every pushed scope for the symtab's lifetime so the lexical scope
+    // tree survives population (pop no longer frees) and location-based scoped
+    // lookup can resolve locals/params after the walk.
+    scope->all_next = st->all_scopes;
+    st->all_scopes  = scope;
+
     ns->current = scope;
     ns->depth++;
 }
@@ -177,25 +183,24 @@ ncc_symtab_pop_scope(ncc_symtab_t *st, ncc_string_t ns_name)
     ncc_scope_t        *scope = ns->current;
     ncc_dict_t *ht    = (ncc_dict_t *)ns->symbols;
 
+    // Restore the hash table to the enclosing scope's view (so lookups during
+    // the rest of the walk stay correct), but DO NOT free the scope or its
+    // entries — they are retained (via all_scopes / first_in_scope chains) for
+    // post-walk scoped lookup and freed only in ncc_symtab_free.
     ncc_sym_entry_t *entry = scope->first_in_scope;
 
     while (entry) {
-        ncc_sym_entry_t *next = entry->next_in_scope;
-
         if (entry->shadowed) {
             ht_put(ht, entry->name, entry->shadowed);
         }
         else {
             ht_remove(ht, entry->name);
         }
-
-        ncc_free(entry);
-        entry = next;
+        entry = entry->next_in_scope;
     }
 
     ns->current = scope->parent;
     ns->depth--;
-    ncc_free(scope);
 }
 
 // ============================================================================
@@ -253,6 +258,48 @@ ncc_symtab_lookup(ncc_symtab_t *st, ncc_string_t ns_name,
     }
 
     return nullptr;
+}
+
+void
+ncc_symtab_set_scope_node(ncc_symtab_t *st, ncc_string_t ns_name,
+                          ncc_parse_tree_t *node)
+{
+    ncc_namespace_t *ns = ncc_symtab_ns(st, ns_name);
+    if (ns && ns->current) {
+        ns->current->node = node;
+    }
+}
+
+ncc_scope_t *
+ncc_symtab_scope_for_node(ncc_symtab_t *st, ncc_parse_tree_t *node)
+{
+    if (!st || !node) {
+        return nullptr;
+    }
+    for (ncc_scope_t *s = st->all_scopes; s; s = s->all_next) {
+        if (s->node == node) {
+            return s;
+        }
+    }
+    return nullptr;
+}
+
+ncc_sym_entry_t *
+ncc_symtab_lookup_scoped(ncc_symtab_t *st, ncc_scope_t *scope,
+                         ncc_string_t ns_name, ncc_string_t name)
+{
+    // Walk the lexical scope chain (innermost first). Globals live in the
+    // retained file-scope scope at the top of the chain, so this covers locals,
+    // parameters, and globals with correct shadowing.
+    for (ncc_scope_t *s = scope; s; s = s->parent) {
+        for (ncc_sym_entry_t *e = s->first_in_scope; e; e = e->next_in_scope) {
+            if (ncc_string_eq(e->name, name)) {
+                return e;
+            }
+        }
+    }
+    // No enclosing scope (or not found): fall back to a plain global lookup.
+    return ncc_symtab_lookup(st, ns_name, name);
 }
 
 bool

--- a/src/parse/type_infer.c
+++ b/src/parse/type_infer.c
@@ -313,6 +313,50 @@ find_descendant_nt(ncc_parse_tree_t *node, const char *name)
     return nullptr;
 }
 
+// True if a leaf with the exact text `text` exists anywhere under `node`.
+static bool
+subtree_has_leaf_text(ncc_parse_tree_t *node, const char *text)
+{
+    if (!node) {
+        return false;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        ncc_string_t t = leaf_text(node);
+        return t.data && strcmp(t.data, text) == 0;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        if (subtree_has_leaf_text(ncc_tree_child(node, i), text)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// `auto x = e;` (C23 type inference): an `auto` storage class with no explicit
+// type specifier — the declared type is the initializer's type.
+static bool
+specs_are_auto(ncc_parse_tree_t *specs)
+{
+    return specs && !find_descendant_nt(specs, "type_specifier")
+        && subtree_has_leaf_text(specs, "auto");
+}
+
+// The initializer expression of declarator `declr`: walk up to the enclosing
+// init_declarator and take its <initializer>, or nullptr.
+static ncc_parse_tree_t *
+declarator_initializer(ncc_parse_tree_t *declr)
+{
+    ncc_parse_tree_t *p = declr;
+    while (p && !ncc_tree_is_leaf(p)) {
+        if (nt_is(p, "init_declarator")) {
+            return child_nt(p, "initializer");
+        }
+        p = ncc_tree_node_value(p).parent;
+    }
+    return nullptr;
+}
+
 // Text of the first IDENTIFIER/TYPEDEF_NAME leaf at or under `node`.
 static ncc_string_t
 identifier_text(ncc_parse_tree_t *node)
@@ -497,6 +541,15 @@ ncc_disambig_eval(void *ud, const char *predicate, ncc_token_info_t *tok)
         return sym->kind == NCC_SYM_TYPEDEF;
     }
 
+    // Any declared symbol at all. A real function specifier (inline / _Noreturn
+    // / _Once) is a keyword, never a declared name — so when the function-
+    // specifier soft-keyword alt matches a known identifier, that reading is
+    // wrong (e.g. `plain(5);` mis-read as a declaration with `plain` a
+    // specifier, or `static box_t f()` with `box_t` a specifier).
+    if (strcmp(predicate, "id_is_known") == 0) {
+        return true; // reached only when lookup found a symbol
+    }
+
     return false;
 }
 
@@ -562,21 +615,60 @@ type_of_member(ncc_parse_tree_t *spec, ncc_string_t name)
 // Expression typing
 // ============================================================================
 
-char *
-ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
+// Ambient lexical scope for the in-progress expression typing: resolved once
+// from the (non-leaf) expression node handed to the public ncc_type_of_expr and
+// read by identifier/callee lookups in the recursive worker. Leaf nodes carry
+// no parent pointer, so the scope cannot be re-derived mid-recursion; threading
+// it as an ambient value keeps the worker's signature and call sites untouched.
+static ncc_scope_t *s_type_scope = nullptr;
+
+// The retained lexical scope enclosing expression node `expr`: walk up parent
+// pointers to the nearest scope-creating node the symbol table tagged.
+static ncc_scope_t *
+scope_for_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
+{
+    ncc_parse_tree_t *cur = expr;
+    while (cur && !ncc_tree_is_leaf(cur)) {
+        ncc_scope_t *s = ncc_symtab_scope_for_node(st, cur);
+        if (s) {
+            return s;
+        }
+        cur = ncc_tree_node_value(cur).parent;
+    }
+    return nullptr;
+}
+
+static char *
+type_of_expr_inner(ncc_symtab_t *st, ncc_parse_tree_t *expr)
 {
     if (!st || !expr) {
         return nullptr;
     }
 
-    // Identifier leaf -> variable/param/function lookup.
+    // Identifier leaf -> variable/param/function lookup, resolved in the
+    // expression's lexical scope (locals + params + globals with shadowing).
     if (ncc_tree_is_leaf(expr)) {
         ncc_token_info_t *tok = ncc_tree_leaf_value(expr);
         if (tok && tok->tid == NCC_TOK_IDENTIFIER) {
             ncc_string_t     name = leaf_text(expr);
-            ncc_sym_entry_t *sym  = ncc_symtab_lookup(st, ncc_string_empty(),
-                                                      name);
+            ncc_sym_entry_t *sym  = ncc_symtab_lookup_scoped(
+                st, s_type_scope, ncc_string_empty(), name);
             if (sym) {
+                // `auto v = init;` — infer v's type from its initializer (typed
+                // in v's scope, the current ambient scope). Bounded to avoid a
+                // pathological auto cycle.
+                if (specs_are_auto(sym->type_node)) {
+                    static int auto_depth = 0;
+                    ncc_parse_tree_t *init =
+                        declarator_initializer(sym->decl_node);
+                    if (!init || auto_depth > 32) {
+                        return nullptr;
+                    }
+                    auto_depth++;
+                    char *r = type_of_expr_inner(st, init);
+                    auto_depth--;
+                    return r;
+                }
                 return type_of_symbol(sym);
             }
         }
@@ -587,7 +679,7 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
     if (is_group(expr)) {
         ncc_parse_tree_t *only = nullptr;
         meaningful_children(expr, &only);
-        return only ? ncc_type_of_expr(st, only) : nullptr;
+        return only ? type_of_expr_inner(st, only) : nullptr;
     }
 
     // cast: ( type_name ) cast_expression  ->  the cast type.
@@ -603,12 +695,12 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
     if (nt_is(expr, "primary_expression")) {
         ncc_parse_tree_t *inner = child_nt(expr, "expression");
         if (inner) {
-            return ncc_type_of_expr(st, inner);
+            return type_of_expr_inner(st, inner);
         }
         // identifier directly under primary_expression.
         ncc_parse_tree_t *id = child_nt(expr, "identifier");
         if (id) {
-            return ncc_type_of_expr(st, id);
+            return type_of_expr_inner(st, id);
         }
     }
 
@@ -617,7 +709,7 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
         ncc_parse_tree_t *only = nullptr;
         meaningful_children(expr, &only);
         if (only) {
-            return ncc_type_of_expr(st, only);
+            return type_of_expr_inner(st, only);
         }
     }
 
@@ -637,11 +729,11 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
             }
             opc = leaf_text(opnode);
             if (opc.data && strcmp(opc.data, "&") == 0) {
-                char *inner = ncc_type_of_expr(st, rhs);
+                char *inner = type_of_expr_inner(st, rhs);
                 return append_stars(inner, 1);
             }
             if (opc.data && strcmp(opc.data, "*") == 0) {
-                char *inner = ncc_type_of_expr(st, rhs);
+                char *inner = type_of_expr_inner(st, rhs);
                 return strip_one_star(inner);
             }
             return nullptr; // other unary operators not typed yet
@@ -701,7 +793,7 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
         }
 
         if ((arrow || dot) && base && mem) {
-            char *bt = ncc_type_of_expr(st, base);
+            char *bt = type_of_expr_inner(st, base);
             if (arrow) {
                 bt = strip_one_star(bt); // p->m : deref then member
             }
@@ -717,12 +809,12 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
         }
         if (sub && base) {
             // a[i] : element type of a pointer (array decay handled as pointer).
-            return strip_one_star(ncc_type_of_expr(st, base));
+            return strip_one_star(type_of_expr_inner(st, base));
         }
         if (call && base) {
             ncc_string_t     fn  = identifier_text(base);
-            ncc_sym_entry_t *sym = fn.data ? ncc_symtab_lookup(
-                                       st, ncc_string_empty(), fn)
+            ncc_sym_entry_t *sym = fn.data ? ncc_symtab_lookup_scoped(
+                                       st, s_type_scope, ncc_string_empty(), fn)
                                            : nullptr;
             if (sym && sym->kind == NCC_SYM_FUNCTION && sym->type_node) {
                 char *b = canonical_base(sym->type_node, fn);
@@ -737,9 +829,25 @@ ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
     {
         ncc_parse_tree_t *only = nullptr;
         if (meaningful_children(expr, &only) == 1 && only) {
-            return ncc_type_of_expr(st, only);
+            return type_of_expr_inner(st, only);
         }
     }
 
     return nullptr; // calls, subscripts, arithmetic: TODO
+}
+
+char *
+ncc_type_of_expr(ncc_symtab_t *st, ncc_parse_tree_t *expr)
+{
+    if (!st || !expr) {
+        return nullptr;
+    }
+    // Resolve the expression's lexical scope once (locals/params are only
+    // resolvable here, not from leaf nodes mid-recursion), then thread it via
+    // the ambient s_type_scope. Save/restore makes nested resolutions safe.
+    ncc_scope_t *saved = s_type_scope;
+    s_type_scope       = scope_for_expr(st, expr);
+    char *result       = type_of_expr_inner(st, expr);
+    s_type_scope       = saved;
+    return result;
 }

--- a/src/xform/nodiscard.c
+++ b/src/xform/nodiscard.c
@@ -1,0 +1,293 @@
+// nodiscard.c — must-check result returns ([[nodiscard]] for result types).
+//
+// A function returning a result-protocol aggregate (one with both an `is_ok`
+// and an `err` member — n00b_result_t(T)) advertises a value the caller must
+// inspect. Calling it as a bare expression statement (`f(x);`) discards the
+// result, dropping the error. This pass reports that; the opt-out is an
+// explicit void cast (`(void)f(x);`).
+//
+// Read-only: emits warnings, never transforms the tree. Runs after transforms,
+// so `_generic_struct` result types are lowered to concrete `struct __<tag>`
+// resolvable through the (rebuilt) symbol table, and `_try` — which consumes a
+// result — is already lowered to a statement expression rather than a call.
+
+#include "lib/alloc.h"
+#include "parse/nodiscard.h"
+#include "parse/parse_tree.h"
+#include "parse/type_infer.h"
+#include "xform/xform_helpers.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static bool
+is_ident_text(const char *t)
+{
+    if (!t || !((t[0] >= 'a' && t[0] <= 'z') || (t[0] >= 'A' && t[0] <= 'Z')
+                || t[0] == '_')) {
+        return false;
+    }
+    for (const char *p = t; *p; p++) {
+        if (!((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z')
+              || (*p >= '0' && *p <= '9') || *p == '_')) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// The last identifier-form leaf token in a subtree. A member's declared name is
+// the last identifier before its `;` regardless of whether the name parsed as a
+// declarator or got mis-read as a typedef-name type specifier (the soft
+// identifier ambiguity), so this is robust to that mis-parse.
+static void
+last_ident(ncc_parse_tree_t *n, const char **out)
+{
+    if (!n) {
+        return;
+    }
+    if (ncc_tree_is_leaf(n)) {
+        const char *t = ncc_xform_leaf_text(n);
+        if (is_ident_text(t)) {
+            *out = t;
+        }
+        return;
+    }
+    size_t nc = ncc_tree_num_children(n);
+    for (size_t i = 0; i < nc; i++) {
+        last_ident(ncc_tree_child(n, i), out);
+    }
+}
+
+// Does this aggregate specifier carry the result protocol: a member named
+// `is_ok` and a member named `err`? Scans only the aggregate's own members (it
+// does not descend into a nested aggregate, whose members are not ours).
+static void
+scan_result_members(ncc_parse_tree_t *n, bool top, bool *has_is_ok,
+                    bool *has_err)
+{
+    if (!n || ncc_tree_is_leaf(n)) {
+        return;
+    }
+    if (!top
+        && (ncc_xform_nt_name_is(n, "struct_or_union_specifier")
+            || ncc_xform_nt_name_is(n, "enum_specifier"))) {
+        return; // a nested aggregate's members are not this type's members
+    }
+    if (ncc_xform_nt_name_is(n, "member_declaration")) {
+        const char *name = nullptr;
+        last_ident(n, &name);
+        if (name) {
+            if (strcmp(name, "is_ok") == 0) {
+                *has_is_ok = true;
+            }
+            else if (strcmp(name, "err") == 0) {
+                *has_err = true;
+            }
+        }
+        return; // one member line — its type body (if any) is not our protocol
+    }
+    size_t nc = ncc_tree_num_children(n);
+    for (size_t i = 0; i < nc; i++) {
+        scan_result_members(ncc_tree_child(n, i), false, has_is_ok, has_err);
+    }
+}
+
+static bool
+is_result_spec(ncc_parse_tree_t *spec)
+{
+    bool has_is_ok = false;
+    bool has_err   = false;
+    scan_result_members(spec, true, &has_is_ok, &has_err);
+    return has_is_ok && has_err;
+}
+
+// First struct/union specifier in a subtree (e.g. an inline `_generic_struct`
+// return type carried in a function's declaration_specifiers).
+static ncc_parse_tree_t *
+find_struct_spec(ncc_parse_tree_t *n)
+{
+    if (!n || ncc_tree_is_leaf(n)) {
+        return nullptr;
+    }
+    if (ncc_xform_nt_name_is(n, "struct_or_union_specifier")) {
+        return n;
+    }
+    size_t nc = ncc_tree_num_children(n);
+    for (size_t i = 0; i < nc; i++) {
+        ncc_parse_tree_t *r = find_struct_spec(ncc_tree_child(n, i));
+        if (r) {
+            return r;
+        }
+    }
+    return nullptr;
+}
+
+// Descend through single-meaningful-child wrappers until a node that branches
+// or is a postfix expression (a call/deref/subscript) — or a try_expression,
+// which consumes the result it is applied to.
+static ncc_parse_tree_t *
+unwrap(ncc_parse_tree_t *n)
+{
+    while (n && !ncc_tree_is_leaf(n)) {
+        if (ncc_xform_nt_name_is(n, "postfix_expression")
+            || ncc_xform_nt_name_is(n, "try_expression")) {
+            break;
+        }
+        ncc_parse_tree_t *only  = nullptr;
+        int               count = 0;
+        size_t            nc     = ncc_tree_num_children(n);
+        for (size_t i = 0; i < nc; i++) {
+            ncc_parse_tree_t *c = ncc_tree_child(n, i);
+            if (c && !ncc_tree_is_leaf(c)) {
+                count++;
+                only = c;
+            }
+        }
+        if (count == 1) {
+            n = only;
+            continue;
+        }
+        break;
+    }
+    return n;
+}
+
+// The lone identifier a node reduces to (a callee name), or nullptr.
+static char *
+callee_name(ncc_parse_tree_t *n)
+{
+    ncc_string_t t = ncc_xform_node_to_text(n);
+    if (!t.data) {
+        return nullptr;
+    }
+    const char *s = t.data;
+    while (*s == ' ') {
+        s++;
+    }
+    size_t len = strlen(s);
+    while (len > 0 && s[len - 1] == ' ') {
+        len--;
+    }
+    bool ident = len > 0 && (((s[0] >= 'a' && s[0] <= 'z')
+                              || (s[0] >= 'A' && s[0] <= 'Z') || s[0] == '_'));
+    for (size_t i = 0; ident && i < len; i++) {
+        char c = s[i];
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+              || (c >= '0' && c <= '9') || c == '_')) {
+            ident = false;
+        }
+    }
+    char *r = nullptr;
+    if (ident) {
+        r = ncc_alloc_array(char, len + 1);
+        memcpy(r, s, len);
+        r[len] = '\0';
+    }
+    ncc_free(t.data);
+    return r;
+}
+
+// The result-protocol aggregate a call returns by value, or nullptr. A pointer
+// return is not a by-value result (you may legitimately hold the pointer).
+static ncc_parse_tree_t *
+call_result_spec(ncc_symtab_t *st, ncc_parse_tree_t *call)
+{
+    char *rt       = ncc_type_of_expr(st, call);
+    bool  has_star = rt && strchr(rt, '*') != nullptr;
+    // A typedef'd / named result resolves through the symbol table.
+    ncc_parse_tree_t *spec = (rt && !has_star)
+                                 ? ncc_symtab_aggregate_spec(st, rt)
+                                 : nullptr;
+    if (rt) {
+        ncc_free(rt);
+    }
+    if (has_star) {
+        return nullptr;
+    }
+    if (spec) {
+        return spec;
+    }
+    // Inline `_generic_struct` / struct return: the spelling isn't a resolvable
+    // type name, so scan the callee's stored return-type specifiers directly.
+    char *callee = callee_name(ncc_tree_child(call, 0));
+    if (!callee) {
+        return nullptr;
+    }
+    ncc_sym_entry_t *sym = ncc_symtab_lookup(st, ncc_string_empty(),
+                                             ncc_string_from_cstr(callee));
+    ncc_free(callee);
+    if (sym && sym->kind == NCC_SYM_FUNCTION && sym->type_node) {
+        return find_struct_spec(sym->type_node);
+    }
+    return nullptr;
+}
+
+static void
+check_stmt(ncc_symtab_t *st, ncc_parse_tree_t *n, int *warnings)
+{
+    if (!n || ncc_tree_is_leaf(n)) {
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(n, "expression_statement")) {
+        // The statement's expression is its first non-leaf, non-attribute child.
+        ncc_parse_tree_t *expr = nullptr;
+        size_t            nc   = ncc_tree_num_children(n);
+        for (size_t i = 0; i < nc; i++) {
+            ncc_parse_tree_t *c = ncc_tree_child(n, i);
+            if (c && !ncc_tree_is_leaf(c)
+                && !ncc_xform_nt_name_is(c, "attribute_specifier_sequence")) {
+                expr = c;
+                break;
+            }
+        }
+
+        ncc_parse_tree_t *u = expr ? unwrap(expr) : nullptr;
+        // A discarded result requires a bare call: `f(...)` as the whole
+        // statement. `(void)f()` unwraps to a cast_expression (not a call) and
+        // is the intended opt-out; `x = f()` to an assignment; `_try f()` to a
+        // try_expression — none of which warn.
+        if (u && ncc_xform_nt_name_is(u, "postfix_expression")
+            && ncc_tree_num_children(u) >= 2) {
+            ncc_parse_tree_t *opn = ncc_tree_child(u, 1);
+            if (opn && ncc_tree_is_leaf(opn)
+                && ncc_xform_leaf_text_eq(opn, "(")) {
+                ncc_parse_tree_t *spec = call_result_spec(st, u);
+                if (spec && is_result_spec(spec)) {
+                    char    *callee = callee_name(ncc_tree_child(u, 0));
+                    uint32_t line   = 0;
+                    uint32_t col    = 0;
+                    ncc_xform_first_leaf_pos(u, &line, &col);
+                    fprintf(stderr,
+                            "ncc: warning: result of '%s()' is ignored; a "
+                            "result must be checked (cast to (void) to "
+                            "discard) (line %u, col %u)\n",
+                            callee ? callee : "call", line, col);
+                    (*warnings)++;
+                    if (callee) {
+                        ncc_free(callee);
+                    }
+                }
+            }
+        }
+        return; // no nested statements inside an expression statement
+    }
+
+    size_t nc = ncc_tree_num_children(n);
+    for (size_t i = 0; i < nc; i++) {
+        check_stmt(st, ncc_tree_child(n, i), warnings);
+    }
+}
+
+int
+ncc_nodiscard_check(ncc_grammar_t *g, ncc_parse_tree_t *tu, ncc_symtab_t *st)
+{
+    (void)g;
+    if (!tu || !st) {
+        return 0;
+    }
+    int warnings = 0;
+    check_stmt(st, tu, &warnings);
+    return warnings;
+}

--- a/src/xform/xform_gc_typemap.c
+++ b/src/xform/xform_gc_typemap.c
@@ -881,13 +881,21 @@ walk_struct_member(ncc_xform_ctx_t *ctx, const char *elem_type,
             }
         }
         else {
-            // No '*' in the declarator, but the SPECS may still make this a
-            // pointer: a pointer typedef, or an _Atomic(T *) wrapper. Detect
-            // that before treating it as a nested by-value aggregate —
-            // otherwise we would emit an offsetof THROUGH a pointer.
-            int ptr_specs = ncc_layout_pointer_depth_for_specs(ctx,
-                                                               member_specs);
-            if (ptr_specs > 0) {
+            // No '*' in the declarator. An INLINE struct/union/_generic_struct
+            // is a by-value aggregate member — recurse into it. This must come
+            // before the pointer-typedef test below: pointer_depth_for_specs
+            // sees pointer MEMBERS in the inline body (e.g. an inline
+            // n00b_list_t's `T *data`) and would wrongly classify the whole
+            // by-value member as a pointer.
+            ncc_parse_tree_t *nspec = ncc_layout_aggregate_spec_from_specs(
+                ctx, member_specs);
+            if (nspec) {
+                gc_walk(ctx, elem_type, nspec, path, offs, asserts, count,
+                        vacc, ok, depth + 1);
+            }
+            else if (ncc_layout_pointer_depth_for_specs(ctx, member_specs) > 0) {
+                // No inline aggregate, but the SPECS still make this a pointer:
+                // a pointer typedef or an _Atomic(T *) wrapper.
                 char *tdname = ncc_layout_first_typedef_name_text(member_specs);
                 bool  is_fnptr = tdname
                               && ncc_layout_typedef_name_is_function_pointer(
@@ -900,15 +908,7 @@ walk_struct_member(ncc_xform_ctx_t *ctx, const char *elem_type,
                 }
                 // function pointer -> excluded (code, not a heap pointer)
             }
-            else {
-                ncc_parse_tree_t *nspec = ncc_layout_aggregate_spec_from_specs(
-                    ctx, member_specs);
-                if (nspec) {
-                    gc_walk(ctx, elem_type, nspec, path, offs, asserts, count,
-                            vacc, ok, depth + 1);
-                }
-                // else: scalar by-value member -> no pointer words.
-            }
+            // else: scalar by-value member -> no pointer words.
         }
 
         ncc_free(path);

--- a/src/xform/xform_helpers.c
+++ b/src/xform/xform_helpers.c
@@ -681,6 +681,50 @@ ncc_string_t ncc_xform_extract_type_string(ncc_xform_ctx_t *ctx,
 // Typed argument resolution (typehash / typeid / typestr of expressions)
 // ============================================================================
 
+// Find the first descendant nonterminal named `name` (preorder), or nullptr.
+static ncc_parse_tree_t *find_descendant_nt(ncc_parse_tree_t *n,
+                                            const char *name) {
+  if (!n || ncc_tree_is_leaf(n)) {
+    return nullptr;
+  }
+  if (ncc_xform_nt_name_is(n, name)) {
+    return n;
+  }
+  size_t nc = ncc_tree_num_children(n);
+  for (size_t i = 0; i < nc; i++) {
+    ncc_parse_tree_t *r = find_descendant_nt(ncc_tree_child(n, i), name);
+    if (r) {
+      return r;
+    }
+  }
+  return nullptr;
+}
+
+// Count the pointer levels an abstract_declarator adds (each `*`). Sets
+// `*simple` false if the declarator is anything other than plain pointers
+// (array / function declarator), so the caller can bail rather than guess.
+static int abstract_declarator_pointer_count(ncc_parse_tree_t *ad,
+                                             bool *simple) {
+  int count = 0;
+  if (!ad) {
+    return 0;
+  }
+  if (ncc_tree_is_leaf(ad)) {
+    const char *t = ncc_xform_leaf_text(ad);
+    if (t && strcmp(t, "*") == 0) {
+      count++;
+    } else if (t && (strcmp(t, "[") == 0 || strcmp(t, "(") == 0)) {
+      *simple = false; // array / function declarator: not a plain pointer
+    }
+    return count;
+  }
+  size_t nc = ncc_tree_num_children(ad);
+  for (size_t i = 0; i < nc; i++) {
+    count += abstract_declarator_pointer_count(ncc_tree_child(ad, i), simple);
+  }
+  return count;
+}
+
 char *
 ncc_xform_expr_arg_type(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *atom,
                         ncc_parse_tree_t *cont) {
@@ -707,5 +751,49 @@ ncc_xform_expr_arg_type(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *atom,
     return ncc_type_of_expr(st, expr);
   }
 
-  return nullptr;
+  // An explicit `typeof(<expr>)` written as the type argument, possibly with a
+  // trailing pointer abstract_declarator: `typehash(typeof(*p))`,
+  // `typehash(typeof(*p) *)`. The argument parses as a <type_name> whose type
+  // specifier is a <typeof_specifier>; resolve that expression via the type
+  // model and re-apply the abstract_declarator's pointers, so the result hashes
+  // identically to the spelled-out element type. (typeof(<type>) — no inner
+  // expression — is left to literal normalization.)
+  ncc_parse_tree_t *tn = ncc_xform_find_child_nt(tsa, "type_name");
+  if (!tn) {
+    return nullptr;
+  }
+  ncc_parse_tree_t *tspec = find_descendant_nt(tn, "typeof_specifier");
+  if (!tspec) {
+    return nullptr;
+  }
+  ncc_parse_tree_t *inner_tsa =
+      ncc_xform_find_child_nt(tspec, "typeof_specifier_argument");
+  ncc_parse_tree_t *inner_expr =
+      inner_tsa ? ncc_xform_find_child_nt(inner_tsa, "expression") : nullptr;
+  if (!inner_expr) {
+    return nullptr; // typeof(<type>) — not an expression
+  }
+  char *base = ncc_type_of_expr(st, inner_expr);
+  if (!base) {
+    return nullptr;
+  }
+
+  ncc_parse_tree_t *ad = ncc_xform_find_child_nt(tn, "abstract_declarator");
+  bool              simple = true;
+  int               ptrs   = abstract_declarator_pointer_count(ad, &simple);
+  if (!simple) {
+    ncc_free(base); // unusual declarator (array/function): leave to fallback
+    return nullptr;
+  }
+  if (ptrs == 0) {
+    return base;
+  }
+
+  ncc_buffer_t *buf = ncc_buffer_empty();
+  ncc_buffer_puts(buf, base);
+  for (int i = 0; i < ptrs; i++) {
+    ncc_buffer_putc(buf, '*');
+  }
+  ncc_free(base);
+  return ncc_buffer_take(buf);
 }

--- a/src/xform/xform_type_layout.c
+++ b/src/xform/xform_type_layout.c
@@ -963,14 +963,29 @@ ncc_parse_tree_t *
 ncc_layout_aggregate_spec_from_specs(ncc_xform_ctx_t *ctx,
                                      ncc_parse_tree_t *specs)
 {
-    if (ncc_layout_pointer_depth_for_specs(ctx, specs) > 0) {
+    // An `_Atomic(T *)` member is a POINTER (the `*` is in the atomic wrapper,
+    // outside any aggregate body), not a by-value aggregate — even though its
+    // specs contain T's struct specifier. Reject it here so the caller emits a
+    // pointer rather than recursing and emitting offsetof through the pointer.
+    if (atomic_type_specifier_is_pointer(specs)) {
         return nullptr;
     }
 
+    // An INLINE struct/union/_generic_struct specifier is a by-value aggregate;
+    // resolve it directly. This must come BEFORE the pointer test:
+    // pointer_depth_for_specs sees pointer MEMBERS in the inline body (e.g. the
+    // `T *data` of an inline n00b_list_t) and would wrongly report depth > 0,
+    // dropping the aggregate. A member that is genuinely a pointer carries its
+    // `*` in the declarator (handled by the caller), not in these specifiers,
+    // and a pointer typedef has no inline specifier (the typedef path below).
     ncc_parse_tree_t *su = ncc_layout_first_descendant_nt(
         specs, "struct_or_union_specifier");
     if (su) {
         return ncc_layout_resolve_aggregate_specifier(ctx, su);
+    }
+
+    if (ncc_layout_pointer_depth_for_specs(ctx, specs) > 0) {
+        return nullptr;
     }
 
     char *td_name = ncc_layout_first_typedef_name_text(specs);

--- a/test/test_nodiscard_ok.c
+++ b/test/test_nodiscard_ok.c
@@ -1,0 +1,38 @@
+// test_nodiscard_ok.c — result returns that ARE handled must not warn. Covers
+// every consuming context plus the `(void)` opt-out and a non-result call, so a
+// false positive in the must-check pass turns the "is ignored" diagnostic on
+// and fails the test (preprocess_stderr_omits).
+
+#define RES(T) _generic_struct typeid("result", T) { int is_ok; T ok; int err; }
+
+static RES(int)
+mk(int v)
+{
+    return (RES(int)){.is_ok = 1, .ok = v, .err = 0};
+}
+
+static int
+plain(int v)
+{
+    return v;
+}
+
+static RES(int)
+via_try(void)
+{
+    int v = _try mk(7); // consumed by _try (checks + unwraps)
+    return mk(v);
+}
+
+int
+main(void)
+{
+    (void)mk(1);            // explicit opt-out
+    RES(int) r = mk(2);     // consumed: declaration initializer
+    plain(4);               // not a result type — never must-check
+    r = mk(5);              // consumed: assignment
+    if (mk(6).is_ok) {      // consumed: member access
+    }
+    RES(int) t = via_try(); // consumed
+    return (r.is_ok && t.is_ok) ? 0 : 1;
+}

--- a/test/test_nodiscard_warn.c
+++ b/test/test_nodiscard_warn.c
@@ -1,0 +1,18 @@
+// test_nodiscard_warn.c — a discarded result-protocol return is flagged.
+// `mk` returns a result-shaped aggregate (is_ok / ok / err); calling it as a
+// bare statement drops the result, so the must-check pass must warn.
+
+#define RES(T) _generic_struct typeid("result", T) { int is_ok; T ok; int err; }
+
+static RES(int)
+mk(int v)
+{
+    return (RES(int)){.is_ok = 1, .ok = v, .err = 0};
+}
+
+int
+main(void)
+{
+    mk(1); // WARN: result of 'mk()' is ignored
+    return 0;
+}

--- a/test/test_typehash_autotag.c
+++ b/test/test_typehash_autotag.c
@@ -1,0 +1,46 @@
+// test_typehash_autotag.c — expression typing must handle two real-world C
+// patterns the type model previously missed:
+//
+//   1. `auto v = init;` — infer v's type from its initializer.
+//   2. `typedef struct X X;` — a tag whose name coincides with a typedef of the
+//      same name (ubiquitous in C / n00b). The tag name tokenizes as a
+//      TYPEDEF_NAME, so it must still be recorded so members resolve.
+//
+// Both are required for typeof(*p)/typehash through the standard n00b container
+// macros (which bind `auto _lp = &(list)` and use same-name typedef'd structs).
+// Non-pointer result types keep the run standalone.
+
+typedef struct atn_node atn_node;   // same-name typedef (tag == typedef)
+struct atn_node {
+    int       v;
+    long      w;
+    atn_node *next;
+};
+
+static int
+use(atn_node *p)
+{
+    int ok = 1;
+
+    // auto var inferred from a parameter pointer.
+    auto q = p;
+    ok &= (typehash(q->v) == typehash(int));
+    ok &= (typehash(q->w) == typehash(long));
+
+    // auto var inferred from a member-access expression.
+    auto m = p->v;
+    ok &= (typehash(m) == typehash(int));
+
+    // typeof through the same-name-typedef tag.
+    ok &= (typehash(typeof(*p)) == typehash(atn_node));
+    ok &= (__builtin_strcmp(typestr(typeof(p->w)), typestr(long)) == 0);
+
+    return ok;
+}
+
+int
+main(void)
+{
+    atn_node n = {.v = 1, .w = 2, .next = (void *)0};
+    return use(&n) ? 0 : 1;
+}

--- a/test/test_typehash_scoped.c
+++ b/test/test_typehash_scoped.c
@@ -1,0 +1,60 @@
+// test_typehash_scoped.c — expression typing must resolve LOCALS and PARAMETERS
+// (and typeof of expressions built from them), not just file-scope globals.
+//
+// Regression for the scope-aware typing fix: parameters were never recorded
+// (the parameter_type_list nests below the declarator, missed by a group-only
+// child search) and nested scopes were freed on pop with root-only lookup, so
+// any typehash/typeid/typestr/typeof of a local- or param-based expression
+// silently hashed the identifier TEXT instead of the type. Non-pointer result
+// types keep the run standalone (a pointer typehash pulls in runtime GC types).
+
+typedef struct tps_point {
+    int  x;
+    long y;
+} tps_point_t;
+
+typedef struct tps_box {
+    tps_point_t *p;
+    int          n;
+} tps_box_t;
+
+static int
+use_param(tps_point_t pt, tps_box_t *bx)
+{
+    int        ok = 1;
+    tps_point_t lp;     // local
+    tps_box_t  *lb = bx; // local pointer
+
+    // Parameter resolves to its declared type.
+    ok &= (typehash(pt) == typehash(tps_point_t));
+    ok &= (typehash(pt.x) == typehash(int));
+    ok &= (typehash(pt.y) == typehash(long));
+
+    // Local resolves likewise.
+    ok &= (typehash(lp) == typehash(tps_point_t));
+    ok &= (typehash(lp.y) == typehash(long));
+
+    // Parameter pointer: member access through it.
+    ok &= (typehash(bx->n) == typehash(int));
+    ok &= (typehash(lb->n) == typehash(int));
+
+    // typeof of an expression built from a parameter/local — the element type
+    // recovered from a data pointer, as the generic containers will do.
+    ok &= (typehash(typeof(*bx->p)) == typehash(tps_point_t));
+    ok &= (typehash(typeof((*bx->p).y)) == typehash(long));
+
+    // typestr spells the resolved type identically to the written type.
+    ok &= (__builtin_strcmp(typestr(lp), typestr(tps_point_t)) == 0);
+    ok &= (__builtin_strcmp(typestr(typeof(*bx->p)), typestr(tps_point_t)) == 0);
+
+    return ok;
+}
+
+int
+main(void)
+{
+    tps_point_t pt = {.x = 1, .y = 2};
+    tps_point_t pp = {.x = 3, .y = 4};
+    tps_box_t   bx = {.p = &pp, .n = 5};
+    return use_param(pt, &bx) ? 0 : 1;
+}


### PR DESCRIPTION
## What

Two related front-end improvements, net-new to `main` (#32):

- **Scope-aware expression typing.** `type_infer.c` / `symtab.c` / `symbol_populate.c` resolve expression types against the lexical scope (typehash auto-tagging, scoped typehash resolution).
- **Must-check / `[[nodiscard]]` result returns.** New `src/xform/nodiscard.c` (+ `include/parse/nodiscard.h`) flags ignored results that must be checked, emitting a diagnostic (cast to `(void)` to discard).

This is the commit that previously lived on top of the merged `ncc-qol` branch (#31) but never shipped; it is rebased cleanly onto current `main`.

## Tests

- New: `test_nodiscard_ok`, `test_nodiscard_warn`, `test_typehash_autotag`, `test_typehash_scoped`.
- Full ncc suite: **269/269 OK, 0 Fail**; clean build.
- Exercised downstream: building libn00b with this ncc surfaces a real unchecked-result (`n00b_conduit_service_start()`), confirming the must-check pass fires on production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)