### PR TITLE
ncc: teach static-init dict baking about the pinref-wrapped dict store

### DIFF
--- a/src/xform/xform_array_literal.c
+++ b/src/xform/xform_array_literal.c
@@ -4996,7 +4996,7 @@ build_static_init_dict_maker(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *site,
                       ".buckets=__ncc_buckets,"
                       ".keys=(void **)__ncc_keys,"
                       ".values=(void **)__ncc_values};"
-                      "(%s){.store=(void *)__ncc_store,"
+                      "%s __ncc_dict=(%s){"
                       ".fn=nullptr,.allocator=nullptr,"
                       ".insertion_epoch=0,.wait_ct=0,"
                       ".length=(int64_t)%zuULL,"
@@ -5006,9 +5006,11 @@ build_static_init_dict_maker(ncc_xform_ctx_t *ctx, ncc_parse_tree_t *site,
                       ".scan_cb=nullptr,.scan_user=nullptr,"
                       ".key_scan_kind=%s,"
                       ".value_scan_kind=%s,"
-                      ".key_tid=%s,.value_tid=%s};})",
+                      ".key_tid=%s,.value_tid=%s};"
+                      "*(void **)&__ncc_dict.store=(void *)__ncc_store;"
+                      "__ncc_dict;})",
                       (unsigned int)(cap - 1), threshold, pair_count,
-                      type->object_type, pair_count, skip_obj_hash,
+                      type->object_type, type->object_type, pair_count, skip_obj_hash,
                       key_scan_kind, value_scan_kind,
                       key_type_hash, value_type_hash);
     ncc_free(key_ptr_type);

--- a/src/xform/xform_static_init.c
+++ b/src/xform/xform_static_init.c
@@ -531,7 +531,7 @@ helper_source(ncc_sym_entry_t *entry, const char *name, const char *init_expr)
         if (patches.len > 0) {
             ncc_buffer_printf(buf,
                 "    __n00b_internal_type_erased_store_t *__ncc_patch_store =\n"
-                "        (__n00b_internal_type_erased_store_t *)%s.store;\n",
+                "        (__n00b_internal_type_erased_store_t *)*(void *const *)&%s.store;\n",
                 name);
             for (size_t i = 0; i < patches.len; i++) {
                 ncc_buffer_printf(buf,


### PR DESCRIPTION
The dict `store` field is now `n00b_pinref(store *)` = `_Atomic(struct { store* raw; uint32_t pins; uint32_t lock:1; })` — an atomic anonymous struct, not an aggregate, so it can't be initialized from a plain pointer. Two static-init emission sites are updated so `d{...}` static dict literals compile again:

- `xform_array_literal.c`: bake the dict with `.store` left zero-initialized and write the store pointer to offset 0 afterward (what `n00b_pinref_init` does at runtime), instead of `.store=(void *)__ncc_store`.
- `xform_static_init.c`: read the baked store through the pinref raw slot (`*(void *const *)&NAME.store`) instead of casting `.store` directly.

The new emission is compatible with both the old `_Atomic(void **)` store shape and the new pinref shape (verified: offset-0 layout, zeroed pins/lock, round-trip). Fixes compilation of static `d{...}` dict literals (e.g. the style registry) against the pinned dict store.

Follow-up: a pinref-specific regression test in ncc's suite is deferred until the pinref dict shape lands in the discoverable (main) n00b tree; the suite currently auto-discovers the old-shape tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)