### PR TITLE
ncc: concatenate adjacent r""/b"" literals like a single literal

### DIFF
--- a/src/ncc.c
+++ b/src/ncc.c
@@ -1177,38 +1177,58 @@ ncc_literal_prescan(char *src, size_t len, size_t *out_len)
             if ((src[i] == 'r' || src[i] == 'b')
                 && i + 1 < len && src[i + 1] == '"') {
                 if (i == 0 || !is_id_char(src[i - 1])) {
-                    const char *callee = src[i] == 'r'
-                                       ? "__ncc_rstr("
-                                       : "__ncc_buflit(";
-                    // Flush everything before the 'r'.
+                    char        prefix_ch = src[i]; // 'r' or 'b'
+                    const char *callee    = prefix_ch == 'r'
+                                              ? "__ncc_rstr("
+                                              : "__ncc_buflit(";
+                    // Flush everything before the prefix char.
                     if (i > flush_from) {
                         ncc_buffer_append(buf, src + flush_from, i - flush_from);
                     }
                     // Emit the internal call instead of the prefix.
                     ncc_buffer_append(buf, callee, strlen(callee));
-                    i++; // skip the prefix, keep the '"'
+                    i++; // skip the prefix char, leaving i at the opening '"'
 
-                    // Scan forward to find the end of the string.
-                    size_t str_start = i;
-                    i++; // skip opening "
+                    // Collect one or more adjacent string literals as the
+                    // single call argument. A continuation literal may be
+                    // plain ("...") or carry the SAME prefix (r"..." after
+                    // r"...", b"..." after b"..."); the continuation prefix is
+                    // stripped so that
+                    //     r"foo" r"bar"   parses exactly like   r"foobar"
+                    // through ordinary adjacent-string concatenation inside the
+                    // synthesized call. A differing prefix is left untouched so
+                    // a nonsensical mix (e.g. r"..." b"...") surfaces as an
+                    // error rather than silently merging.
+                    bool first_seg = true;
 
-                    while (i < len) {
-                        if (src[i] == '\\' && i + 1 < len) {
-                            i += 2;
-                        }
-                        else if (src[i] == '"') {
-                            i++;
-                            break;
-                        }
-                        else {
-                            i++;
-                        }
-                    }
+                    for (;;) {
+                        // i is at the opening '"' of a segment.
+                        size_t seg_start = i;
+                        i++; // skip opening "
 
-                    // Check for adjacent string concatenation.
-                    while (i < len) {
+                        while (i < len) {
+                            if (src[i] == '\\' && i + 1 < len) {
+                                i += 2;
+                            }
+                            else if (src[i] == '"') {
+                                i++;
+                                break;
+                            }
+                            else {
+                                i++;
+                            }
+                        }
+
+                        // Separate segments with a space so adjacent C string
+                        // literals concatenate (and never glue into one token).
+                        if (!first_seg) {
+                            ncc_buffer_append(buf, " ", 1);
+                        }
+                        ncc_buffer_append(buf, src + seg_start, i - seg_start);
+                        first_seg = false;
+
+                        // Look past whitespace for an adjacent literal.
                         size_t ws = i;
-
                         while (ws < len
                                && (src[ws] == ' ' || src[ws] == '\t'
                                    || src[ws] == '\n' || src[ws] == '\r')) {
@@ -1216,28 +1236,19 @@ ncc_literal_prescan(char *src, size_t len, size_t *out_len)
                         }
 
                         if (ws < len && src[ws] == '"') {
-                            i = ws + 1;
+                            i = ws; // plain continuation
+                            continue;
+                        }
 
-                            while (i < len) {
-                                if (src[i] == '\\' && i + 1 < len) {
-                                    i += 2;
-                                }
-                                else if (src[i] == '"') {
-                                    i++;
-                                    break;
-                                }
-                                else {
-                                    i++;
-                                }
-                            }
+                        if (ws + 1 < len && src[ws] == prefix_ch
+                            && src[ws + 1] == '"') {
+                            i = ws + 1; // same-prefix continuation; strip prefix
+                            continue;
                         }
-                        else {
-                            break;
-                        }
+
+                        break;
                     }
 
-                    // Emit the string content and closing ).
-                    ncc_buffer_append(buf, src + str_start, i - str_start);
                     ncc_buffer_append(buf, ")", 1);
                     flush_from = i;
                     continue;

--- a/test/test_rstr.c
+++ b/test/test_rstr.c
@@ -86,6 +86,35 @@ test_adjacent_concat(void)
 }
 
 static void
+test_adjacent_rstr_concat(void)
+{
+    TEST("adjacent r-string concatenation (r\"...\" r\"...\")");
+
+    // Two (and three) r-prefixed literals juxtaposed must concatenate
+    // exactly like a single r"..." spanning the same text.
+    ncc_string_t *s = r"foo" r"bar";
+
+    CHECK(s != nullptr, "null pointer");
+    CHECK(s->u8_bytes == 6, "wrong byte count");
+    CHECK(s->codepoints == 6, "wrong codepoint count");
+    CHECK(bytes_eq(s->data, "foobar", 6), "wrong data");
+
+    ncc_string_t *t = r"a" r"b" r"c";
+
+    CHECK(t != nullptr, "null pointer (3-way)");
+    CHECK(t->u8_bytes == 3, "wrong byte count (3-way)");
+    CHECK(bytes_eq(t->data, "abc", 3), "wrong data (3-way)");
+
+    // Empty continuation literal contributes nothing.
+    ncc_string_t *u = r"x" r"";
+
+    CHECK(u != nullptr, "null pointer (empty cont)");
+    CHECK(u->u8_bytes == 1, "wrong byte count (empty cont)");
+    CHECK(bytes_eq(u->data, "x", 1), "wrong data (empty cont)");
+    PASS();
+}
+
+static void
 test_escaped_guillemet(void)
 {
     TEST("escaped guillemet");
@@ -200,6 +229,7 @@ main(void)
     test_plain_string();
     test_bold_markup();
     test_adjacent_concat();
+    test_adjacent_rstr_concat();
     test_escaped_guillemet();
     test_multiple_styles();
     test_bracket_syntax();


### PR DESCRIPTION
## Problem

`r"foo" r"bar"` failed to parse, even though `r"foobar"` and `r"foo" "bar"` both work.

`r"..."` is rewritten to `__ncc_rstr("...")` (and `b"..."` to `__ncc_buflit("...")`) by the literal prescan in `ncc_literal_prescan()`, before the C preprocessor runs. Its continuation scanner already absorbed a following **plain** string literal into the same call, but when the next literal carried its own `r`/`b` prefix it closed the call and started a new one — yielding two juxtaposed call expressions `__ncc_rstr("foo") __ncc_rstr("bar")`, which is a syntax error.

## Change

Extend the continuation scanner to also absorb a following **same-prefix** literal, stripping the inner prefix so every segment folds into one call's argument and concatenates via ordinary adjacent-string concatenation.

- `r"foo" r"bar"` is now byte-identical to `r"foobar"` (same for `b""`).
- Plain mixing (`r"foo" "bar"`) and no-space (`r"foo"r"bar"`) also work.
- A differing prefix (`r"foo" b"bar"`) is deliberately **not** merged, so the nonsensical mix still surfaces as an error rather than silently combining.

## Verified

| input | result |
|---|---|
| `r"foo" r"bar"` | `"foobar"` |
| `r"a" r"b" r"c"` | `"abc"` |
| `r"foo"r"bar"` | `"foobar"` |
| `r"x" r""` | `"x"` |
| `r""` | `""` (empty — already worked) |
| `r"foo" b"bar"` | error (by design) |

## Testing

Added `test_adjacent_rstr_concat` to `test/test_rstr.c` (2-way, 3-way, empty-continuation). Full suite: 269/269 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)