### PR TITLE
xform: emit pointer typehash in rstr static-object descriptors

### DIFF
--- a/include/xform/xform_static_object.h
+++ b/include/xform/xform_static_object.h
@@ -31,6 +31,7 @@ void ncc_static_object_names_for_array(ncc_static_object_names_t *out,
                                        const char *data_name);
 
 char *ncc_static_object_typehash_expr(const char *type_name);
+char *ncc_static_object_ptr_typehash_expr(const char *type_name);
 const char *ncc_static_object_entry_attr(ncc_xform_ctx_t *ctx);
 void ncc_static_object_slots_init(ncc_static_object_slots_t *out,
                                   ncc_xform_ctx_t *ctx,

--- a/src/xform/xform_rstr.c
+++ b/src/xform/xform_rstr.c
@@ -1086,7 +1086,12 @@ ncc_rstr_static_ref_t ncc_rstr_build_static_ref_ex(
   char cp_str[32];
   snprintf(cp_str, sizeof(cp_str), "%lld", (long long)cp_count);
 
-  char *typehash_str = ncc_static_object_typehash_expr(get_rstr_string_type(ctx));
+  // Hash the POINTER form: the descriptor's tinfo must match the runtime
+  // type registry (keyed by typehash(T*)) so a static r-string resolves to
+  // the same n00b_string_t type_info as a heap string. get_rstr_string_type
+  // is configured as a value type (n00b's array-literal type matcher relies
+  // on that), so use the '*'-normalizing helper here.
+  char *typehash_str = ncc_static_object_ptr_typehash_expr(get_rstr_string_type(ctx));
 
   char wrapper_var[64];
   snprintf(wrapper_var, sizeof(wrapper_var), "_ncc_rsh_%d", uid);
@@ -1295,7 +1300,12 @@ static ncc_parse_tree_t *xform_rstr(ncc_xform_ctx_t *ctx,
   // Extra args for n00b build (typehash + wrapper var name).
   // These are ignored by the default template (fewer slots), but
   // consumed by the n00b template override which adds more slots.
-  char *typehash_str = ncc_static_object_typehash_expr(get_rstr_string_type(ctx));
+  // Hash the POINTER form: the descriptor's tinfo must match the runtime
+  // type registry (keyed by typehash(T*)) so a static r-string resolves to
+  // the same n00b_string_t type_info as a heap string. get_rstr_string_type
+  // is configured as a value type (n00b's array-literal type matcher relies
+  // on that), so use the '*'-normalizing helper here.
+  char *typehash_str = ncc_static_object_ptr_typehash_expr(get_rstr_string_type(ctx));
 
   char wrapper_var[64];
   snprintf(wrapper_var, sizeof(wrapper_var), "_ncc_rsh_%d", uid);

--- a/src/xform/xform_static_object.c
+++ b/src/xform/xform_static_object.c
@@ -632,6 +632,35 @@ ncc_static_object_typehash_expr(const char *type_name)
     return ncc_buffer_take(buf);
 }
 
+// Like ncc_static_object_typehash_expr, but hashes the POINTER form of the
+// type. The runtime type registry and heap objects' dynamic metadata records
+// key types by typehash(T*) (the reference form), so a static object's
+// descriptor must carry typehash(T*) too — otherwise n00b_type_info_for()
+// can't resolve a static object to the same type_info as its heap twin and
+// the formatter falls through to the generic pointer route. Callers whose
+// configured type name is spelled as a value (e.g. "n00b_string_t") need this;
+// names already ending in '*' are hashed as-is. (xform_static_image.c emits the
+// pointer form directly via "%s*"; this is the shared, '*'-idempotent helper.)
+char *
+ncc_static_object_ptr_typehash_expr(const char *type_name)
+{
+    if (!type_name) {
+        type_name = "";
+    }
+
+    size_t len = strlen(type_name);
+    if (len > 0 && type_name[len - 1] == '*') {
+        return ncc_static_object_typehash_expr(type_name);
+    }
+
+    ncc_buffer_t *buf = ncc_buffer_empty();
+    ncc_buffer_printf(buf, "%s*", type_name);
+    char *ptr_type = ncc_buffer_take(buf);
+    char *expr     = ncc_static_object_typehash_expr(ptr_type);
+    ncc_free(ptr_type);
+    return expr;
+}
+
 const char *
 ncc_static_object_entry_attr(ncc_xform_ctx_t *ctx)
 {


### PR DESCRIPTION
## Problem

A static r-string's `n00b_static_object_desc_t` carried `tinfo = typehash(T)` — the **value** type (e.g. `n00b_string_t`). But the n00b runtime type registry, and heap objects' dynamic metadata records, key types by `typehash(T *)` — the **pointer/reference** form. So `n00b_type_info_for()` couldn't resolve a static r-string to the same `type_info` as a heap string, the `TO_STRING` vtable lookup missed, and the formatter fell through to the `<typename@addr>` generic-pointer route — rendering `r"..."` literals as `<unknown@0x...>` (observed in `crayon login`'s QR prompt).

The rstr string type is configured as a **value** type on purpose: ncc's array-literal type matcher (`xform_array_literal.c`) appends `*` itself and relies on the value spelling, so the `--ncc-rstr-string-type` flag can't change.

## Fix

Emit the **pointer** form for the descriptor's `tinfo`. Add `ncc_static_object_ptr_typehash_expr()` — a `*`-idempotent wrapper over `ncc_static_object_typehash_expr()` — and use it at both rstr emission sites (plain + styled). This mirrors `xform_static_image.c`, which already hashes the pointer form via `"%s*"`.

## Verification

- With `--ncc-rstr-string-type=n00b_string_t`, the emitted descriptor's `tinfo` is now `typehash(n00b_string_t*)` = `907074058949430326` (the registry key), not `typehash(n00b_string_t)` = `4600804951667324469`. Confirmed via `ncc -E`.
- ncc test suite: **269/269 pass**.
- Downstream: rebuilt libn00b + `crayon` with this ncc; `crayon login` now renders the static `r"Or scan:"` label as text (was `<unknown@…>`). The companion n00b PR removes the format.c "treat unknown object as a string" band-aid that previously masked this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)