### PR TITLE
ncc: precise variant GC typemaps + traditional-union deprecation

### DIFF
--- a/docs/variant_precise_scan_and_union_deprecation.md
+++ b/docs/variant_precise_scan_and_union_deprecation.md
@@ -1,0 +1,161 @@
+# Precise struct-arm variant typemaps + union deprecation
+
+Status: planned (tracking doc)
+Scope: ncc emitter + the shared n00b GC-metadata ABI + n00b consumers.
+See also: `docs/gc_typemaps.md` (the existing link-time type→GC-map machinery).
+
+ncc targets n00b as its expected runtime base (you *can* build against another
+runtime, but n00b is the default), so both changes below are reasonable
+ncc-level defaults.
+
+---
+
+## Change 1 — precise GC typemaps for struct-arm `n00b_variant_t`
+
+### Problem
+`n00b_variant_t(...)` lowers to `{ uint64_t selector; union { ...field_<typeid>... } value; }`.
+Today ncc's variant typemap models `value` as **one word** that is a heap
+pointer iff `selector` is one of a set of "pointer alternative" typehashes. So
+it only handles arms that are themselves a single pointer (`ALT_PTR`) or a
+scalar (`ALT_NONPTR`). A by-value **struct** arm (pointers at several offsets)
+is `ALT_UNSUPPORTED` (`src/xform/xform_gc_typemap.c`, `classify_variant_alt`,
+the `total == 0` non-scalar branch), which downgrades the whole enclosing type
+to conservative `DEFAULT` scan — imprecise (false-retention on scalar fields)
+and "not precisely marshalable".
+
+This is what blocks `n00b_draw_cmd_t` (arms are structs carrying `string`/
+`style` + coords) and `n00b_json_node_t` and every other struct-arm variant from
+precise scanning.
+
+### Fix — per-selector pointer-offset tables
+Generalize "one pointer word per selector" → "a set of pointer offsets per
+selector". A single-pointer arm is just `ptr_offsets = {0}`, so one
+representation subsumes both.
+
+#### Shared ABI (n00b `include/n00b.h`) — lands atomically with the emitter
+```c
+typedef struct {                 // one alternative (arm)
+    uint64_t        selector;        // typehash(T) of this arm
+    uint64_t        ptr_offset_count;
+    const uint64_t *ptr_offsets;     // word offsets within value, sorted asc
+} n00b_gc_variant_arm_t;
+
+typedef struct {
+    uint64_t                     selector_offset;  // word offset of selector
+    uint64_t                     value_offset;     // word offset of value union
+    uint64_t                     arm_count;
+    const n00b_gc_variant_arm_t *arms;             // sorted by selector
+} n00b_gc_variant_field_t;
+```
+Offsets in each arm are relative to `value_offset` (every union member starts at
+the union base, i.e. value-relative offset 0), so an arm's internal pointer
+offsets — computed by the existing struct walker — drop in directly.
+
+#### ncc emitter (`src/xform/xform_gc_typemap.c`)
+- `classify_variant_alt`: add `ALT_AGGREGATE`. In the `total == 0` non-scalar
+  branch, resolve the arm's aggregate definition by spelling and compute its
+  pointer offsets instead of bailing. If the arm is itself not fully
+  describable (nested unsupported union/atomic/etc.), keep `ALT_UNSUPPORTED`
+  (whole variant → conservative). **Invariant preserved: never under-scan.**
+- Reuse `gc_walk` (the tolerant struct pointer-offset walker) factored to return
+  an offset list for an arm type with `base=""`.
+- `walk_variant`: emit one `static const uint64_t` offset array per
+  pointer-bearing arm + an `arms[]` table sorted by selector, replacing the flat
+  `ptr_hashes` list.
+
+#### n00b consumers (all read the shared layout)
+- `src/core/gc_map.c` (`n00b_gc_map_mark_struct_layout_count` + helper): replace
+  the bool `selector ∈ ptr_hashes` test with an arm lookup; for the matched arm,
+  mark `base + value_offset + arm->ptr_offsets[k]` for each offset. Extend the
+  bounds `n00b_require`s (`value_offset + max_offset < stride`, within
+  `num_words`).
+- `src/util/marshal.c` (walks `n00b_gc_struct_layout_t` at `:782,1075,2576`):
+  follow per-arm offsets too — this is what clears "not precisely marshalable".
+- `src/slay/codegen.c`: builds layouts for JIT/runtime-created types; if any
+  carry struct-arm variants, emit the new arm shape. Audit; guard if not needed
+  yet (see open question).
+- `src/typecheck/print.c`: diagnostics dump — cosmetic update for the new shape.
+
+### Safety
+- "Never under-scan": any uncertainty about an arm ⇒ whole variant conservative.
+- `selector == 0` (unset) ⇒ mark nothing (existing guard).
+- Conservative fallback remains GC-safe; this change only adds precision.
+
+### Tests
+- ncc `test/test_gc_typemap.c`: a struct-arm variant (mirroring `draw_cmd`) →
+  assert no conservative warning + correct `arms[]`; a nested-unsupported arm →
+  assert it still falls back conservatively.
+- n00b: allocate a struct-arm variant, set each arm, force a compacting
+  collection, assert (a) arm pointers are forwarded and (b) a scalar field whose
+  value looks like a heap address is NOT followed (proves precision). Marshal
+  round-trip of a struct-arm variant.
+
+### Rollout (lockstep, cross-repo)
+The descriptor is shared and n00b builds with a pinned ncc, so:
+1. ncc PR (ABI struct in n00b first or simultaneously).
+2. Bump the ncc the n00b build uses.
+3. n00b PR with the format + consumer changes.
+Rebuild n00b and diff gc-typemap warnings: confirm `draw_cmd`, `json_node`, and
+other struct-arm variants flip conservative → precise, and nothing regresses.
+
+### Effort
+~1–2 days. Emitter (arm-type resolution + `gc_walk` reuse) is the load-bearing
+piece; the n00b scanner is small; marshal/codegen localized; then tests + the
+lockstep bump + a full rebuild.
+
+### Open questions
+1. All-scalar aggregate arm: empty offset list, or classify `ALT_NONPTR`
+   (no arm entry)? Latter is leaner.
+2. `codegen.c` JIT path: any JIT types with struct-arm variants today, or is
+   this purely link-time (so codegen is just guarded, not changed now)?
+
+---
+
+## Change 2 — deprecation warning for traditional unions
+
+Steer all bare C unions toward `n00b_variant_t` (GC-precise + marshalable after
+Change 1). Wording uses "may", not "will".
+
+### Trigger
+Every `union` specifier that is **not**:
+1. an `n00b_variant_t` value-union — reuse the `field_<typeid>`-naming detector
+   in `xform_gc_typemap.c` (every union member named `field_…`);
+2. in a system header — reuse `ncc_layout_node_starts_in_system_header()`
+   (`src/xform/xform_type_layout.c`) / `node_in_system_header()`
+   (`src/xform/transform.c`); ncc has per-token file/line provenance from the
+   preprocessor `#`-line markers, so this is reliable (and gives the warning its
+   `file:line` and lets us dedup a widely-included header union to one
+   diagnostic);
+3. opted out per-union via `[[n00b::raw_union]]` — following the
+   `[[n00b::noscan]]` / `[[n00b::nogc]]` precedent
+   (`ncc_xform_subtree_carries_n00b_named_attr`), for type-punning / FFI layout /
+   non-n00b-target cases.
+
+### Placement
+A dedicated traversal over union specifiers (the gc-typemap pass only sees
+unions inside scanned heap aggregates; we want all of them). Can ride an
+existing full-tree structural walk (`transform.c` already traverses declarations
+and has the system-header helper). One warning per offending union declaration,
+deduped by source location.
+
+### Wording
+```
+ncc: warning: traditional C union '<name>' is discouraged; use n00b_variant_t
+for a GC-precise, marshalable tagged union. Raw unions may become an error in a
+future release (suppress with [[n00b::raw_union]]).
+```
+
+### Knobs
+- `--ncc-error-on-union` — escalate warning → error now (per-project opt-in
+  ahead of the global change).
+- `--ncc-allow-unions` — global suppress for the "building against another
+  runtime" case. Off by default (n00b is the expected base).
+
+### Effort
+Small — a few hours on top of Change 1: one traversal + three exclusion checks,
+all reusing existing helpers and the attribute plumbing.
+
+### Open question
+Warn on every non-system, non-variant union (incl. pure stack/FFI scratch), or
+only GC-reachable ones? Plan: **every** such union, with `[[n00b::raw_union]]`
+as the release valve — surfaces more sites than just GC-relevant ones.

--- a/include/internal/ncc_opts.h
+++ b/include/internal/ncc_opts.h
@@ -27,6 +27,8 @@ typedef struct {
     bool         auto_gc_roots;
     bool         custom_entry;
     bool         no_comptime;
+    bool         allow_unions;    // suppress the traditional-union deprecation
+    bool         error_on_union;  // escalate the deprecation to a hard error
     bool         static_identity_generate_namespace;
 
     // Dependency file generation (handled separately from compilation).

--- a/include/parse/union_deprecation.h
+++ b/include/parse/union_deprecation.h
@@ -1,0 +1,37 @@
+#pragma once
+
+/**
+ * @file union_deprecation.h
+ * @brief Deprecation diagnostic steering bare C unions toward n00b_variant_t.
+ *
+ * ncc targets n00b as its runtime base, where the GC-precise, marshalable way
+ * to express a tagged union is `n00b_variant_t`. A traditional C union has no
+ * discriminator the collector can read, so it forces a conservative scan (and
+ * is not precisely marshalable) — exactly the footgun n00b_variant_t avoids.
+ *
+ * This read-only pass warns on every union that is NOT:
+ *   1. an n00b_variant_t value-union (all members named `field_<...>`),
+ *   2. in a system header (libc / SDK unions are not ours to change), or
+ *   3. annotated `union [[n00b::raw_union]] { ... }` (the escape hatch for
+ *      type-punning / FFI-layout / non-n00b-target unions).
+ *
+ * With `error_on_union` the diagnostic is emitted at error severity and the
+ * caller fails the compile. The wording says raw unions *may* become an error
+ * in a future release.
+ */
+
+#include "parse/types.h"
+#include "parse/parse_tree.h"
+
+/**
+ * @brief Diagnose traditional (non-variant) unions. Returns the number of
+ *        diagnostics emitted. No-op (returns 0) when @p allow_unions is true.
+ *
+ * Must run PRE-transform (before _generic_struct lowering), so n00b_variant_t
+ * value-unions are still in their `_generic_struct typeid("n00b_variant", ...)`
+ * source form and excluded by that marker — rather than after lowering, which
+ * yields synthesized nodes no type-model query can resolve.
+ */
+int ncc_union_deprecation_check(ncc_parse_tree_t *tu,
+                                bool              allow_unions,
+                                bool              error_on_union);

--- a/include/xform/xform_helpers.h
+++ b/include/xform/xform_helpers.h
@@ -26,7 +26,9 @@ bool ncc_xform_subtree_carries_n00b_named_attr(ncc_parse_tree_t *node,
                                                const char       *name);
 
 // Recursively remove every <attribute_specifier> carrying `[[n00b::<name>]]`
-// from `parent` so the attribute never reaches the C emitter.
+// from `parent` so the attribute never reaches the C emitter. When `name` is
+// NULL, removes EVERY `[[n00b::*]]` attribute (used as the final pre-emit sweep
+// so no ncc-only attribute leaks to clang).
 void ncc_xform_strip_n00b_named_attribute_specifiers(ncc_parse_tree_t *parent,
                                                      const char       *name);
 

--- a/meson.build
+++ b/meson.build
@@ -1491,7 +1491,8 @@ test('ncc_gc_typemap_variant_descriptor_emitted', test_runner,
   depends : ncc_exe,
 )
 
-# The descriptor records the selector and value word offsets.
+# The descriptor records the selector offset and, per alternative, the
+# element-relative pointer offsets that are live when that selector is active.
 test('ncc_gc_typemap_variant_selector_offset', test_runner,
   args : [ncc_exe, 'preprocess_contains',
           test_dir / 'test_gc_typemap_variant.c',
@@ -1501,10 +1502,34 @@ test('ncc_gc_typemap_variant_selector_offset', test_runner,
   depends : ncc_exe,
 )
 
-test('ncc_gc_typemap_variant_value_offset', test_runner,
+# A single-pointer alternative's pointer is the value word, addressed through
+# its named union field (value.field_0), not a bare `value` word.
+test('ncc_gc_typemap_variant_value_ptr_offset', test_runner,
   args : [ncc_exe, 'preprocess_contains',
           test_dir / 'test_gc_typemap_variant.c',
-          '__builtin_offsetof(vmap_variant_t,value)']
+          '__builtin_offsetof(vmap_variant_t,value.field_0)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# A by-value AGGREGATE alternative is described precisely: an arm table
+# (n00b_gc_variant_arm_t) carries the pointer offsets of the struct's fields,
+# addressed through value.<field>.<member>. (Previously this fell back to a
+# conservative scan.)
+test('ncc_gc_typemap_variant_aggregate_arm', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          'n00b_gc_variant_arm_t']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_variant_aggregate_arm_field_offset', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          '__builtin_offsetof(vmap_agg_variant_t,value.field_0.a)']
          + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
   suite : 'ncc',
   depends : ncc_exe,

--- a/meson.build
+++ b/meson.build
@@ -207,6 +207,7 @@ src_xform = files(
   'src/xform/xform_nullable.c',
   'src/xform/nullability.c',
   'src/xform/nodiscard.c',
+  'src/xform/union_deprecation.c',
   'src/xform/xform_generic_struct.c',
   'src/xform/xform_gc_globals.c',
   'src/xform/xform_gc_stack_maps.c',
@@ -1575,6 +1576,53 @@ test('ncc_gc_typemap_variant_generic_struct', test_runner,
   args : [ncc_exe, 'preprocess_contains',
           test_dir / 'test_gc_typemap_variant.c',
           '__builtin_offsetof(vmap_generic_variant_t,selector)']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# Traditional-union deprecation: a bare (non-variant) union is steered toward
+# n00b_variant_t.
+
+# A hand-rolled tagged union warns.
+test('ncc_union_deprecation_warn', test_runner,
+  args : [ncc_exe, 'preprocess_stderr_contains',
+          test_dir / 'test_union_deprecation.c',
+          'traditional C union is discouraged']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# --ncc-allow-unions suppresses the warning entirely.
+test('ncc_union_deprecation_allow', test_runner,
+  args : [ncc_exe, 'preprocess_stderr_omits',
+          test_dir / 'test_union_deprecation.c',
+          'traditional C union']
+         + ncc_test_flags
+         + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots',
+            '--ncc-allow-unions'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# --ncc-error-on-union makes it a hard error (non-zero exit).
+test('ncc_union_deprecation_error', test_runner,
+  args : [ncc_exe, 'expect_error_contains',
+          test_dir / 'test_union_deprecation.c',
+          'traditional C union is discouraged']
+         + ncc_test_flags
+         + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots',
+            '--ncc-error-on-union'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+# An n00b_variant_t value-union and a [[n00b::raw_union]] union are NOT flagged.
+test('ncc_union_deprecation_excluded', test_runner,
+  args : [ncc_exe, 'preprocess_stderr_omits',
+          test_dir / 'test_union_deprecation_excluded.c',
+          'traditional C union']
          + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
   suite : 'ncc',
   depends : ncc_exe,

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -51,6 +51,7 @@
 #include "parse/comptime_meta.h"
 #include "parse/crt_entry.h"
 #include "parse/emit.h"
+#include "parse/union_deprecation.h"
 #include "xform/xform_gc_typemap.h"
 #include "xform/xform_helpers.h"
 #include "parse/tree_dump.h"
@@ -517,6 +518,14 @@ parse_argv(ncc_opts_t *opts, int argc, const char **argv)
             opts->auto_gc_roots = false;
             continue;
         }
+        if (strcmp(arg, "--ncc-allow-unions") == 0) {
+            opts->allow_unions = true;
+            continue;
+        }
+        if (strcmp(arg, "--ncc-error-on-union") == 0) {
+            opts->error_on_union = true;
+            continue;
+        }
         if (strcmp(arg, "--ncc-custom-entry") == 0) {
             opts->custom_entry = true;
             continue;
@@ -823,6 +832,10 @@ print_help(void)
         "                       as libn00b GC roots\n"
         "  --ncc-no-auto-gc-roots\n"
         "                       Disable auto-registration of TU-scope GC roots\n"
+        "  --ncc-allow-unions   Suppress the traditional-union deprecation\n"
+        "                       warning (e.g. when not targeting n00b)\n"
+        "  --ncc-error-on-union Make the traditional-union deprecation a hard\n"
+        "                       error (opt in ahead of the future default)\n"
         "  --ncc-custom-entry   Link with ncc's generated libc-less n00b entry\n"
         "  --ncc-comptime-arg=VAL\n"
         "                       Pass VAL as an argv element to comptime_main\n"
@@ -3747,6 +3760,19 @@ compile_file(ncc_opts_t *opts)
     // skipped by the discard check.
     ncc_nodiscard_check(g, tree, xdata.symtab);
 
+    // Traditional-union deprecation. Runs PRE-transform (here, alongside the
+    // other read-only lint passes) so n00b_variant_t value-unions are still in
+    // their `_generic_struct typeid("n00b_variant", ...)` source form and are
+    // excluded by that marker — after _generic_struct lowering they become
+    // synthesized, file-less, parent-less nodes that no type query can resolve.
+    // `union_error` gates the final exit code when --ncc-error-on-union is set
+    // and a bare union was found (the diagnostics are emitted at error severity
+    // above), avoiding a mid-pipeline teardown.
+    int n_union_diags = ncc_union_deprecation_check(tree,
+                                                    opts->allow_unions,
+                                                    opts->error_on_union);
+    bool union_error = opts->error_on_union && n_union_diags > 0;
+
     bool has_optional_comptime = false;
     if (ncc_comptime_check(g, tree, xdata.symtab, &has_optional_comptime) > 0) {
         ncc_symtab_free(xdata.symtab);
@@ -3837,12 +3863,18 @@ compile_file(ncc_opts_t *opts)
                                                       &comptime_vars,
                                                       &n_comptime_vars);
 
-    // The `[[n00b::noscan]]` per-field attribute is consumed above (it tells
-    // ncc_gc_typemap_emit to omit a field from the GC typemap). Strip it from
-    // the whole tree now — AFTER the typemap detection has read it, BEFORE the
-    // tree is pretty-printed — so clang never sees this ncc-only attribute.
-    ncc_xform_strip_n00b_named_attribute_specifiers(tree, "noscan");
-    ncc_xform_strip_n00b_named_attribute_specifiers(tree, "comptime");
+    // (The traditional-union deprecation check runs pre-transform, above, where
+    // the [[n00b::raw_union]] escape hatch is still present — before the strip
+    // below removes every ncc-only attribute.)
+
+    // Strip EVERY remaining `[[n00b::*]]` attribute now — AFTER every pass that
+    // consumes one has read it (noscan by the GC typemap above; comptime by
+    // comptime-check; raw_union by the union-deprecation check above; nogc is
+    // already stripped inside the GC stack-map xform) and BEFORE the tree is
+    // pretty-printed — so clang never sees an ncc-dialect attribute (and never
+    // warns "unknown attribute"). A blanket strip means new ncc-only attributes
+    // are handled automatically.
+    ncc_xform_strip_n00b_named_attribute_specifiers(tree, nullptr);
 
 #ifdef NCC_MEM_DEBUG
     ncc_mem_report("after transform");
@@ -4128,6 +4160,11 @@ cleanup:
     ncc_scanner_free(scanner);
     ncc_grammar_free(g);
 
+    // --ncc-error-on-union: a traditional union was found and reported at error
+    // severity above; fail the compile (without disturbing a real error rc).
+    if (union_error && rc == 0) {
+        rc = 1;
+    }
     return rc;
 }
 

--- a/src/xform/union_deprecation.c
+++ b/src/xform/union_deprecation.c
@@ -1,0 +1,142 @@
+// union_deprecation.c -- warn (or error) on traditional C unions, steering
+// them toward n00b_variant_t. See include/parse/union_deprecation.h.
+//
+// Read-only: emits diagnostics, never transforms the tree. Runs PRE-transform
+// (before _generic_struct lowering), so n00b_variant_t value-unions are still
+// in their source `_generic_struct typeid("n00b_variant", ...)` form and are
+// identified by that marker — not by member names (which fold ambiguously) and
+// not after lowering (which produces synthesized, file-less, parent-less nodes
+// that no type-model query can see).
+
+#include "ncc.h"
+#include "parse/union_deprecation.h"
+#include "parse/token.h"
+#include "xform/xform_helpers.h"
+#include "xform/xform_type_layout.h"
+#include "lib/option.h"
+#include "lib/tree.h"
+
+#include <stdio.h>
+#include <string.h>
+
+// First-leaf source location of `node`: returns the file path (or nullptr) and
+// fills line/col, so the diagnostic can name the header a union lives in.
+static const char *
+first_leaf_loc(ncc_parse_tree_t *node, uint32_t *line, uint32_t *col)
+{
+    if (!node) {
+        return nullptr;
+    }
+    if (ncc_tree_is_leaf(node)) {
+        ncc_token_info_t *tok = ncc_tree_leaf_value(node);
+        if (tok) {
+            *line = tok->line;
+            *col  = tok->column;
+            return ncc_option_is_set(tok->file) ? ncc_option_get(tok->file).data
+                                                : nullptr;
+        }
+        return nullptr;
+    }
+    size_t nc = ncc_tree_num_children(node);
+    for (size_t i = 0; i < nc; i++) {
+        const char *f = first_leaf_loc(ncc_tree_child(node, i), line, col);
+        if (*line != 0) {
+            return f;
+        }
+    }
+    return nullptr;
+}
+
+// Is `su` the n00b_variant_t shape: a `_generic_struct` (child 0 is the
+// `_kw_generic_struct` keyword) whose tag is `typeid("n00b_variant", ...)`?
+// That marker is unique to the n00b_variant_t macro, so the struct's value
+// union is a precisely-scanned variant alternative table, not a raw union.
+static bool
+is_n00b_variant_generic_struct(ncc_parse_tree_t *su)
+{
+    if (ncc_tree_num_children(su) == 0) {
+        return false;
+    }
+    ncc_parse_tree_t *kw = ncc_tree_child(su, 0);
+    if (!kw || !ncc_xform_nt_name_is(kw, "_kw_generic_struct")) {
+        return false;
+    }
+    ncc_parse_tree_t *tag = ncc_xform_find_child_nt(su, "tag_name");
+    if (!tag) {
+        return false;
+    }
+    char *text = ncc_layout_node_text(tag);
+    bool  ok   = text != nullptr && strstr(text, "n00b_variant") != nullptr;
+    if (text) {
+        ncc_free(text);
+    }
+    return ok;
+}
+
+// Is this union the value-union of an n00b_variant_t? Walk up to the nearest
+// enclosing aggregate specifier and test the marker. Pre-transform, parent
+// pointers are set and the _generic_struct is intact, so this is exact: a bare
+// union nested in a normal struct (or in a variant arm, whose nearest enclosing
+// struct is the arm, not the variant) is correctly NOT excluded.
+static bool
+is_variant_value_union(ncc_parse_tree_t *union_node)
+{
+    ncc_parse_tree_t *cur = union_node;
+    while (cur && !ncc_tree_is_leaf(cur)) {
+        ncc_parse_tree_t *parent =
+            (ncc_parse_tree_t *)ncc_tree_node_value(cur).parent;
+        if (!parent) {
+            return false;
+        }
+        if (ncc_xform_nt_name_is(parent, "struct_or_union_specifier")) {
+            return is_n00b_variant_generic_struct(parent);
+        }
+        cur = parent;
+    }
+    return false;
+}
+
+static void
+walk(ncc_parse_tree_t *n, bool error_on_union, int *count)
+{
+    if (!n || ncc_tree_is_leaf(n)) {
+        return;
+    }
+
+    if (ncc_xform_nt_name_is(n, "struct_or_union_specifier")
+        && ncc_layout_struct_or_union_is_union(n)
+        && !ncc_layout_node_starts_in_system_header(n)
+        && !is_variant_value_union(n)
+        && !ncc_xform_subtree_carries_n00b_named_attr(n, "raw_union")) {
+
+        uint32_t    line = 0;
+        uint32_t    col  = 0;
+        const char *file = first_leaf_loc(n, &line, &col);
+        fprintf(stderr,
+                "%s:%u:%u: ncc: %s: traditional C union is discouraged; use "
+                "n00b_variant_t for a GC-precise, marshalable tagged union. "
+                "Raw unions may become an error in a future release (suppress "
+                "with `union [[n00b::raw_union]] { ... }`)\n",
+                file ? file : "<unknown>", line, col,
+                error_on_union ? "error" : "warning");
+        (*count)++;
+    }
+
+    size_t nc = ncc_tree_num_children(n);
+    for (size_t i = 0; i < nc; i++) {
+        walk(ncc_tree_child(n, i), error_on_union, count);
+    }
+}
+
+int
+ncc_union_deprecation_check(ncc_parse_tree_t *tu,
+                            bool              allow_unions,
+                            bool              error_on_union)
+{
+    if (tu == nullptr || allow_unions) {
+        return 0;
+    }
+    int count = 0;
+    walk(tu, error_on_union, &count);
+    return count;
+}

--- a/src/xform/xform_gc_typemap.c
+++ b/src/xform/xform_gc_typemap.c
@@ -343,6 +343,7 @@ typedef struct {
 typedef enum {
     ALT_PTR,        // a heap pointer; its typehash joins the discriminant set
     ALT_NONPTR,     // carries no heap pointer (primitive scalar or code pointer)
+    ALT_AGGREGATE,  // a by-value aggregate; its pointer offsets are walked per-arm
     ALT_UNSUPPORTED // cannot be described safely -> fall back to conservative
 } alt_class_t;
 
@@ -438,12 +439,20 @@ classify_variant_alt(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *member,
 
     if (total == 0) {
         // Non-pointer by value: a recognized primitive scalar carries no heap
-        // word; a by-value aggregate may hide pointers across several words and
-        // anything else is an unknown typedef — bail to a conservative scan for
-        // both (never an under-scan).
+        // word. A by-value aggregate is described precisely per-arm by
+        // walk_variant (which walks its pointer fields via gc_walk); its
+        // selector is typehash(T) of the aggregate spelling — the same value
+        // n00b_variant_set stamps. An unknown typedef also reaches here and is
+        // tagged ALT_AGGREGATE; walk_variant then fails to resolve an aggregate
+        // spec for it and falls back to conservative (never an under-scan).
         bool scalar = elem_type_is_scalar_no_ptr(base);
+        if (scalar) {
+            ncc_free(base);
+            return ALT_NONPTR;
+        }
+        *out_hash = ncc_type_hash_u64(base);
         ncc_free(base);
-        return scalar ? ALT_NONPTR : ALT_UNSUPPORTED;
+        return ALT_AGGREGATE;
     }
 
     if (decl && ncc_layout_declarator_is_function_pointer(decl)) {
@@ -579,14 +588,47 @@ variant_value_union(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *spec)
     return all_field ? value_union : nullptr;
 }
 
+// Forward declarations: walk_variant (below) drives these, which are defined
+// later in the file.
+static void
+emit_pointer(const char *elem_type, const char *path, ncc_buffer_t *offs,
+             ncc_buffer_t *asserts, int *count);
+static void
+gc_walk(ncc_xform_ctx_t *ctx, const char *elem_type, ncc_parse_tree_t *spec,
+        const char *base, ncc_buffer_t *offs, ncc_buffer_t *asserts,
+        int *count, variant_acc_t *vacc, bool *ok, int depth);
+
+// One alternative's contribution to a variant descriptor: its selector
+// typehash and the element-relative pointer word offsets that are live when the
+// selector is active. `offs` is a CSV of offset expressions (as produced by
+// emit_pointer / gc_walk). Alignment static_asserts go straight into the shared
+// arrays buffer as they are discovered.
+typedef struct {
+    uint64_t      selector;
+    ncc_buffer_t *offs;
+    int           count;
+} variant_arm_acc_t;
+
+static int
+cmp_variant_arm(const void *a, const void *b)
+{
+    uint64_t sa = ((const variant_arm_acc_t *)a)->selector;
+    uint64_t sb = ((const variant_arm_acc_t *)b)->selector;
+    return (sa < sb) ? -1 : (sa > sb) ? 1 : 0;
+}
+
 // Emit a variant descriptor for an n00b_variant_t field at `base`. `vunion` is
-// the resolved value-union specifier. On any alternative we cannot describe,
-// sets *ok = false and warns (the whole type then falls back to conservative
-// scanning, exactly as the legacy union path does — never an under-scan).
+// the resolved value-union specifier. Each pointer-bearing alternative becomes
+// an arm carrying the element-relative pointer offsets that are live when its
+// selector is active: a single-pointer alternative has one offset (the value
+// word); a by-value aggregate alternative has the pointer offsets of its fields
+// (walked by gc_walk). On any alternative we cannot describe, sets *ok = false
+// and warns — the whole type then falls back to conservative scan (never an
+// under-scan).
 static void
 walk_variant(ncc_xform_ctx_t *ctx, const char *elem_type,
              ncc_parse_tree_t *vunion, const char *base, variant_acc_t *vacc,
-             bool *ok)
+             bool *ok, int depth)
 {
     ncc_parse_tree_t *members = ncc_xform_find_child_nt(
         vunion, "member_declaration_list");
@@ -598,71 +640,140 @@ walk_variant(ncc_xform_ctx_t *ctx, const char *elem_type,
     ncc_layout_parse_tree_list_t alts = {0};
     ncc_layout_collect_nt_children(members, "member_declaration", &alts);
 
-    ncc_layout_uint64_list_t hashes = {0};
-    bool                     unsupported = false;
+    char              *val_base    = path_join(base, "value");
+    variant_arm_acc_t *arms        = ncc_alloc_array(variant_arm_acc_t, alts.len);
+    size_t             narms       = 0;
+    bool               unsupported = false;
 
-    for (size_t i = 0; i < alts.len; i++) {
+    for (size_t i = 0; i < alts.len && !unsupported; i++) {
         uint64_t    h   = 0;
         alt_class_t cls = classify_variant_alt(ctx, alts.data[i], &h);
+
         if (cls == ALT_UNSUPPORTED) {
             unsupported = true;
             break;
         }
-        if (cls == ALT_PTR) {
-            ncc_layout_uint64_list_push(&hashes, h);
+        if (cls == ALT_NONPTR) {
+            continue; // no heap pointer in this alternative
         }
+
+        ncc_parse_tree_t *aspecs = ncc_xform_find_child_nt(
+            alts.data[i], "specifier_qualifier_list");
+        char *field = aspecs ? ncc_layout_implicit_member_field_name(
+                                   alts.data[i], aspecs)
+                             : nullptr;
+        if (!field) {
+            unsupported = true;
+            break;
+        }
+        char         *armbase = path_join(val_base, field);
+        ncc_buffer_t *aoffs   = ncc_buffer_empty();
+        int           acount  = 0;
+        ncc_free(field);
+
+        if (cls == ALT_PTR) {
+            // The value word itself is the heap pointer.
+            emit_pointer(elem_type, armbase, aoffs, vacc->arrays, &acount);
+        }
+        else { // ALT_AGGREGATE: walk the by-value struct's pointer fields.
+            ncc_parse_tree_t *aspec = ncc_layout_aggregate_spec_from_specs(
+                ctx, aspecs);
+            // A nested variant inside an arm needs conditional nesting we don't
+            // express yet; route it (and anything gc_walk can't fully describe)
+            // to the conservative fallback. A throwaway vacc catches a nested
+            // variant via its non-zero count.
+            variant_acc_t inner = {
+                .arrays = ncc_buffer_empty(),
+                .inits  = ncc_buffer_empty(),
+                .count  = 0,
+                .rec    = vacc->rec,
+            };
+            bool aok = true;
+            if (aspec) {
+                gc_walk(ctx, elem_type, aspec, armbase, aoffs, vacc->arrays,
+                        &acount, &inner, &aok, depth + 1);
+            }
+            bool inner_variant = inner.count != 0;
+            ncc_free(inner.arrays->data);
+            ncc_free(inner.arrays);
+            ncc_free(inner.inits->data);
+            ncc_free(inner.inits);
+            if (!aspec || !aok || inner_variant) {
+                ncc_free(armbase);
+                ncc_free(aoffs->data);
+                ncc_free(aoffs);
+                unsupported = true;
+                break;
+            }
+        }
+
+        ncc_free(armbase);
+
+        if (acount == 0) {
+            // Alternative with no heap pointers: omit it from the arm table.
+            ncc_free(aoffs->data);
+            ncc_free(aoffs);
+            continue;
+        }
+
+        arms[narms].selector = h;
+        arms[narms].offs     = aoffs;
+        arms[narms].count    = acount;
+        narms++;
     }
+
     if (alts.data) {
         ncc_free(alts.data);
     }
+    ncc_free(val_base);
 
     if (unsupported) {
+        for (size_t i = 0; i < narms; i++) {
+            ncc_free(arms[i].offs->data);
+            ncc_free(arms[i].offs);
+        }
+        ncc_free(arms);
         fprintf(stderr,
                 "ncc: warning: gc-typemap: type '%s' has an n00b_variant_t with "
                 "an alternative that cannot be statically described for GC "
                 "scanning; the type loses its precise pointer map and falls "
                 "back to conservative scan (not precisely marshalable).\n",
                 elem_type ? elem_type : "(anonymous)");
-        if (hashes.data) {
-            ncc_free(hashes.data);
-        }
         *ok = false;
         return;
     }
 
-    if (hashes.len == 0) {
-        // No pointer alternatives: the value word is never a heap pointer, so
-        // there is nothing to mark and the type stays precise.
-        if (hashes.data) {
-            ncc_free(hashes.data);
-        }
+    if (narms == 0) {
+        // No pointer-bearing alternatives: precise, nothing to mark.
+        ncc_free(arms);
         return;
     }
 
-    // Sort ascending and dedup so the runtime can binary-search.
-    qsort(hashes.data, hashes.len, sizeof(uint64_t), cmp_u64);
-    size_t n = 0;
-    for (size_t i = 0; i < hashes.len; i++) {
-        if (n == 0 || hashes.data[i] != hashes.data[n - 1]) {
-            hashes.data[n++] = hashes.data[i];
-        }
-    }
+    // Sort arms by selector so the runtime can binary-search.
+    qsort(arms, narms, sizeof(*arms), cmp_variant_arm);
 
     char *sel_path = path_join(base, "selector");
-    char *val_path = path_join(base, "value");
     char *sel_as   = offset_assert(elem_type, sel_path);
-    char *val_as   = offset_assert(elem_type, val_path);
     char *sel_off  = offset_expr(elem_type, sel_path);
-    char *val_off  = offset_expr(elem_type, val_path);
+    int   k        = vacc->count;
 
-    int k = vacc->count;
-    ncc_buffer_printf(vacc->arrays, "%s%s", sel_as, val_as);
-    ncc_buffer_printf(vacc->arrays,
-                      "static const uint64_t __ncc_gcvar_h_%zu_%d[]={",
-                      vacc->rec, k);
-    for (size_t i = 0; i < n; i++) {
-        ncc_buffer_printf(vacc->arrays, "%s%lluULL", i ? "," : "",
-                          (unsigned long long)hashes.data[i]);
+    ncc_buffer_puts(vacc->arrays, sel_as);
+    for (size_t a = 0; a < narms; a++) {
+        ncc_buffer_printf(
+            vacc->arrays,
+            "static const uint64_t __ncc_gcvaroff_%zu_%d_%zu[]={%s};",
+            vacc->rec, k, a, arms[a].offs->data ? arms[a].offs->data : "");
+    }
+    ncc_buffer_printf(
+        vacc->arrays,
+        "static const n00b_gc_variant_arm_t __ncc_gcvararms_%zu_%d[]={",
+        vacc->rec, k);
+    for (size_t a = 0; a < narms; a++) {
+        ncc_buffer_printf(vacc->arrays,
+                          "%s{.selector=%lluULL,.ptr_offset_count=%dULL,"
+                          ".ptr_offsets=__ncc_gcvaroff_%zu_%d_%zu}",
+                          a ? "," : "", (unsigned long long)arms[a].selector,
+                          arms[a].count, vacc->rec, k, a);
     }
     ncc_buffer_puts(vacc->arrays, "};");
 
@@ -670,20 +781,19 @@ walk_variant(ncc_xform_ctx_t *ctx, const char *elem_type,
         ncc_buffer_puts(vacc->inits, ",");
     }
     ncc_buffer_printf(vacc->inits,
-                      "{.selector_offset=%s,.value_offset=%s,"
-                      ".ptr_hash_count=%zuULL,.ptr_hashes=__ncc_gcvar_h_%zu_%d}",
-                      sel_off, val_off, n, vacc->rec, k);
+                      "{.selector_offset=%s,.arm_count=%zuULL,"
+                      ".arms=__ncc_gcvararms_%zu_%d}",
+                      sel_off, narms, vacc->rec, k);
     vacc->count++;
 
     ncc_free(sel_path);
-    ncc_free(val_path);
     ncc_free(sel_as);
-    ncc_free(val_as);
     ncc_free(sel_off);
-    ncc_free(val_off);
-    if (hashes.data) {
-        ncc_free(hashes.data);
+    for (size_t a = 0; a < narms; a++) {
+        ncc_free(arms[a].offs->data);
+        ncc_free(arms[a].offs);
     }
+    ncc_free(arms);
 }
 
 // ---------------------------------------------------------------------------
@@ -1134,7 +1244,7 @@ gc_walk(ncc_xform_ctx_t *ctx, const char *elem_type, ncc_parse_tree_t *spec,
     // never sees (and warns about) the variant's value union.
     ncc_parse_tree_t *vunion = variant_value_union(ctx, spec);
     if (vunion) {
-        walk_variant(ctx, elem_type, vunion, base, vacc, ok);
+        walk_variant(ctx, elem_type, vunion, base, vacc, ok, depth);
         return;
     }
 

--- a/src/xform/xform_helpers.c
+++ b/src/xform/xform_helpers.c
@@ -546,10 +546,12 @@ ncc_string_t ncc_xform_node_to_text(ncc_parse_tree_t *node) {
 // declared in the header; the two inner helpers are static here.
 // ============================================================================
 
-// Does a single <attribute> node spell `[[n00b::<name>]]`?
+// Does a single <attribute> node spell `[[n00b::<name>]]`? When `name` is NULL,
+// matches ANY `[[n00b::<something>]]` attribute (used to strip every ncc-only
+// attribute before the tree is handed to clang).
 static bool ncc_xform_attribute_is_n00b_named(ncc_parse_tree_t *attr_node,
                                               const char       *name) {
-  if (!attr_node || !name || ncc_tree_is_leaf(attr_node)) {
+  if (!attr_node || ncc_tree_is_leaf(attr_node)) {
     return false;
   }
 
@@ -588,7 +590,7 @@ static bool ncc_xform_attribute_is_n00b_named(ncc_parse_tree_t *attr_node,
       saw_n00b = true;
       continue;
     }
-    if (saw_n00b && !saw_name && strcmp(text, name) == 0) {
+    if (saw_n00b && !saw_name && (name == nullptr || strcmp(text, name) == 0)) {
       saw_name = true;
     }
   }
@@ -599,7 +601,7 @@ static bool ncc_xform_attribute_is_n00b_named(ncc_parse_tree_t *attr_node,
 // Does an <attribute_specifier_sequence> contain `[[n00b::<name>]]`?
 static bool ncc_xform_attribute_seq_contains_n00b_named(
     ncc_parse_tree_t *attr_seq, const char *name) {
-  if (!attr_seq || !name || ncc_tree_is_leaf(attr_seq)) {
+  if (!attr_seq || ncc_tree_is_leaf(attr_seq)) {
     return false;
   }
 
@@ -636,9 +638,10 @@ bool ncc_xform_subtree_carries_n00b_named_attr(ncc_parse_tree_t *node,
   return false;
 }
 
+// When `name` is NULL, strips EVERY `[[n00b::*]]` attribute specifier.
 void ncc_xform_strip_n00b_named_attribute_specifiers(ncc_parse_tree_t *parent,
                                                      const char       *name) {
-  if (!parent || !name || ncc_tree_is_leaf(parent)) {
+  if (!parent || ncc_tree_is_leaf(parent)) {
     return;
   }
 

--- a/test/test_gc_typemap_variant.c
+++ b/test/test_gc_typemap_variant.c
@@ -63,13 +63,33 @@ typedef _generic_struct typeid("n00b_variant", n00b_string_t *, uint64_t) {
     } value;
 } vmap_generic_variant_t;
 
+// A variant with a by-value AGGREGATE alternative: a struct carrying two heap
+// pointers plus a scalar. ncc must describe this arm precisely -- an arm table
+// (n00b_gc_variant_arm_t) whose live alternative marks value.field_0.a and
+// value.field_0.b -- instead of falling back to a conservative scan, which is
+// what a by-value aggregate alternative used to force.
+typedef struct vmap_agg_arm_t {
+    n00b_string_t *a;
+    n00b_string_t *b;
+    uint64_t       n;
+} vmap_agg_arm_t;
+
+typedef struct vmap_agg_variant_t {
+    uint64_t selector;
+    union {
+        vmap_agg_arm_t field_0;
+        uint64_t       field_1;
+    } value;
+} vmap_agg_variant_t;
+
 static uint64_t h_variant = typehash(vmap_variant_t *);
 static uint64_t h_holder  = typehash(vmap_holder_t *);
 static uint64_t h_scalar  = typehash(vmap_scalar_variant_t *);
 static uint64_t h_generic = typehash(vmap_generic_variant_t *);
+static uint64_t h_agg     = typehash(vmap_agg_variant_t *);
 
 int
 main(void)
 {
-    return (int)((h_variant ^ h_holder ^ h_scalar ^ h_generic) == 0);
+    return (int)((h_variant ^ h_holder ^ h_scalar ^ h_generic ^ h_agg) == 0);
 }

--- a/test/test_union_deprecation.c
+++ b/test/test_union_deprecation.c
@@ -1,0 +1,27 @@
+// test_union_deprecation.c -- a traditional (non-variant) C union. The
+// union-deprecation pass warns on it (and, with --ncc-error-on-union, errors).
+// Used by ncc_union_deprecation_{warn,allow,error}.
+
+#include <stdint.h>
+
+typedef struct n00b_string_t {
+    uint64_t length;
+    char    *data;
+} n00b_string_t;
+
+// A hand-rolled tagged union: a discriminant plus a bare `union`. This is
+// exactly the shape the deprecation steers toward n00b_variant_t.
+typedef struct trad_tagged_t {
+    int32_t kind;
+    union {
+        int64_t        as_int;
+        n00b_string_t *as_str;
+    } payload;
+} trad_tagged_t;
+
+int
+main(void)
+{
+    trad_tagged_t t = {.kind = 0};
+    return (int)t.kind;
+}

--- a/test/test_union_deprecation_excluded.c
+++ b/test/test_union_deprecation_excluded.c
@@ -1,0 +1,39 @@
+// test_union_deprecation_excluded.c -- unions the deprecation pass must NOT
+// flag: an n00b_variant_t value-union and a `[[n00b::raw_union]]`-annotated
+// union. Neither should produce a "traditional C union" diagnostic.
+// Used by ncc_union_deprecation_excluded.
+
+#include <stdint.h>
+
+typedef struct n00b_string_t {
+    uint64_t length;
+    char    *data;
+} n00b_string_t;
+
+// A real n00b_variant_t (the _generic_struct form the macro lowers to),
+// referenced via typehash below so the type model resolves it — exactly how
+// the GC-typemap detector sees it. Its value-union must be excluded.
+typedef _generic_struct typeid("n00b_variant", n00b_string_t *, uint64_t) {
+    uint64_t selector;
+    union {
+        n00b_string_t *field_0;
+        uint64_t       field_1;
+    } value;
+} my_variant_t;
+
+// The escape hatch: a deliberately-raw union must be excluded.
+typedef struct punned_t {
+    int32_t tag;
+    union [[n00b::raw_union]] {
+        float    f;
+        uint32_t bits;
+    } pun;
+} punned_t;
+
+static uint64_t h = typehash(my_variant_t *);
+
+int
+main(void)
+{
+    return (int)(h == 0);
+}


### PR DESCRIPTION
Two related changes supporting GC-precise `n00b_variant_t` adoption in n00b.

## 1. gc-typemap: precise per-arm scanning for struct-arm `n00b_variant_t`
The GC typemap emitter now reads the variant `selector` and emits a per-arm
pointer-offset table, so a variant whose arms are structs is scanned
**precisely** (only the live arm's pointers) instead of falling back to a
conservative whole-object scan. This is what lets variant payloads carry
pointers that are forwarded correctly across collections.

## 2. Traditional-union deprecation warning
Warns on every traditional C `union` that is not:
- an `n00b_variant_t` value-union (identified pre-transform by the
  `_generic_struct typeid("n00b_variant", …)` marker — structural, no
  member-name/text heuristics, and never sees post-lowering synthesized nodes),
- in a system header, or
- annotated `union [[n00b::raw_union]] { … }` (the escape hatch for
  type-punning / FFI-layout / non-n00b-target unions).

`--ncc-allow-unions` suppresses it (used by vendored subprojects);
`--ncc-error-on-union` promotes it to an error. The message says raw unions
*may* become an error in a future release.

Adds `union_deprecation.{c,h}`, the two flags, fixtures, and gc-typemap
aggregate tests. Full ncc suite: 317 OK (the ~18 failures are pre-existing
WP_ROOT-dependent tests, unaffected by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)