### PR TITLE
xform: idempotency guard for vargs-only calls (fix nested double-pack)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -463,6 +463,8 @@ ncc_compile_tests = {
   'constexpr':    ['compile_run',  test_dir / 'test_constexpr.c'],
   'kargs':        ['compile_run',  test_dir / 'test_kargs.c'],
   'kargs_vargs':  ['compile_run',  test_dir / 'test_kargs_vargs.c'],
+  'vargs_nested_call': ['compile_run',
+                        test_dir / 'test_vargs_nested_call.c'],
   'kargs_vargs_default_omitted': ['compile_run',
                                   test_dir / 'test_kargs_vargs_default_omitted.c'],
   'kargs_void_params': ['compile_run',

--- a/src/xform/xform_kargs_vargs.c
+++ b/src/xform/xform_kargs_vargs.c
@@ -1936,8 +1936,14 @@ static ncc_parse_tree_t *xform_call(ncc_xform_ctx_t *ctx,
   // If there are no keyword arguments, check whether the call has already
   // been transformed.  A transformed call has exactly the expected number
   // of positional args plus one synthesized arg per vargs/kargs parameter.
-  // Vargs-only functions are never skipped here because excess positional
-  // args need to be bundled into a vargs compound literal.
+  // Every case needs an idempotency check: a vargs call nested as an
+  // argument of another vargs/kargs call is transformed once by
+  // rewrite_nested_kargs_calls (inside the outer call's re-parsed
+  // replacement) and then visited AGAIN by the engine's traversal of the
+  // replacement subtree.  Without the check the second visit bundles the
+  // synthesized `&(n00b_vargs_t){...}` literal itself as a variadic
+  // argument, and the callee formats the inner vargs struct instead of the
+  // real argument (the crayon `<bad-string-arg>` login-banner regression).
   if (n_keyword == 0 && meta) {
     bool already_done = false;
 
@@ -1969,8 +1975,21 @@ static ncc_parse_tree_t *xform_call(ncc_xform_ctx_t *ctx,
           already_done = true;
         }
       }
+    } else if (meta->va && !meta->kw) {
+      // vargs-only: expected = positional + 1 synthesized vargs literal.
+      // Count alone is not enough (`log(fmt, a)` matches when fmt is the
+      // only fixed positional parameter), so require the synthesized
+      // compound-literal shape in the vargs slot — the same test the
+      // vargs+kargs case uses.
+      int expected = meta->va->num_positional + 1;
+      if (n_positional == expected) {
+        ncc_parse_tree_t *vargs_arg =
+            nth_positional_arg(args, arg_count, expected);
+        if (is_ncc_vargs_literal(ctx, vargs_arg)) {
+          already_done = true;
+        }
+      }
     }
-    // vargs-only: never skip — excess args need bundling.
 
     if (already_done) {
       for (int i = 0; i < arg_count; i++) {

--- a/test/test_vargs_nested_call.c
+++ b/test/test_vargs_nested_call.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <string.h>
+
+typedef struct ncc_vargs_t {
+    unsigned int  nargs;
+    unsigned int  cur_ix;
+    void        **args;
+} ncc_vargs_t;
+
+/* Regression: a `+`-variadic call nested directly as an argument of another
+ * `+`-variadic call must be vargs-packed exactly once. The outer call's
+ * rewrite re-parses its replacement text and transforms the inner call via
+ * rewrite_nested_kargs_calls; the engine then traverses the replacement
+ * subtree and visits the inner call AGAIN. Without an idempotency check for
+ * vargs-only callees, the second visit re-bundled the inner call's already-
+ * synthesized `&(ncc_vargs_t){...}` literal as if it were a user argument,
+ * so the inner callee saw nargs == 1 with args[0] pointing at a vargs
+ * struct instead of the real argument (the `n00b_print(n00b_cformat(...))`
+ * `<bad-string-arg>` shape). */
+
+static const char *
+pick_only(const char *tag, +)
+{
+    (void)tag;
+    if (vargs->nargs != 1) {
+        return "WRONG-NARGS";
+    }
+    return (const char *)vargs->args[0];
+}
+
+int
+main(void)
+{
+    const char *hello = "HELLO";
+
+    /* Unnested baseline. */
+    const char *flat = pick_only("flat", (void *)hello);
+
+    /* The regression shape: variadic call directly as a variadic argument.
+     * Double-packing makes the INNER call return a pointer to a synthesized
+     * vargs struct rather than `hello`. */
+    const char *nested = pick_only("outer",
+                                   (void *)pick_only("inner", (void *)hello));
+
+    printf("%s %s\n", flat, nested);
+    return (strcmp(flat, "HELLO") != 0 || strcmp(nested, "HELLO") != 0);
+}


### PR DESCRIPTION
A `+`-variadic call nested directly as an argument of another variadic/kargs call was vargs-packed twice: `xform_call` rewrites the outer call, re-parses the replacement text, and `rewrite_nested_kargs_calls` transforms the inner call — but the engine's traversal then revisits the replacement subtree and re-transforms it. The already-transformed check had no vargs-only branch ('vargs-only: never skip'), so the second visit bundled the synthesized `&(vargs){...}` literal as a user argument and the callee received a pointer to a vargs struct instead of the real argument.

Downstream this was the crayon `<bad-string-arg>` login-banner regression, and corrupted **every** nested variadic call in binaries compiled since #43 (2026-07-02) — runtime argument corruption, not just display.

The new branch mirrors the vargs+kargs case: skip when the positional count is `num_positional + 1` and the vargs slot satisfies `is_ncc_vargs_literal`.

Regression test `test/test_vargs_nested_call.c` fails on the pre-fix compiler and passes with the fix; suite otherwise unchanged (the 13 pre-existing static-object/gc-stack-maps failures are identical with the change reverted). Audited via ncc-internal-code-auditor (verdict: WARNINGS — one pre-existing-pattern note on the `is_ncc_vargs_literal` text-shape heuristic, inherited not introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)