### PR TITLE
build: gate #embed on a capability check, not a clang version number

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,8 +5,13 @@ project('ncc', 'c',
 
 cc = meson.get_compiler('c')
 
-if cc.get_id() != 'clang' or not cc.version().version_compare('>=22.1.0')
-  error('ncc requires Clang 22.1.0+ because the compiler embeds assets with C23 #embed and Clang --embed-dir.')
+# ncc embeds its grammar assets via C23 #embed + Clang --embed-dir.  Rather than
+# gate on a clang VERSION number (which under-counts compilers that already have
+# the feature — clang 21.1.x supports #embed with --embed-dir fine), require
+# clang and let the functional #embed compile check below be the authoritative
+# capability gate.
+if cc.get_id() != 'clang'
+  error('ncc requires Clang (it embeds assets with C23 #embed and Clang --embed-dir).')
 endif
 
 embed_check = '''


### PR DESCRIPTION
## What

`meson setup` hard-errored unless `clang >= 22.1.0`, on the rationale that ncc embeds its grammar assets with C23 `#embed` + `--embed-dir`. But the version-number gate under-counts compilers that already implement the feature: **clang 21.1.x supports `#embed` with `--embed-dir` fine**, and a full ncc build (with asset embedding) works correctly on it.

This drops the version-number gate and keeps the existing **functional `#embed` compile check** (immediately below it in `meson.build`) as the authoritative capability gate. We still require clang, since the feature is reached via the clang-specific `--embed-dir`.

## Why

- A compiler that genuinely lacks `#embed`/`--embed-dir` still fails fast at the functional check, with a clear message — so nothing regresses for unsupported toolchains.
- Compilers that *have* the feature are no longer turned away for carrying the 'wrong' version string. Capability checks beat version-number guesses.

## Testing

Built ncc from `main` with Homebrew clang 21.1.8 on arm64-darwin: meson configure passes the functional `#embed` check, and `ncc` compiles + links + embeds its grammar assets successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)