### PR TITLE
ncc: repair kargs, header rstrings, and variant gc maps

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1538,6 +1538,33 @@ test('ncc_gc_typemap_variant_descriptor_emitted', test_runner,
   depends : ncc_exe,
 )
 
+test('ncc_gc_typemap_variant_arm_descriptor_emitted', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          'n00b_gc_variant_arm_t']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_variant_arm_count', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          '.arm_count=']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
+test('ncc_gc_typemap_variant_arm_ptr_offsets', test_runner,
+  args : [ncc_exe, 'preprocess_contains',
+          test_dir / 'test_gc_typemap_variant.c',
+          '.ptr_offset_count=1ULL,.ptr_offsets=']
+         + ncc_test_flags + ['--ncc-no-gc-stack-maps', '--ncc-no-auto-gc-roots'],
+  suite : 'ncc',
+  depends : ncc_exe,
+)
+
 # The descriptor records the selector offset and, per alternative, the
 # element-relative pointer offsets that are live when that selector is active.
 test('ncc_gc_typemap_variant_selector_offset', test_runner,

--- a/src/ncc.c
+++ b/src/ncc.c
@@ -1480,9 +1480,9 @@ run_preprocessor(const ncc_opts_t *opts, size_t *out_len)
     char  *wrapped_pp     = wrap_system_headers(buf, len, &wrapped_pp_len);
     ncc_free(buf);
 
-    // A project macro can expand to r"..." / b"..." only after CPP has run.
-    // The raw-source prescan above cannot see that spelling, so run the same
-    // lexer-aware rewrite once more before tokenization.
+    // A project macro can expand to r"..." / b"..." only after CPP has run,
+    // and user headers are only visible in the preprocessed stream. Run the
+    // same lexer-aware rewrite once more before tokenization.
     wrapped_pp = ncc_literal_prescan(wrapped_pp, wrapped_pp_len,
                                      &wrapped_pp_len);
 

--- a/src/xform/xform_gc_typemap.c
+++ b/src/xform/xform_gc_typemap.c
@@ -328,8 +328,8 @@ offset_assert(const char *elem_type, const char *path)
 // makes it precisely scannable: the `value` word is a heap pointer iff the
 // selector equals the typehash of one of the POINTER alternatives. ncc records
 // those typehashes (recomputed exactly as `typehash(T)` does, so they match the
-// runtime selector byte-for-byte) and emits a variant descriptor the collector
-// resolves per element at scan time.
+// runtime selector byte-for-byte) and emits variant arms the collector resolves
+// per element at scan time.
 // ---------------------------------------------------------------------------
 
 // Accumulates the emitted variant descriptors for one element type.
@@ -509,14 +509,6 @@ classify_variant_alt(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *member,
     ncc_free(base);
     ncc_free(ncc_buffer_take(tb));
     return ALT_PTR;
-}
-
-static int
-cmp_u64(const void *a, const void *b)
-{
-    uint64_t x = *(const uint64_t *)a;
-    uint64_t y = *(const uint64_t *)b;
-    return (x > y) - (x < y);
 }
 
 // If `spec` is an n00b_variant_t struct, return its resolved value-union

--- a/src/xform/xform_kargs_vargs.c
+++ b/src/xform/xform_kargs_vargs.c
@@ -1863,6 +1863,9 @@ static ncc_parse_tree_t *xform_kw_func(ncc_xform_ctx_t *ctx,
   return replacement;
 }
 
+static void rewrite_nested_kargs_calls(ncc_xform_ctx_t *ctx,
+                                       ncc_parse_tree_t *node);
+
 static ncc_parse_tree_t *xform_call(ncc_xform_ctx_t *ctx,
                                     ncc_parse_tree_t *node) {
   // postfix_expression ::= postfix_expression "(" argument_expression_list? ")"
@@ -2256,11 +2259,32 @@ static ncc_parse_tree_t *xform_call(ncc_xform_ctx_t *ctx,
   ncc_free(kw_func_kargs_text.data);
 
   if (replacement) {
+    rewrite_nested_kargs_calls(ctx, replacement);
     ctx->nodes_replaced++;
     return replacement;
   }
 
   return nullptr;
+}
+
+static void rewrite_nested_kargs_calls(ncc_xform_ctx_t *ctx,
+                                       ncc_parse_tree_t *node) {
+  if (!node || ncc_tree_is_leaf(node)) {
+    return;
+  }
+
+  size_t nc = ncc_tree_num_children(node);
+  for (size_t i = 0; i < nc; i++) {
+    ncc_parse_tree_t *child = ncc_tree_child(node, i);
+    if (!child) {
+      continue;
+    }
+    rewrite_nested_kargs_calls(ctx, child);
+    ncc_parse_tree_t *new_child = xform_call(ctx, child);
+    if (new_child != nullptr && new_child != child) {
+      ncc_tree_set_child(node, i, new_child);
+    }
+  }
 }
 
 // ============================================================================

--- a/test/test_kargs.c
+++ b/test/test_kargs.c
@@ -30,6 +30,14 @@ int default_once(int x) _kargs { int bias = next_plain_default(); } {
     return x + bias;
 }
 
+int nested_inner(int x) _kargs { int bias = 0; } {
+    return x + bias;
+}
+
+int nested_outer(int x) _kargs { int suffix = 0; } {
+    return x + suffix;
+}
+
 int main(void) {
     int r1 = add(1, 2);                             // defaults: bias=0, verbose=false
     int r2 = add(1, 2, .bias = 10);                 // override bias
@@ -70,6 +78,14 @@ int main(void) {
     }
     if (plain_default_counter != 0) {
         return 9;
+    }
+
+    if (nested_outer(nested_inner(7)) != 7) {
+        return 10;
+    }
+
+    if (nested_outer(nested_inner(7, .bias = 2), .suffix = 3) != 12) {
+        return 11;
     }
 
     return 0;

--- a/test/test_rstr.c
+++ b/test/test_rstr.c
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "ncc_runtime.h"
+#include "test_rstr_header.h"
 
 static int
 bytes_eq(const void *a, const void *b, size_t n)
@@ -48,6 +49,20 @@ test_plain_string(void)
     CHECK(s->codepoints == 11, "wrong codepoint count");
     CHECK(s->styling == nullptr, "styling should be nullptr");
     CHECK(bytes_eq(s->data, "Hello world", 11), "wrong data");
+    PASS();
+}
+
+static void
+test_header_string(void)
+{
+    TEST("plain r-string in user header");
+
+    ncc_string_t *s = ncc_rstr_header_slash();
+
+    CHECK(s != nullptr, "null pointer");
+    CHECK(s->u8_bytes == 1, "wrong byte count");
+    CHECK(s->codepoints == 1, "wrong codepoint count");
+    CHECK(bytes_eq(s->data, "/", 1), "wrong data");
     PASS();
 }
 
@@ -239,6 +254,7 @@ main(void)
     printf("=== r-string transform tests ===\n");
 
     test_plain_string();
+    test_header_string();
     test_bold_markup();
     test_adjacent_concat();
     test_macro_expanded_string();

--- a/test/test_rstr_header.h
+++ b/test/test_rstr_header.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ncc_runtime.h"
+
+static inline ncc_string_t *
+ncc_rstr_header_slash(void)
+{
+    return r"/";
+}


### PR DESCRIPTION
## Summary
- make nested extern `_kargs` calls lower omitted defaults recursively
- run NCC literal prescan after preprocessing so user headers and macro expansions can contain `r"..."` / `b"..."`
- align GC typemap variant tests with the current arm-based descriptor shape and remove the stale selector-hash helper

## Tests
- `meson test -C /Users/viega/ncc/build --no-rebuild --print-errorlogs ncc_rstr ncc_kargs ncc_gc_typemap_variant_descriptor_emitted ncc_gc_typemap_variant_arm_descriptor_emitted ncc_gc_typemap_variant_arm_count ncc_gc_typemap_variant_arm_ptr_offsets ncc_gc_typemap_variant_selector_offset ncc_gc_typemap_variant_value_ptr_offset ncc_gc_typemap_variant_embedded ncc_gc_typemap_variant_embedded_flat_offset ncc_gc_typemap_variant_all_scalar_no_descriptor ncc_gc_typemap_variant_generic_struct`
